### PR TITLE
feat: ARIA → Mission Control hook for real-time agent tracking

### DIFF
--- a/scripts/aria-mc-hook.sh
+++ b/scripts/aria-mc-hook.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────
+# ARIA → Mission Control Hook
+# One-liner wrapper for ARIA to notify MC when agents spawn/finish.
+#
+# Usage:
+#   aria-mc-hook.sh start <label> <task-title>
+#     → prints task_id to stdout (capture it for later)
+#
+#   aria-mc-hook.sh done <label> <task-id> [summary]
+#     → marks task complete, agent back to standby
+#
+#   aria-mc-hook.sh error <label> <task-id> [error-message]
+#     → marks task in review with error, agent back to standby
+#
+#   aria-mc-hook.sh update <label> <task-id> <message>
+#     → logs progress activity without changing status
+#
+#   aria-mc-hook.sh tmux-start <label> <task-title>
+#     → same as start, for tmux Claude Code sessions
+#
+#   aria-mc-hook.sh tmux-done <label> <task-id> [summary]
+#     → same as done, for tmux sessions
+#
+# Examples:
+#   TASK_ID=$(aria-mc-hook.sh start researcher-1900 "Research Axe 2 Business")
+#   aria-mc-hook.sh done researcher-1900 "$TASK_ID" "Found 6 viable ideas"
+#   aria-mc-hook.sh error coder-fix-bug "$TASK_ID" "Build failed"
+#
+# Design: Fails silently if MC is down (never blocks ARIA).
+# ─────────────────────────────────────────────────────────────────
+
+MC_URL="${MC_URL:-http://localhost:3000}"
+BRIDGE="$(dirname "$0")/mc-bridge.py"
+TIMEOUT=5
+
+# ─── Label → Agent name mapping ────────────────────────────────
+resolve_agent() {
+  local label
+  label=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+  case "$label" in
+    researcher*)         echo "Researcher" ;;
+    coder*|fix-*|dev-*)  echo "Coder" ;;
+    brainstorm*)         echo "Brainstorm" ;;
+    qa*|test-*)          echo "QA" ;;
+    linkedin*|writer*)   echo "LinkedIn Writer" ;;
+    synth*|brief*|morning*) echo "Synthesizer" ;;
+    archiv*|journal*)    echo "Archivist" ;;
+    diving*|casar*)      echo "Diving" ;;
+    home*|tv-*|sonos-*)  echo "Home" ;;
+    monitor*)            echo "Monitor" ;;
+    aria*)               echo "ARIA" ;;
+    *)                   echo "" ;;
+  esac
+}
+
+# ─── Quick health check (non-blocking) ─────────────────────────
+mc_alive() {
+  curl -sf --max-time 2 "${MC_URL}/api/agents" >/dev/null 2>&1
+}
+
+# ─── Main ───────────────────────────────────────────────────────
+CMD="${1:-}"
+shift 2>/dev/null || true
+
+case "$CMD" in
+
+  start|tmux-start)
+    LABEL="${1:?Usage: aria-mc-hook.sh start <label> <task-title>}"
+    shift
+    TITLE="${*:?Usage: aria-mc-hook.sh start <label> <task-title>}"
+    AGENT=$(resolve_agent "$LABEL")
+
+    if [[ -z "$AGENT" ]]; then
+      # Unknown label → try as direct agent name
+      AGENT="$LABEL"
+    fi
+
+    # Fail silently if MC is down
+    if ! mc_alive; then
+      exit 0
+    fi
+
+    # Use the Python bridge (has full label mapping + error handling)
+    DESCRIPTION=""
+    [[ "$CMD" == "tmux-start" ]] && DESCRIPTION="[tmux session: $LABEL]"
+
+    TASK_ID=$(timeout "$TIMEOUT" python3 "$BRIDGE" agent-start \
+      --agent "$AGENT" \
+      --task "$TITLE" \
+      --label "$LABEL" \
+      ${DESCRIPTION:+--description "$DESCRIPTION"} \
+      2>/dev/null) || exit 0
+
+    # Output task ID for ARIA to capture
+    echo "$TASK_ID"
+    ;;
+
+  done|tmux-done)
+    LABEL="${1:?Usage: aria-mc-hook.sh done <label> <task-id> [summary]}"
+    TASK_ID="${2:?Usage: aria-mc-hook.sh done <label> <task-id> [summary]}"
+    SUMMARY="${3:-Task completed}"
+    AGENT=$(resolve_agent "$LABEL")
+
+    [[ -z "$AGENT" ]] && AGENT="$LABEL"
+
+    if ! mc_alive; then
+      exit 0
+    fi
+
+    timeout "$TIMEOUT" python3 "$BRIDGE" agent-done \
+      --agent "$AGENT" \
+      --task-id "$TASK_ID" \
+      --summary "$SUMMARY" \
+      --done \
+      >/dev/null 2>&1 || exit 0
+    ;;
+
+  error)
+    LABEL="${1:?Usage: aria-mc-hook.sh error <label> <task-id> [error-message]}"
+    TASK_ID="${2:?Usage: aria-mc-hook.sh error <label> <task-id> [error-message]}"
+    ERROR_MSG="${3:-Unknown error}"
+    AGENT=$(resolve_agent "$LABEL")
+
+    [[ -z "$AGENT" ]] && AGENT="$LABEL"
+
+    if ! mc_alive; then
+      exit 0
+    fi
+
+    timeout "$TIMEOUT" python3 "$BRIDGE" agent-error \
+      --agent "$AGENT" \
+      --task-id "$TASK_ID" \
+      --error "$ERROR_MSG" \
+      >/dev/null 2>&1 || exit 0
+    ;;
+
+  update)
+    LABEL="${1:?Usage: aria-mc-hook.sh update <label> <task-id> <message>}"
+    TASK_ID="${2:?Usage: aria-mc-hook.sh update <label> <task-id> <message>}"
+    shift 2
+    MESSAGE="${*:?Usage: aria-mc-hook.sh update <label> <task-id> <message>}"
+    AGENT=$(resolve_agent "$LABEL")
+
+    [[ -z "$AGENT" ]] && AGENT="$LABEL"
+
+    if ! mc_alive; then
+      exit 0
+    fi
+
+    timeout "$TIMEOUT" python3 "$BRIDGE" agent-update \
+      --agent "$AGENT" \
+      --task-id "$TASK_ID" \
+      --message "$MESSAGE" \
+      >/dev/null 2>&1 || exit 0
+    ;;
+
+  *)
+    echo "ARIA → Mission Control Hook"
+    echo ""
+    echo "Usage:"
+    echo "  $0 start   <label> <task-title>           → returns task_id"
+    echo "  $0 done    <label> <task-id> [summary]     → mark complete"
+    echo "  $0 error   <label> <task-id> [error-msg]   → mark error"
+    echo "  $0 update  <label> <task-id> <message>     → log progress"
+    echo "  $0 tmux-start <label> <task-title>         → tmux session start"
+    echo "  $0 tmux-done  <label> <task-id> [summary]  → tmux session done"
+    echo ""
+    echo "Examples:"
+    echo '  TASK_ID=$(aria-mc-hook.sh start researcher-1900 "Research Axe 2")'
+    echo '  aria-mc-hook.sh done researcher-1900 "$TASK_ID" "Found 6 ideas"'
+    echo '  aria-mc-hook.sh error coder-fix "$TASK_ID" "Build failed"'
+    exit 1
+    ;;
+esac

