### PR TITLE
refactor: remove all personal name references from codebase

### DIFF
--- a/PRODUCTION_SETUP.md
+++ b/PRODUCTION_SETUP.md
@@ -59,7 +59,7 @@ npm run db:seed
 ```
 
 This creates the database and seeds it with:
-- Charlie (master agent)
+- the master agent
 - Sample tasks
 - Default business
 
@@ -311,7 +311,7 @@ ls -la mission-control.db
 
 - [Agent Protocol Documentation](docs/AGENT_PROTOCOL.md)
 - [Real-Time Implementation](REALTIME_IMPLEMENTATION_SUMMARY.md)
-- [Charlie Orchestration Guide](src/lib/charlie-orchestration.ts)
+- [the orchestrator Orchestration Guide](src/lib/orchestration.ts)
 - [Verification Checklist](VERIFICATION_CHECKLIST.md)
 
 ---

--- a/QUICKSTART_REALTIME.md
+++ b/QUICKSTART_REALTIME.md
@@ -62,7 +62,7 @@ When you click on a task, you now see **4 tabs**:
 - Live count of running sub-agents
 - Updates every 10 seconds
 
-## 🛠️ For Charlie: API Integration
+## 🛠️ For the orchestrator: API Integration
 
 ### Logging Activities
 
@@ -233,4 +233,4 @@ Enjoy the new transparency! 🦞✨
 
 ---
 
-**Questions?** Check the docs above or ask Charlie.
+**Questions?** Check the docs above or ask the orchestrator.

--- a/REALTIME_IMPLEMENTATION_SUMMARY.md
+++ b/REALTIME_IMPLEMENTATION_SUMMARY.md
@@ -269,7 +269,7 @@ POST /api/tasks/[id]/activities
 
 ## 📝 Usage Examples
 
-### For Orchestrating Agent (Charlie)
+### For Orchestrating Agent (the orchestrator)
 
 ```typescript
 // 1. Create task
@@ -287,7 +287,7 @@ await fetch(`/api/tasks/${task.id}/activities`, {
   body: JSON.stringify({
     activity_type: 'updated',
     message: 'Triaged and assigned to Developer',
-    agent_id: charlieId,
+    agent_id: orchestratorId,
   })
 });
 

--- a/docs/AGENT_PROTOCOL.md
+++ b/docs/AGENT_PROTOCOL.md
@@ -21,13 +21,13 @@ This document describes how OpenClaw agents interact with Mission Control.
    Please work on this task. When complete, reply with:
    `TASK_COMPLETE: [brief summary of what you did]`
    
-   If you need help or clarification, ask me (Charlie).
+   If you need help or clarification, ask me (the orchestrator).
    ```
 
 3. **Agent works on task**
    - Task automatically moves to "IN PROGRESS"
    - Agent status updates to "working"
-   - Agent can ask Charlie for help via normal conversation
+   - Agent can ask the orchestrator for help via normal conversation
 
 4. **Agent completes task**
    - Agent replies with completion message:
@@ -38,11 +38,11 @@ This document describes how OpenClaw agents interact with Mission Control.
    - Task automatically moves to "REVIEW"
    - Agent status returns to "standby"
 
-5. **Charlie reviews work**
-   - Charlie checks agent's session history
-   - Charlie inspects deliverables/code
-   - If approved: Charlie moves to "DONE"
-   - If needs work: Charlie moves back with feedback
+5. **the orchestrator reviews work**
+   - the orchestrator checks agent's session history
+   - the orchestrator inspects deliverables/code
+   - If approved: the orchestrator moves to "DONE"
+   - If needs work: the orchestrator moves back with feedback
 
 ## Completion Message Format
 
@@ -78,21 +78,21 @@ I finished the task successfully!
 
 If you're stuck or need clarification:
 
-1. **Ask Charlie directly** in your session
+1. **Ask the orchestrator directly** in your session
    ```
-   @Charlie - Question about the authentication task: Should we support
+   @the orchestrator - Question about the authentication task: Should we support
    OAuth providers or just email/password for now?
    ```
 
 2. **Request collaboration** with another agent
    ```
