### PR TITLE
fix: force dynamic /api/openclaw/status

### DIFF
--- a/src/app/api/openclaw/status/route.ts
+++ b/src/app/api/openclaw/status/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from 'next/server';
 import { getOpenClawClient } from '@/lib/openclaw/client';
 
+// Force this API route to be evaluated at request time.
+// Next.js may try to prerender certain API routes as static during `next build`,
+// which would freeze an "offline" status from build-time.
+export const dynamic = 'force-dynamic';
+
 // GET /api/openclaw/status - Check OpenClaw connection status
 export async function GET() {
   try {


### PR DESCRIPTION
This fixes a case where Mission Control can successfully talk to the OpenClaw Gateway (e.g. `/api/openclaw/sessions` returns data) but the UI shows OFFLINE because `/api/openclaw/status` can be evaluated/cached at build time.

### Symptoms
- UI top-right status shows OFFLINE
- `/api/openclaw/sessions` returns session data
- `/api/openclaw/status` may return `connected:false` even though the WS client authenticated

### Fix
Mark the status route as dynamic so it always runs at request time:
```ts
export const dynamic = "force-dynamic";
```

This prevents build-time/static evaluation from freezing an offline result.