--- a/scripts/mc-bridge.py
+++ b/scripts/mc-bridge.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""
+ARIA ↔ Mission Control Bridge
+Syncs agent activity with Mission Control via its REST API.
+
+Usage:
+  mc-bridge.py agent-start --agent "Researcher" --task "Research Axe 2" [--label "researcher-1900"]
+  mc-bridge.py agent-done  --agent "Researcher" --task-id <ID> --summary "Found 6 ideas"
+  mc-bridge.py agent-error --agent "Researcher" --task-id <ID> --error "API timeout"
+  mc-bridge.py status
+
+Requires: Python 3 stdlib only (no pip install)
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+BASE_URL = os.environ.get("MC_URL", "http://localhost:3000")
+WORKSPACE_ID = os.environ.get("MC_WORKSPACE", "default")
+
+# Label prefix → Mission Control agent name
+LABEL_MAP = [
+    # (prefix_list, agent_name)
+    (["researcher"],                       "Researcher"),
+    (["coder", "fix-", "dev-"],            "Coder"),
+    (["brainstorm"],                       "Brainstorm"),
+    (["qa", "test-"],                      "QA"),
+    (["linkedin", "writer"],               "LinkedIn Writer"),
+    (["synth", "brief", "morning"],        "Synthesizer"),
+    (["archiv", "journal"],                "Archivist"),
+    (["diving", "casar"],                  "Diving"),
+    (["home", "tv-", "sonos-"],            "Home"),
+    (["monitor"],                          "Monitor"),
+]
+
+# ---------------------------------------------------------------------------
+# HTTP helpers  (stdlib only – no requests/httpx)
+# ---------------------------------------------------------------------------
+
+def _request(method: str, path: str, body: dict | None = None, quiet: bool = False) -> dict | list | None:
+    """Make an HTTP request to Mission Control. Returns parsed JSON or None on error."""
+    url = f"{BASE_URL}{path}"
+    data = json.dumps(body).encode() if body else None
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method=method,
+        headers={"Content-Type": "application/json"} if data else {},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            raw = resp.read().decode()
+            return json.loads(raw) if raw else None
+    except urllib.error.HTTPError as e:
+        err_body = e.read().decode() if e.fp else ""
+        if not quiet:
+            print(f"⚠️  HTTP {e.code} on {method} {path}: {err_body}", file=sys.stderr)
+        return None
+    except urllib.error.URLError as e:
+        if not quiet:
+            print(f"⚠️  Mission Control unreachable ({BASE_URL}): {e.reason}", file=sys.stderr)
+        return None
+    except Exception as e:
+        if not quiet:
+            print(f"⚠️  Request failed: {e}", file=sys.stderr)
+        return None
+
+
+def api_get(path: str, quiet: bool = False):
+    return _request("GET", path, quiet=quiet)
+
+def api_post(path: str, body: dict, quiet: bool = False):
+    return _request("POST", path, body, quiet=quiet)
+
+def api_patch(path: str, body: dict, quiet: bool = False):
+    return _request("PATCH", path, body, quiet=quiet)
+
+# ---------------------------------------------------------------------------
+# Agent resolution
+# ---------------------------------------------------------------------------
+
+_agent_cache: list | None = None
+
+def get_agents() -> list:
+    global _agent_cache
+    if _agent_cache is None:
+        result = api_get("/api/agents")
+        _agent_cache = result if isinstance(result, list) else []
+    return _agent_cache
+
+
+def resolve_agent_name(label: str) -> str | None:
+    """Map a Clawdbot session label to a Mission Control agent name."""
+    label_lower = label.lower()
+    for prefixes, agent_name in LABEL_MAP:
+        for prefix in prefixes:
+            if label_lower.startswith(prefix):
+                return agent_name
+    return None
+
+
+def find_agent(name: str) -> dict | None:
+    """Find an agent by name (case-insensitive) in Mission Control."""
+    agents = get_agents()
+    name_lower = name.lower()
+    for a in agents:
+        if a.get("name", "").lower() == name_lower:
+            return a
+    return None
+
+
+def find_agent_by_name_or_label(name_or_label: str) -> dict | None:
+    """Try to find agent by exact name first, then by label prefix mapping."""
+    # Direct name match
+    agent = find_agent(name_or_label)
+    if agent:
+        return agent
+    # Try label mapping
+    mapped_name = resolve_agent_name(name_or_label)
+    if mapped_name:
+        return find_agent(mapped_name)
+    return None
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+def cmd_agent_start(args):
+    """Agent starts working on a task."""
+    # Resolve agent
+    agent = find_agent_by_name_or_label(args.agent)
+    if not agent:
+        # Try label if provided
+        if args.label:
+            mapped = resolve_agent_name(args.label)
+            if mapped:
+                agent = find_agent(mapped)
+        if not agent:
+            print(f"❌ Agent not found: {args.agent}", file=sys.stderr)
+            # List available agents for debugging
+            agents = get_agents()
+            if agents:
+                names = [a["name"] for a in agents]
+                print(f"   Available: {', '.join(names)}", file=sys.stderr)
+            sys.exit(1)
+
+    agent_id = agent["id"]
+    agent_name = agent["name"]
+
+    # 1. Create task
+    task_body = {
+        "title": args.task,
+        "status": "in_progress",
+        "priority": getattr(args, "priority", "normal") or "normal",
+        "assigned_agent_id": agent_id,
+        "created_by_agent_id": agent_id,
+        "workspace_id": WORKSPACE_ID,
+    }
+    if args.description:
+        task_body["description"] = args.description
+
+    task = api_post("/api/tasks", task_body)
+    if not task:
+        print("❌ Failed to create task", file=sys.stderr)
+        sys.exit(1)
+
+    task_id = task["id"]
+
+    # 2. Set agent status to working
+    api_patch(f"/api/agents/{agent_id}", {"status": "working"})
+
+    # 3. Log activity
+    api_post(f"/api/tasks/{task_id}/activities", {
+        "activity_type": "spawned",
+        "message": f"{agent_name} started working" + (f" (label: {args.label})" if args.label else ""),
+        "agent_id": agent_id,
+    })
+
+    # Output task ID (for ARIA to capture)
+    print(task_id)
+
+
+def cmd_agent_done(args):
+    """Agent finished a task."""
+    agent = find_agent_by_name_or_label(args.agent)
+    if not agent:
+        print(f"❌ Agent not found: {args.agent}", file=sys.stderr)
+        sys.exit(1)
+
+    agent_id = agent["id"]
+    agent_name = agent["name"]
+    task_id = args.task_id
+
+    # 1. Move task to review (or done if --done flag)
+    target_status = "done" if args.force_done else "review"
+    api_patch(f"/api/tasks/{task_id}", {"status": target_status})
+
+    # 2. Set agent back to standby
+    api_patch(f"/api/agents/{agent_id}", {"status": "standby"})
+
+    # 3. Log activity
+    summary = args.summary or "Task completed"
+    api_post(f"/api/tasks/{task_id}/activities", {
+        "activity_type": "completed",
+        "message": f"{agent_name}: {summary}",
+        "agent_id": agent_id,
+    })
+
+    print(f"✅ {agent_name} → {target_status} | {summary}")
+
+
+def cmd_agent_error(args):
+    """Agent encountered an error."""
+    agent = find_agent_by_name_or_label(args.agent)
+    if not agent:
+        print(f"❌ Agent not found: {args.agent}", file=sys.stderr)
+        sys.exit(1)
+
+    agent_id = agent["id"]
+    agent_name = agent["name"]
+    task_id = args.task_id
+
+    # 1. Move task to review
+    api_patch(f"/api/tasks/{task_id}", {"status": "review"})
+
+    # 2. Set agent back to standby
+    api_patch(f"/api/agents/{agent_id}", {"status": "standby"})
+
+    # 3. Log error activity
+    error_msg = args.error or "Unknown error"
+    api_post(f"/api/tasks/{task_id}/activities", {
+        "activity_type": "status_changed",
+        "message": f"⚠️ {agent_name} error: {error_msg}",
+        "agent_id": agent_id,
+        "metadata": json.dumps({"error": error_msg}),
+    })
+
+    print(f"⚠️ {agent_name} → review | Error: {error_msg}")
+
+
+def cmd_agent_update(args):
+    """Update task activity without changing status."""
+    agent = find_agent_by_name_or_label(args.agent)
+    if not agent:
+        print(f"❌ Agent not found: {args.agent}", file=sys.stderr)
+        sys.exit(1)
+
+    agent_id = agent["id"]
+    agent_name = agent["name"]
+    task_id = args.task_id
+
+    api_post(f"/api/tasks/{task_id}/activities", {
+        "activity_type": "updated",
+        "message": f"{agent_name}: {args.message}",
+        "agent_id": agent_id,
+    })
+
+    print(f"📝 {agent_name}: {args.message}")
+
+
+def cmd_status(args):
+    """Show current agent and task status."""
+    # Agents
+    agents = get_agents()
+    if not agents:
+        print("⚠️  No agents found (is Mission Control running?)")
+        return
+
+    print("── Agents ──────────────────────────────────")
+    for a in agents:
+        emoji = a.get("avatar_emoji", "🤖")
+        status = a.get("status", "?")
+        indicator = {"working": "🟢", "standby": "⚪", "offline": "🔴"}.get(status, "❓")
+        master = " 👑" if a.get("is_master") else ""
+        print(f"  {indicator} {emoji} {a['name']:<20} {status}{master}")
+
+    # Active tasks
+    tasks = api_get("/api/tasks?status=in_progress,assigned,review,testing")
+    if tasks:
+        print("\n── Active Tasks ────────────────────────────")
+        for t in tasks:
+            status = t.get("status", "?")
+            agent_name = t.get("assigned_agent_name", "unassigned")
+            emoji = {"in_progress": "🔧", "assigned": "📋", "review": "👀", "testing": "🧪"}.get(status, "❓")
+            print(f"  {emoji} [{status:<11}] {t['title'][:50]:<50} → {agent_name}")
+            print(f"    id: {t['id']}")
+    else:
+        print("\n  No active tasks")
+
+    # Quick stats
+    all_tasks = api_get("/api/tasks", quiet=True)
+    if all_tasks:
+        by_status = {}
+        for t in all_tasks:
+            s = t.get("status", "?")
+            by_status[s] = by_status.get(s, 0) + 1
+        print("\n── Stats ───────────────────────────────────")
+        order = ["inbox", "planning", "assigned", "in_progress", "testing", "review", "done"]
+        parts = []
+        for s in order:
+            if s in by_status:
+                parts.append(f"{s}: {by_status[s]}")
+        print(f"  {' | '.join(parts)}")
+
+
+def cmd_list_agents(args):
+    """List all agents (useful for debugging label mapping)."""
+    agents = get_agents()
+    if not agents:
+        print("⚠️  No agents found")
+        return
+
+    print(f"{'Name':<20} {'ID':<38} {'Status':<10} {'Role'}")
+    print("─" * 90)
+    for a in agents:
+        print(f"{a['name']:<20} {a['id']:<38} {a.get('status', '?'):<10} {a.get('role', '')}")
+
+    # Show label mapping
+    print("\n── Label Mapping ───────────────────────────")
+    for prefixes, agent_name in LABEL_MAP:
+        found = find_agent(agent_name)
+        status = "✅" if found else "❌ (not in MC)"
+        print(f"  {', '.join(prefixes):<30} → {agent_name:<20} {status}")
+
+
+# ---------------------------------------------------------------------------
+# CLI Parser
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="ARIA ↔ Mission Control Bridge",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s agent-start --agent Researcher --task "Research Axe 2 Business"
+  %(prog)s agent-done --agent Researcher --task-id abc-123 --summary "Found 6 ideas"
+  %(prog)s agent-error --agent Researcher --task-id abc-123 --error "API timeout"
+  %(prog)s agent-update --agent Researcher --task-id abc-123 --message "Step 2/5 done"
+  %(prog)s status
+  %(prog)s agents
+        """,
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # -- agent-start --
+    p_start = sub.add_parser("agent-start", help="Agent starts working on a task")
+    p_start.add_argument("--agent", required=True, help="Agent name or label prefix")
+    p_start.add_argument("--task", required=True, help="Task title")
+    p_start.add_argument("--label", help="Clawdbot session label (for mapping)")
+    p_start.add_argument("--description", help="Task description")
+    p_start.add_argument("--priority", choices=["low", "normal", "high", "urgent"], default="normal")
+    p_start.set_defaults(func=cmd_agent_start)
+
+    # -- agent-done --
+    p_done = sub.add_parser("agent-done", help="Agent finished a task")
+    p_done.add_argument("--agent", required=True, help="Agent name or label prefix")
+    p_done.add_argument("--task-id", required=True, help="Task ID")
+    p_done.add_argument("--summary", help="Completion summary")
+    p_done.add_argument("--done", dest="force_done", action="store_true",
+                        help="Move directly to done (skip review)")
+    p_done.set_defaults(func=cmd_agent_done)
+
+    # -- agent-error --
+    p_error = sub.add_parser("agent-error", help="Agent encountered an error")
+    p_error.add_argument("--agent", required=True, help="Agent name or label prefix")
+    p_error.add_argument("--task-id", required=True, help="Task ID")
+    p_error.add_argument("--error", required=True, help="Error message")
+    p_error.set_defaults(func=cmd_agent_error)
+
+    # -- agent-update --
+    p_update = sub.add_parser("agent-update", help="Log progress without changing status")
+    p_update.add_argument("--agent", required=True, help="Agent name or label prefix")
+    p_update.add_argument("--task-id", required=True, help="Task ID")
+    p_update.add_argument("--message", required=True, help="Progress message")
+    p_update.set_defaults(func=cmd_agent_update)
+
+    # -- status --
+    p_status = sub.add_parser("status", help="Show current status")
+    p_status.set_defaults(func=cmd_status)
+
+    # -- agents --
+    p_agents = sub.add_parser("agents", help="List all agents and label mappings")
+    p_agents.set_defaults(func=cmd_list_agents)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mc-bridge.sh
+++ b/scripts/mc-bridge.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# ARIA ↔ Mission Control Bridge (thin bash wrapper)
+#
+# Usage:
+#   mc-bridge.sh agent-start --agent "Researcher" --task "Research Axe 2" [--label "researcher-1900"]
+#   mc-bridge.sh agent-done  --agent "Researcher" --task-id <ID> --summary "Found 6 ideas"
+#   mc-bridge.sh agent-error --agent "Researcher" --task-id <ID> --error "API timeout"
+#   mc-bridge.sh status
+#
+# For the full Python version with label mapping, use mc-bridge.py instead.
+# This bash version is a lightweight alternative using curl.
+
+set -euo pipefail
+
+MC_URL="${MC_URL:-http://localhost:3000}"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+mc_get() {
+  curl -sf --max-time 5 "${MC_URL}$1" 2>/dev/null
+}
+
+mc_post() {
+  curl -sf --max-time 5 -X POST "${MC_URL}$1" \
+    -H 'Content-Type: application/json' \
+    -d "$2" 2>/dev/null
+}
+
+mc_patch() {
+  curl -sf --max-time 5 -X PATCH "${MC_URL}$1" \
+    -H 'Content-Type: application/json' \
+    -d "$2" 2>/dev/null
+}
+
+# Find agent ID by name (case-insensitive via jq)
+find_agent_id() {
+  local name="$1"
+  local agents
+  agents=$(mc_get "/api/agents") || { echo "⚠️  Mission Control unreachable" >&2; return 1; }
+  echo "$agents" | python3 -c "
+import json, sys
+agents = json.load(sys.stdin)
+name = '${name}'.lower()
+for a in agents:
+    if a['name'].lower() == name:
+        print(a['id'])
+        sys.exit(0)
+sys.exit(1)
+" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+cmd_agent_start() {
+  local agent="" task="" label="" description="" priority="normal"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --agent) agent="$2"; shift 2;;
+      --task) task="$2"; shift 2;;
+      --label) label="$2"; shift 2;;
+      --description) description="$2"; shift 2;;
+      --priority) priority="$2"; shift 2;;
+      *) echo "Unknown option: $1" >&2; exit 1;;
+    esac
+  done
+
+  [[ -z "$agent" ]] && { echo "❌ --agent required" >&2; exit 1; }
+  [[ -z "$task" ]] && { echo "❌ --task required" >&2; exit 1; }
+
+  local agent_id
+  agent_id=$(find_agent_id "$agent") || { echo "❌ Agent not found: $agent" >&2; exit 1; }
+
+  # Create task
+  local body
+  body=$(python3 -c "
+import json
+d = {
+    'title': $(python3 -c "import json; print(json.dumps('$task'))"),
+    'status': 'in_progress',
+    'priority': '$priority',
+    'assigned_agent_id': '$agent_id',
+    'created_by_agent_id': '$agent_id',
+    'workspace_id': 'default'
+}
+if '$description':
+    d['description'] = $(python3 -c "import json; print(json.dumps('$description'))")
+print(json.dumps(d))
+")
+
+  local result
+  result=$(mc_post "/api/tasks" "$body") || { echo "❌ Failed to create task" >&2; exit 1; }
+
+  local task_id
+  task_id=$(echo "$result" | python3 -c "import json,sys; print(json.load(sys.stdin)['id'])")
+
+  # Set agent to working
+  mc_patch "/api/agents/$agent_id" '{"status":"working"}' >/dev/null
+
+  # Log activity
+  local activity_msg="$agent started working"
+  [[ -n "$label" ]] && activity_msg="$activity_msg (label: $label)"
+  mc_post "/api/tasks/$task_id/activities" "{\"activity_type\":\"spawned\",\"message\":\"$activity_msg\",\"agent_id\":\"$agent_id\"}" >/dev/null
+
+  # Output task ID
+  echo "$task_id"
+}
+
+cmd_agent_done() {
+  local agent="" task_id="" summary="Task completed" force_done=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --agent) agent="$2"; shift 2;;
+      --task-id) task_id="$2"; shift 2;;
+      --summary) summary="$2"; shift 2;;
+      --done) force_done=true; shift;;
+      *) echo "Unknown option: $1" >&2; exit 1;;
+    esac
+  done
+
+  [[ -z "$agent" ]] && { echo "❌ --agent required" >&2; exit 1; }
+  [[ -z "$task_id" ]] && { echo "❌ --task-id required" >&2; exit 1; }
+
+  local agent_id
+  agent_id=$(find_agent_id "$agent") || { echo "❌ Agent not found: $agent" >&2; exit 1; }
+
+  local status="review"
+  [[ "$force_done" == "true" ]] && status="done"
+
+  mc_patch "/api/tasks/$task_id" "{\"status\":\"$status\"}" >/dev/null
+  mc_patch "/api/agents/$agent_id" '{"status":"standby"}' >/dev/null
+  mc_post "/api/tasks/$task_id/activities" "{\"activity_type\":\"completed\",\"message\":\"$agent: $summary\",\"agent_id\":\"$agent_id\"}" >/dev/null
+
+  echo -e "${GREEN}✅ $agent → $status | $summary${NC}"
+}
+
+cmd_agent_error() {
+  local agent="" task_id="" error_msg=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --agent) agent="$2"; shift 2;;
+      --task-id) task_id="$2"; shift 2;;
+      --error) error_msg="$2"; shift 2;;
+      *) echo "Unknown option: $1" >&2; exit 1;;
+    esac
+  done
+
+  [[ -z "$agent" ]] && { echo "❌ --agent required" >&2; exit 1; }
+  [[ -z "$task_id" ]] && { echo "❌ --task-id required" >&2; exit 1; }
+  [[ -z "$error_msg" ]] && { echo "❌ --error required" >&2; exit 1; }
+
+  local agent_id
+  agent_id=$(find_agent_id "$agent") || { echo "❌ Agent not found: $agent" >&2; exit 1; }
+
+  mc_patch "/api/tasks/$task_id" '{"status":"review"}' >/dev/null
+  mc_patch "/api/agents/$agent_id" '{"status":"standby"}' >/dev/null
+  mc_post "/api/tasks/$task_id/activities" "{\"activity_type\":\"status_changed\",\"message\":\"⚠️ $agent error: $error_msg\",\"agent_id\":\"$agent_id\"}" >/dev/null
+
+  echo -e "${YELLOW}⚠️ $agent → review | Error: $error_msg${NC}"
+}
+
+cmd_status() {
+  local agents tasks
+
+  agents=$(mc_get "/api/agents") || { echo "⚠️  Mission Control unreachable at $MC_URL" >&2; exit 1; }
+
+  echo "── Agents ──────────────────────────────────"
+  echo "$agents" | python3 -c "
+import json, sys
+agents = json.load(sys.stdin)
+icons = {'working': '🟢', 'standby': '⚪', 'offline': '🔴'}
+for a in agents:
+    s = a.get('status', '?')
+    i = icons.get(s, '❓')
+    e = a.get('avatar_emoji', '🤖')
+    m = ' 👑' if a.get('is_master') else ''
+    print(f'  {i} {e} {a[\"name\"]:<20} {s}{m}')
+"
+
+  tasks=$(mc_get "/api/tasks?status=in_progress,assigned,review,testing") || tasks="[]"
+  echo ""
+  echo "── Active Tasks ────────────────────────────"
+  echo "$tasks" | python3 -c "
+import json, sys
+tasks = json.load(sys.stdin)
+if not tasks:
+    print('  No active tasks')
+    sys.exit(0)
+icons = {'in_progress': '🔧', 'assigned': '📋', 'review': '👀', 'testing': '🧪'}
+for t in tasks:
+    s = t.get('status', '?')
+    i = icons.get(s, '❓')
+    a = t.get('assigned_agent_name', 'unassigned')
+    print(f'  {i} [{s:<11}] {t[\"title\"][:50]:<50} → {a}')
+    print(f'    id: {t[\"id\"]}')
+"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+case "${1:-}" in
+  agent-start) shift; cmd_agent_start "$@";;
+  agent-done)  shift; cmd_agent_done "$@";;
+  agent-error) shift; cmd_agent_error "$@";;
+  status)      shift; cmd_status "$@";;
+  *)
+    echo "ARIA ↔ Mission Control Bridge (bash)"
+    echo ""
+    echo "Usage:"
+    echo "  $0 agent-start --agent NAME --task TITLE [--label LABEL]"
+    echo "  $0 agent-done  --agent NAME --task-id ID [--summary TEXT]"
+    echo "  $0 agent-error --agent NAME --task-id ID --error TEXT"
+    echo "  $0 status"
+    echo ""
+    echo "For the full version with label mapping, use mc-bridge.py"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Add `scripts/aria-mc-hook.sh` — one-liner wrapper for ARIA to auto-notify Mission Control on agent spawn/done/error
- Add `scripts/mc-bridge.py` — full Python bridge with label mapping (stdlib only, no pip)
- Add `scripts/mc-bridge.sh` — lightweight bash alternative using curl

## How it works
ARIA calls the hook before/after spawning sub-agents:
```bash
TASK_ID=$(aria-mc-hook.sh start researcher-1900 "Research Axe 2")
aria-mc-hook.sh done researcher-1900 "$TASK_ID" "Found 6 ideas"
```

The hook calls mc-bridge.py → REST API → SSE broadcast → dashboard updates in real-time.

Supports all 11 ARIA agents via label prefix mapping (e.g. `coder-fix-bug` → Coder, `synth-morning` → Synthesizer).

Fails silently if MC is down (never blocks ARIA).

## Test plan
- [x] Verified `start` creates task as `in_progress`, sets agent to `working`
- [x] Verified `update` logs activity without changing status
- [x] Verified `done` moves task to `done`, agent back to `standby`
- [x] Verified `error` moves task to `review` with error logged
- [x] Verified fail-silent when MC is unreachable (exit 0, no output)
- [x] Verified SSE broadcast triggers dashboard real-time updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)