### PR TITLE
fix: auto-reset tasks to planning when dispatch fails

### DIFF
--- a/src/app/api/tasks/[id]/planning/poll/route.ts
+++ b/src/app/api/tasks/[id]/planning/poll/route.ts
@@ -138,16 +138,27 @@ async function handlePlanningCompletion(taskId: string, parsed: any, messages: a
     }
   }
 
-  // Final transaction: mark as complete or store error for retry
+  // Final transaction: mark as complete or reset to planning on failure
   db.transaction(() => {
     if (dispatchError) {
-      // Store the error but don't mark as complete - user can retry
+      // Reset to planning so user can re-plan - clears stale planning data
       db.prepare(`
         UPDATE tasks
-        SET planning_dispatch_error = ?,
+        SET status = 'planning',
+            status_reason = ?,
+            planning_complete = 0,
+            planning_spec = NULL,
+            planning_agents = NULL,
+            planning_messages = NULL,
+            planning_dispatch_error = ?,
             updated_at = datetime('now')
         WHERE id = ?
-      `).run(dispatchError, taskId);
+      `).run(
+        'Dispatch failed: ' + dispatchError,
+        dispatchError,
+        taskId
+      );
+      console.log(`[Planning Poll] Dispatch failed, reset task ${taskId} to planning: ${dispatchError}`);
     } else if (firstAgentId) {
       // Success - mark complete and assign
       db.prepare(`

--- a/src/app/api/tasks/[id]/planning/retry-dispatch/route.ts
+++ b/src/app/api/tasks/[id]/planning/retry-dispatch/route.ts
@@ -70,14 +70,19 @@ export async function POST(
           WHERE id = ?
         `, [taskId]);
       } else {
-        // Store the error for display, keep as 'pending_dispatch'
+        // Reset to planning so user can re-plan - clears stale planning data
         run(`
-          UPDATE tasks 
-          SET planning_dispatch_error = ?,
-              status = 'pending_dispatch',
+          UPDATE tasks
+          SET status = 'planning',
+              status_reason = ?,
+              planning_complete = 0,
+              planning_spec = NULL,
+              planning_agents = NULL,
+              planning_messages = NULL,
+              planning_dispatch_error = ?,
               updated_at = datetime('now')
           WHERE id = ?
-        `, [result.error, taskId]);
+        `, ['Dispatch retry failed: ' + result.error, result.error, taskId]);
       }
     });
 
@@ -98,13 +103,19 @@ export async function POST(
     console.error('Failed to retry dispatch:', error);
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     
-    // Store the error in the database for user display
+    // Reset to planning so user can re-plan - clears stale planning data
     run(`
-      UPDATE tasks 
-      SET planning_dispatch_error = ?,
+      UPDATE tasks
+      SET status = 'planning',
+          status_reason = ?,
+          planning_complete = 0,
+          planning_spec = NULL,
+          planning_agents = NULL,
+          planning_messages = NULL,
+          planning_dispatch_error = ?,
           updated_at = datetime('now')
       WHERE id = ?
-    `, [`Retry error: ${errorMessage}`, taskId]);
+    `, [`Retry error: ${errorMessage}`, `Retry error: ${errorMessage}`, taskId]);
 
     return NextResponse.json({ 
       error: 'Failed to retry dispatch', 

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -202,6 +202,20 @@ const migrations: Migration[] = [
         console.log('[Migration 007] Added gateway_agent_id to agents');
       }
     }
+  },
+  {
+    id: '008',
+    name: 'add_status_reason_column',
+    up: (db) => {
+      console.log('[Migration 008] Adding status_reason column to tasks...');
+
+      const tasksInfo = db.prepare("PRAGMA table_info(tasks)").all() as { name: string }[];
+
+      if (!tasksInfo.some(col => col.name === 'status_reason')) {
+        db.exec(`ALTER TABLE tasks ADD COLUMN status_reason TEXT`);
+        console.log('[Migration 008] Added status_reason to tasks');
+      }
+    }
   }
 ];
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -59,6 +59,7 @@ CREATE TABLE IF NOT EXISTS tasks (
   planning_spec TEXT,
   planning_agents TEXT,
   planning_dispatch_error TEXT,
+  status_reason TEXT,
   created_at TEXT DEFAULT (datetime('now')),
   updated_at TEXT DEFAULT (datetime('now'))
 );

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,7 +2,7 @@
 
 export type AgentStatus = 'standby' | 'working' | 'offline';
 
-export type TaskStatus = 'planning' | 'inbox' | 'assigned' | 'in_progress' | 'testing' | 'review' | 'done';
+export type TaskStatus = 'pending_dispatch' | 'planning' | 'inbox' | 'assigned' | 'in_progress' | 'testing' | 'review' | 'done';
 
 export type TaskPriority = 'low' | 'normal' | 'high' | 'urgent';
 
@@ -64,6 +64,7 @@ export interface Task {
   workspace_id: string;
   business_id: string;
   due_date?: string;
+  status_reason?: string;
   created_at: string;
   updated_at: string;
   // Joined fields
@@ -131,6 +132,7 @@ export interface WorkspaceStats {
   slug: string;
   icon: string;
   taskCounts: {
+    pending_dispatch: number;
     planning: number;
     inbox: number;
     assigned: number;


### PR DESCRIPTION
## Summary
- When dispatch fails, tasks now auto-reset to `planning` status instead of getting stuck in `pending_dispatch`
- Planning data is cleared for a fresh retry
- New `status_reason` column tracks why status changed (migration 009)
- Both auto-dispatch and manual retry-dispatch follow the same reset behavior

Fixes #36

cc @ilakskill — this implements the solution you described in the issue. Would appreciate your review.

## Test plan
- [ ] Create task, complete planning without assigning agent
- [ ] Verify dispatch fails and task resets to `planning` (not stuck in `pending_dispatch`)
- [ ] Verify `status_reason` is populated
- [ ] Verify planning data is cleared for fresh retry
- [ ] Test manual retry-dispatch failure path