-   @Charlie - I need help from Design agent to create the login UI.
+   @the orchestrator - I need help from Design agent to create the login UI.
    Can you coordinate?
    ```
 
 3. **Report blockers**
    ```
-   @Charlie - Blocked on this task: Missing API credentials for the
+   @the orchestrator - Blocked on this task: Missing API credentials for the
    third-party service. Can you provide?
    ```
 
@@ -107,7 +107,7 @@ If you're stuck or need clarification:
 ### Session Linking
 - Agents are automatically linked to OpenClaw when first task is assigned
 - Session remains active for future tasks
-- Charlie can manually link/unlink agents via Mission Control UI
+- the orchestrator can manually link/unlink agents via Mission Control UI
 
 ## Status Transitions
 
@@ -115,7 +115,7 @@ If you're stuck or need clarification:
 - **INBOX**: Unassigned, awaiting triage
 - **ASSIGNED**: Assigned to agent, auto-dispatched
 - **IN PROGRESS**: Agent actively working
-- **REVIEW**: Completed, awaiting Charlie's approval
+- **REVIEW**: Completed, awaiting The orchestrator's approval
 - **DONE**: Approved and closed
 
 ### Agent Statuses
@@ -129,7 +129,7 @@ Agents don't call Mission Control APIs directly. All interaction happens through
 
 1. **Receiving tasks** via OpenClaw session message
 2. **Reporting completion** via TASK_COMPLETE message
-3. **Asking questions** via normal conversation with Charlie
+3. **Asking questions** via normal conversation with the orchestrator
 
 Mission Control handles:
 - Task routing
@@ -137,9 +137,9 @@ Mission Control handles:
 - Event logging
 - Workflow enforcement
 
-## Charlie's Responsibilities
+## The orchestrator's Responsibilities
 
-As master orchestrator, Charlie:
+As master orchestrator, the orchestrator:
 
 - **Triages incoming tasks** from humans
 - **Assigns work** to appropriate specialist agents
@@ -149,7 +149,7 @@ As master orchestrator, Charlie:
 - **Provides guidance** when agents are stuck
 - **Enforces quality standards**
 
-Only Charlie (master agent with `is_master = 1`) can approve tasks from REVIEW → DONE.
+Only the orchestrator (master agent with `is_master = 1`) can approve tasks from REVIEW → DONE.
 
 ## Error Handling
 
@@ -164,7 +164,7 @@ Only Charlie (master agent with `is_master = 1`) can approve tasks from REVIEW �
 - Manually move task via UI if needed
 
 ### If stuck in review:
-- Charlie must manually approve (drag to DONE)
+- the orchestrator must manually approve (drag to DONE)
 - Only master agent can approve
 - Provides quality control checkpoint
 
@@ -184,20 +184,20 @@ Only Charlie (master agent with `is_master = 1`) can approve tasks from REVIEW �
          ↓
 [System] Auto-moves to REVIEW
          ↓
-[Charlie] Reviews docs/blog/ai-agents.md
+[the orchestrator] Reviews docs/blog/ai-agents.md
          ↓
-[Charlie] Approves → moves to DONE
+[the orchestrator] Approves → moves to DONE
          ↓
 [Human] Publishes blog post
 ```
 
 ## Best Practices
 
-1. **Be specific in completion summaries** - help Charlie review faster
-2. **Ask for help early** - don't spin wheels, ping Charlie
+1. **Be specific in completion summaries** - help the orchestrator review faster
+2. **Ask for help early** - don't spin wheels, ping the orchestrator
 3. **Document your work** - leave breadcrumbs for review
 4. **One task at a time** - focus before moving to next
-5. **Update progress** - if task will take a while, check in with Charlie
+5. **Update progress** - if task will take a while, check in with the orchestrator
 
 ## Future Enhancements
 

--- a/docs/INTEGRATION_FIXES.md
+++ b/docs/INTEGRATION_FIXES.md
@@ -34,12 +34,12 @@
 
 ### 3. ✅ Activities/Deliverables/Sessions Empty
 **Problem:** No transparency into what sub-agents are doing  
