### PR TITLE
fix: add force-dynamic to pre-rendered API routes

### DIFF
--- a/src/app/api/demo/route.ts
+++ b/src/app/api/demo/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server';
 
+export const dynamic = 'force-dynamic';
+
 export async function GET() {
   return NextResponse.json({
     demo: process.env.DEMO_MODE === 'true',

--- a/src/app/api/openclaw/models/route.ts
+++ b/src/app/api/openclaw/models/route.ts
@@ -3,6 +3,8 @@ import { existsSync, readFileSync, statSync } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
 
+export const dynamic = 'force-dynamic';
+
 // Maximum allowed config file size (1MB) to prevent DoS
 const MAX_CONFIG_SIZE_BYTES = 1024 * 1024;
 

--- a/src/app/api/openclaw/status/route.ts
+++ b/src/app/api/openclaw/status/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 import { getOpenClawClient } from '@/lib/openclaw/client';
 
+export const dynamic = 'force-dynamic';
+
 // GET /api/openclaw/status - Check OpenClaw connection status
 export async function GET() {
   try {


### PR DESCRIPTION
## Problem

Next.js pre-renders API routes at build time by default. Routes that depend on runtime environment variables or external services (like connecting to an OpenClaw gateway) get their responses cached permanently during `docker build`, when those services aren't available.

This means routes like `/api/openclaw/status` always return `connected: false`, `/api/openclaw/models` returns empty results, and `/api/demo` caches a stale `DEMO_MODE` value — regardless of the actual runtime state.

## Fix

Add `export const dynamic = 'force-dynamic'` to the three affected routes, forcing Next.js to evaluate them at request time instead of build time:

- `src/app/api/openclaw/status/route.ts`
- `src/app/api/openclaw/models/route.ts`
- `src/app/api/demo/route.ts`

Routes with dynamic path segments (`[id]`) or POST-only methods are already dynamic by default and don't need this fix.

## Verification

Confirmed via `.next/prerender-manifest.json` that these three routes were the only ones being statically pre-rendered.