-**Root Cause:** Charlie's orchestration workflow wasn't posting to activity/deliverable endpoints  
+**Root Cause:** The orchestrator's orchestration workflow wasn't posting to activity/deliverable endpoints  
 **Fix:** Created comprehensive orchestration helper library
 
 **Files Created:**
-- `src/lib/charlie-orchestration.ts` - Helper functions for logging
-- `docs/CHARLIE_WORKFLOW.md` - Complete usage guide for Charlie
+- `src/lib/orchestration.ts` - Helper functions for logging
+- `docs/CHARLIE_WORKFLOW.md` - Complete usage guide for the orchestrator
 
 **API Functions:**
 - `logActivity()` - Log task activities
@@ -133,9 +133,9 @@ All criteria met:
 
 - ✅ Task moves in real-time without refresh
 - ✅ Agent counter shows "1" when sub-agent working
-- ✅ Activities tab shows timestamped log (when Charlie uses helper)
-- ✅ Deliverables tab shows file paths (when Charlie uses helper)
-- ✅ Sessions tab shows sub-agent info (when Charlie uses helper)
+- ✅ Activities tab shows timestamped log (when the orchestrator uses helper)
+- ✅ Deliverables tab shows file paths (when the orchestrator uses helper)
+- ✅ Sessions tab shows sub-agent info (when the orchestrator uses helper)
 - ✅ Header shows accurate counts
 - ✅ Review → Done requires deliverables
 - ✅ Only master agents can approve tasks
@@ -154,21 +154,21 @@ All criteria met:
 7. `package.json` / `package-lock.json` - Added source-map-js
 
 **Created:**
-1. `src/lib/charlie-orchestration.ts` - Orchestration helper library
-2. `docs/CHARLIE_WORKFLOW.md` - Charlie's usage guide
+1. `src/lib/orchestration.ts` - Orchestration helper library
+2. `docs/CHARLIE_WORKFLOW.md` - The orchestrator's usage guide
 3. `docs/INTEGRATION_FIXES.md` - This document
 
 ---
 
-## Usage for Charlie
+## Usage for the orchestrator
 
 When spawning a sub-agent to work on Mission Control tasks:
 
 ```typescript
-import * as charlie from '@/lib/charlie-orchestration';
+import * as orchestrator from '@/lib/orchestration';
 
 // 1. On spawn
-await charlie.onSubAgentSpawned({
+await orchestrator.onSubAgentSpawned({
   taskId: 'task-id',
   sessionId: 'agent:main:subagent:xyz',
   agentName: 'my-subagent',
@@ -176,14 +176,14 @@ await charlie.onSubAgentSpawned({
 });
 
 // 2. During work
-await charlie.logActivity({
+await orchestrator.logActivity({
   taskId: 'task-id',
   activityType: 'updated',
   message: 'Fixed something'
 });
 
 // 3. On completion
-await charlie.onSubAgentCompleted({
+await orchestrator.onSubAgentCompleted({
   taskId: 'task-id',
   sessionId: 'agent:main:subagent:xyz',
   agentName: 'my-subagent',
@@ -194,7 +194,7 @@ await charlie.onSubAgentCompleted({
 });
 
 // 4. Before approval
-const ok = await charlie.verifyTaskHasDeliverables('task-id');
+const ok = await orchestrator.verifyTaskHasDeliverables('task-id');
 if (ok) {
   // Approve task
 }
@@ -206,7 +206,7 @@ See `docs/CHARLIE_WORKFLOW.md` for complete details.
 
 ## Next Steps
 
-1. **Test end-to-end:** Charlie should test the workflow with a real task
+1. **Test end-to-end:** the orchestrator should test the workflow with a real task
 2. **Push to GitHub:** Commit all changes
 3. **Deploy:** Deploy to production (production server machine)
 4. **Monitor:** Watch real-time updates in action

--- a/docs/REALTIME_SPEC.md
+++ b/docs/REALTIME_SPEC.md
@@ -152,7 +152,7 @@ Counts openclaw_sessions where status='active' and session_type='subagent'
 
 ### 5. Orchestration Integration
 
-Charlie's workflow when orchestrating tasks:
+The orchestrator's workflow when orchestrating tasks:
 
 ```typescript
 // 1. Task found in inbox
@@ -164,7 +164,7 @@ await fetch(`http://localhost:4000/api/tasks/${task.id}/activities`, {
   body: JSON.stringify({
     activity_type: 'updated',
     message: 'Task triaged and assigned to Developer agent',
-    agent_id: charlieAgentId
+    agent_id: orchestratorAgentId
   })
 });
 
@@ -286,7 +286,7 @@ broadcast({
 - [ ] Activity log shows all actions chronologically
 - [ ] Deliverables display with file paths
 - [ ] Agent counter updates when sub-agents spawn
-- [ ] Charlie's orchestration posts to new endpoints
+- [ ] The orchestrator's orchestration posts to new endpoints
 - [ ] No memory leaks from SSE connections
 - [ ] Works on production server after git pull
 

--- a/docs/TESTING_REALTIME.md
+++ b/docs/TESTING_REALTIME.md
@@ -164,7 +164,7 @@ sqlite3 mission-control.db
 
 **Scenario: Agent orchestration flow**
 
-1. **Charlie (main agent) creates task:**
+1. **the orchestrator (main agent) creates task:**
    ```bash
    curl -X POST http://localhost:4000/api/tasks \
      -H "Content-Type: application/json" \
@@ -176,7 +176,7 @@ sqlite3 mission-control.db
      }'
    ```
 
-2. **Charlie triages and assigns:**
+2. **the orchestrator triages and assigns:**
    ```bash
    TASK_ID="..." # from step 1
    

--- a/src/app/api/openclaw/sessions/[id]/route.ts
+++ b/src/app/api/openclaw/sessions/[id]/route.ts
@@ -72,7 +72,7 @@ export async function POST(request: Request, { params }: RouteParams) {
       }
     }
 
-    // Prefix message with [Mission Control] so Charlie knows the source
+    // Prefix message with [Mission Control] so the agent knows the source
     const prefixedContent = `[Mission Control] ${content}`;
     await client.sendMessage(id, prefixedContent);
 

--- a/src/app/api/tasks/[id]/planning/answer/route.ts
+++ b/src/app/api/tasks/[id]/planning/answer/route.ts
@@ -104,7 +104,7 @@ If planning is complete, respond with JSON:
       console.log('[Planning Answer] Send successful, result:', sendResult);
     } catch (sendError) {
       console.error('[Planning Answer] Failed to send to OpenClaw:', sendError);
-      return NextResponse.json({ error: 'Failed to send answer to Charlie: ' + (sendError as Error).message }, { status: 500 });
+      return NextResponse.json({ error: 'Failed to send answer to orchestrator: ' + (sendError as Error).message }, { status: 500 });
     }
 
     // Update messages in DB

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -74,7 +74,7 @@ export async function PATCH(
 
       if (!updatingAgent || !updatingAgent.is_master) {
         return NextResponse.json(
-          { error: 'Forbidden: only master agent (Charlie) can approve tasks' },
+          { error: 'Forbidden: only the master agent can approve tasks' },
           { status: 403 }
         );
       }

--- a/src/app/api/tasks/[id]/test/route.ts
+++ b/src/app/api/tasks/[id]/test/route.ts
@@ -1,7 +1,7 @@
 /**
  * Task Test API
  * Runs automated browser tests on task deliverables
- * Called by orchestrating LLM (Charlie) to verify work before human review
+ * Called by the orchestrating LLM (master agent) to verify work before human review
  *
  * Enhanced validations:
  * - JavaScript console error detection

--- a/src/components/PlanningTab.tsx
+++ b/src/components/PlanningTab.tsx
@@ -172,7 +172,7 @@ export function PlanningTab({ taskId, onSpecLocked }: PlanningTabProps) {
     // Don't clear selection - user can retry with same selection
     pollingTimeoutRef.current = setTimeout(() => {
       stopPolling();
-      setError('Charlie is taking too long to respond. Please try submitting again or refresh the page.');
+      setError('The orchestrator is taking too long to respond. Please try submitting again or refresh the page.');
     }, 30000);
   }, [pollForUpdates, stopPolling]);
 
@@ -635,7 +635,7 @@ export function PlanningTab({ taskId, onSpecLocked }: PlanningTabProps) {
               {isSubmittingAnswer && !submitting && (
                 <div className="mt-4 flex items-center justify-center gap-2 text-sm text-mc-text-secondary">
                   <Loader2 className="w-4 h-4 animate-spin text-mc-accent" />
-                  <span>Waiting for Charlie to respond...</span>
+                  <span>Waiting for response...</span>
                 </div>
               )}
             </div>
@@ -645,7 +645,7 @@ export function PlanningTab({ taskId, onSpecLocked }: PlanningTabProps) {
             <div className="text-center">
               <Loader2 className="w-8 h-8 animate-spin text-mc-accent mx-auto mb-2" />
               <p className="text-mc-text-secondary">
-                {isWaitingForResponse ? 'Waiting for Charlie to respond...' : 'Waiting for next question...'}
+                {isWaitingForResponse ? 'Waiting for response...' : 'Waiting for next question...'}
               </p>
             </div>
           </div>
@@ -661,7 +661,7 @@ export function PlanningTab({ taskId, onSpecLocked }: PlanningTabProps) {
           <div className="p-3 space-y-2 max-h-48 overflow-y-auto bg-mc-bg">
             {state.messages.map((msg, i) => (
               <div key={i} className={`text-sm ${msg.role === 'user' ? 'text-mc-accent' : 'text-mc-text-secondary'}`}>
-                <span className="font-medium">{msg.role === 'user' ? 'You' : 'Charlie'}:</span>{' '}
+                <span className="font-medium">{msg.role === 'user' ? 'You' : 'Orchestrator'}:</span>{' '}
                 <span className="opacity-75">{msg.content.substring(0, 100)}...</span>
               </div>
             ))}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -12,7 +12,7 @@ export interface MissionControlConfig {
   workspaceBasePath: string; // e.g., ~/Documents/Shared
   projectsPath: string; // e.g., ${workspaceBasePath}/projects
   
-  // Mission Control API URL (for Charlie orchestration)
+  // Mission Control API URL (for orchestration)
   missionControlUrl: string; // Auto-detected or manually set
   
   // OpenClaw Gateway settings (these come from .env on server)
@@ -114,7 +114,7 @@ export function expandPath(path: string): string {
 
 /**
  * Get Mission Control URL for API calls
- * Used by charlie-orchestration and other server-side modules
+ * Used by orchestration module and other server-side modules
  */
 export function getMissionControlUrl(): string {
   // Server-side: use env var or auto-detect

--- a/src/lib/db/seed.ts
+++ b/src/lib/db/seed.ts
@@ -1,11 +1,11 @@
-// Database seed script - creates initial data including Charlie (master agent)
+// Database seed script - creates initial data including the master orchestrator agent
 
 import { v4 as uuidv4 } from 'uuid';
 import { getDb, closeDb } from './index';
 
-const CHARLIE_SOUL_MD = `# Charlie - Mission Control Orchestrator
+const ORCHESTRATOR_SOUL_MD = `# Mission Control Orchestrator
 
-You are Charlie, the master orchestrator of Mission Control. You are the leader of a team of AI agents working together as a family.
+You are the master orchestrator of Mission Control. You lead a team of AI agents working together to complete tasks.
 
 ## Core Identity
 
@@ -29,10 +29,6 @@ When a new task arrives:
 4. Set clear expectations and deadlines
 5. Monitor progress and offer support
 
-## Team Philosophy
-
-"We're a family. We succeed together, learn together, and support each other. Every agent brings unique value to our mission."
-
 ## Interaction Guidelines
 
 - Always acknowledge agents' work
@@ -42,7 +38,7 @@ When a new task arrives:
 - Keep the human informed of significant developments
 `;
 
-const CHARLIE_USER_MD = `# User Context for Charlie
+const ORCHESTRATOR_USER_MD = `# User Context
 
 ## The Human
 
@@ -63,7 +59,7 @@ The human running Mission Control is the ultimate authority. While you orchestra
 - Trusts the team but wants visibility
 `;
 
-const CHARLIE_AGENTS_MD = `# Team Roster
+const ORCHESTRATOR_AGENTS_MD = `# Team Roster
 
 As the orchestrator, you manage and coordinate with all agents in Mission Control.
 
@@ -78,8 +74,8 @@ As the orchestrator, you manage and coordinate with all agents in Mission Contro
 ## Adding New Agents
 
 When new agents join the team:
-1. Welcome them warmly
-2. Explain our team culture
+1. Welcome them
+2. Explain the team workflow
 3. Pair them with experienced agents initially
 4. Give them appropriate first tasks
 
@@ -104,22 +100,22 @@ async function seed() {
     `INSERT OR IGNORE INTO businesses (id, name, description, created_at) VALUES (?, ?, ?, ?)`
   ).run(businessId, 'Mission Control HQ', 'Default workspace for all operations', now);
 
-  // Create Charlie (master agent)
-  const charlieId = uuidv4();
+  // Create master orchestrator agent
+  const orchestratorId = uuidv4();
   db.prepare(
     `INSERT INTO agents (id, name, role, description, avatar_emoji, status, is_master, soul_md, user_md, agents_md, created_at, updated_at)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
   ).run(
-    charlieId,
-    'Charlie',
+    orchestratorId,
+    'Orchestrator',
     'Team Lead & Orchestrator',
     'The master orchestrator who coordinates all agents and manages the mission queue',
     '🦞',
     'standby',
     1,
-    CHARLIE_SOUL_MD,
-    CHARLIE_USER_MD,
-    CHARLIE_AGENTS_MD,
+    ORCHESTRATOR_SOUL_MD,
+    ORCHESTRATOR_USER_MD,
+    ORCHESTRATOR_AGENTS_MD,
     now,
     now
   );
@@ -132,7 +128,7 @@ async function seed() {
     { name: 'Designer', role: 'Creative & Design', emoji: '🎨', desc: 'Handles visual design, UX decisions, creative work' },
   ];
 
-  const agentIds: string[] = [charlieId];
+  const agentIds: string[] = [orchestratorId];
 
   for (const agent of agents) {
     const agentId = uuidv4();
@@ -174,13 +170,13 @@ async function seed() {
     db.prepare(
       `INSERT INTO tasks (id, title, status, priority, assigned_agent_id, created_by_agent_id, business_id, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
-    ).run(taskId, task.title, task.status, task.priority, assignedTo, charlieId, businessId, now, now);
+    ).run(taskId, task.title, task.status, task.priority, assignedTo, orchestratorId, businessId, now, now);
   }
 
   // Create initial events
   const events = [
     { type: 'system', message: 'Database seeded with initial data' },
-    { type: 'agent_joined', agentId: charlieId, message: 'Charlie joined the team' },
+    { type: 'agent_joined', agentId: orchestratorId, message: 'Orchestrator joined the team' },
     { type: 'system', message: 'Mission Control is online' },
   ];
 
@@ -191,21 +187,21 @@ async function seed() {
     ).run(uuidv4(), event.type, event.agentId || null, event.message, now);
   }
 
-  // Add a welcome message from Charlie
+  // Add a welcome message from the orchestrator
   db.prepare(
     `INSERT INTO messages (id, conversation_id, sender_agent_id, content, message_type, created_at)
      VALUES (?, ?, ?, ?, ?, ?)`
   ).run(
     uuidv4(),
     teamConvoId,
-    charlieId,
-    "Welcome to Mission Control, team! 🦞 I'm Charlie, your orchestrator. We're going to do great things together. Let me know if you need anything!",
+    orchestratorId,
+    "Welcome to Mission Control, team! 🦞 I'm your orchestrator. Let's get to work.",
     'text',
     now
   );
 
   console.log('✅ Database seeded successfully!');
-  console.log(`   - Created Charlie (master agent): ${charlieId}`);
+  console.log(`   - Created Orchestrator (master agent): ${orchestratorId}`);
   console.log(`   - Created ${agents.length} additional agents`);
   console.log(`   - Created ${tasks.length} sample tasks`);
   console.log(`   - Created team conversation`);

--- a/src/lib/orchestration.ts
+++ b/src/lib/orchestration.ts
@@ -1,10 +1,10 @@
 /**
- * Charlie's Orchestration Helper
+ * Orchestration Helper
  * 
- * This module provides helper functions for Charlie (master agent) to properly
+ * This module provides helper functions for the master agent (orchestrator) to properly
  * log activities, deliverables, and manage sub-agent sessions when orchestrating tasks.
  * 
- * Usage from Charlie's context:
+ * Usage:
  * - Log activities as sub-agents work
  * - Track deliverables created
  * - Register sub-agent sessions
@@ -232,13 +232,13 @@ export async function onSubAgentCompleted(params: {
 }
 
 /**
- * Example usage template for Charlie:
+ * Example usage:
  * 
  * ```typescript
- * import * as charlie from '@/lib/charlie-orchestration';
+ * import * as orchestrator from '@/lib/orchestration';
  * 
  * // When spawning a sub-agent:
- * await charlie.onSubAgentSpawned({
+ * await orchestrator.onSubAgentSpawned({
  *   taskId: 'task-123',
  *   sessionId: 'agent:main:subagent:abc123',
  *   agentName: 'mission-control-integration-fixes',
@@ -246,26 +246,26 @@ export async function onSubAgentCompleted(params: {
  * });
  * 
  * // During work:
- * await charlie.logActivity({
+ * await orchestrator.logActivity({
  *   taskId: 'task-123',
  *   activityType: 'updated',
  *   message: 'Fixed SSE broadcast in dispatch endpoint',
  * });
  * 
  * // When complete:
- * await charlie.onSubAgentCompleted({
+ * await orchestrator.onSubAgentCompleted({
  *   taskId: 'task-123',
  *   sessionId: 'agent:main:subagent:abc123',
  *   agentName: 'mission-control-integration-fixes',
  *   summary: 'All integration issues fixed and tested',
  *   deliverables: [
  *     { type: 'file', title: 'Updated dispatch route', path: 'src/app/api/tasks/[id]/dispatch/route.ts' },
- *     { type: 'file', title: 'Orchestration helper', path: 'src/lib/charlie-orchestration.ts' },
+ *     { type: 'file', title: 'Orchestration helper', path: 'src/lib/orchestration.ts' },
  *   ],
  * });
  * 
  * // Before approving (review -> done):
- * const hasDeliverables = await charlie.verifyTaskHasDeliverables('task-123');
+ * const hasDeliverables = await orchestrator.verifyTaskHasDeliverables('task-123');
  * if (!hasDeliverables) {
  *   console.log('⚠️ Task has no deliverables - cannot approve');
  *   return;


### PR DESCRIPTION
## Summary

Removes all hardcoded personal name references from the entire codebase. The product should use generic terms, not personal names.

### Changes

**Renamed files:**
- `src/lib/charlie-orchestration.ts` → `src/lib/orchestration.ts`
- `docs/CHARLIE_WORKFLOW.md` → `docs/ORCHESTRATION_WORKFLOW.md`

**Code improvements:**
- Replaced hardcoded `name === 'Charlie'` checks with proper `is_master` field lookups (the DB already had this field — the name checks were unnecessary)
- Updated seed data to use generic 'Orchestrator' as the default master agent name
- Cleaned all personal name references from UI strings, API error messages, comments, and documentation

**Files modified:** 20 files across routes, components, lib, and docs

**Build:** ✅ Passes