### PR TITLE
security: fix remaining audit findings from #18

### DIFF
--- a/src/app/api/openclaw/models/route.ts
+++ b/src/app/api/openclaw/models/route.ts
@@ -209,7 +209,7 @@ export async function GET() {
       defaultModel: undefined,
       availableModels: FALLBACK_MODELS,
       source: 'fallback',
-      error: error instanceof Error ? error.message : 'Unknown error',
+      error: 'Model discovery failed',
     }, { status: 500 });
   }
 }

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { v4 as uuidv4 } from 'uuid';
-import { queryOne, queryAll, run } from '@/lib/db';
+import { queryOne, queryAll, run, transaction } from '@/lib/db';
 import { getOpenClawClient } from '@/lib/openclaw/client';
 import { broadcast } from '@/lib/events';
 import { getProjectsPath, getMissionControlUrl } from '@/lib/config';
@@ -227,13 +227,39 @@ If you need help or clarification, ask the orchestrator.`;
         idempotencyKey: `dispatch-${task.id}-${Date.now()}`
       });
 
-      // Update task status to in_progress
-      run(
-        'UPDATE tasks SET status = ?, updated_at = ? WHERE id = ?',
-        ['in_progress', now, id]
-      );
+      // Wrap all post-dispatch DB writes in a transaction for atomicity.
+      // If any step fails, everything rolls back — no partial state.
+      transaction(() => {
+        // Update task status to in_progress
+        run(
+          'UPDATE tasks SET status = ?, updated_at = ? WHERE id = ?',
+          ['in_progress', now, id]
+        );
 
-      // Broadcast task update
+        // Update agent status to working
+        run(
+          'UPDATE agents SET status = ?, updated_at = ? WHERE id = ?',
+          ['working', now, agent.id]
+        );
+
+        // Log dispatch event to events table
+        const eventId = uuidv4();
+        run(
+          `INSERT INTO events (id, type, agent_id, task_id, message, created_at)
+           VALUES (?, ?, ?, ?, ?, ?)`,
+          [eventId, 'task_dispatched', agent.id, task.id, `Task "${task.title}" dispatched to ${agent.name}`, now]
+        );
+
+        // Log dispatch activity to task_activities table (for Activity tab)
+        const activityId = crypto.randomUUID();
+        run(
+          `INSERT INTO task_activities (id, task_id, agent_id, activity_type, message, created_at)
+           VALUES (?, ?, ?, ?, ?, ?)`,
+          [activityId, task.id, agent.id, 'status_changed', `Task dispatched to ${agent.name} - Agent is now working on this task`, now]
+        );
+      });
+
+      // Broadcast task update (outside transaction — non-critical)
       const updatedTask = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [id]);
       if (updatedTask) {
         broadcast({
@@ -241,28 +267,6 @@ If you need help or clarification, ask the orchestrator.`;
           payload: updatedTask,
         });
       }
-
-      // Update agent status to working
-      run(
-        'UPDATE agents SET status = ?, updated_at = ? WHERE id = ?',
-        ['working', now, agent.id]
-      );
-
-      // Log dispatch event to events table
-      const eventId = uuidv4();
-      run(
-        `INSERT INTO events (id, type, agent_id, task_id, message, created_at)
-         VALUES (?, ?, ?, ?, ?, ?)`,
-        [eventId, 'task_dispatched', agent.id, task.id, `Task "${task.title}" dispatched to ${agent.name}`, now]
-      );
-
-      // Log dispatch activity to task_activities table (for Activity tab)
-      const activityId = crypto.randomUUID();
-      run(
-        `INSERT INTO task_activities (id, task_id, agent_id, activity_type, message, created_at)
-         VALUES (?, ?, ?, ?, ?, ?)`,
-        [activityId, task.id, agent.id, 'status_changed', `Task dispatched to ${agent.name} - Agent is now working on this task`, now]
-      );
 
       return NextResponse.json({
         success: true,

--- a/src/app/api/tasks/[id]/planning/answer/route.ts
+++ b/src/app/api/tasks/[id]/planning/answer/route.ts
@@ -125,6 +125,6 @@ If planning is complete, respond with JSON:
     });
   } catch (error) {
     console.error('Failed to submit answer:', error);
-    return NextResponse.json({ error: 'Failed to submit answer: ' + (error as Error).message }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to submit answer' }, { status: 500 });
   }
 }

--- a/src/app/api/tasks/[id]/planning/retry-dispatch/route.ts
+++ b/src/app/api/tasks/[id]/planning/retry-dispatch/route.ts
@@ -118,8 +118,7 @@ export async function POST(
     `, [`Retry error: ${errorMessage}`, `Retry error: ${errorMessage}`, taskId]);
 
     return NextResponse.json({ 
-      error: 'Failed to retry dispatch', 
-      details: errorMessage 
+      error: 'Failed to retry dispatch'
     }, { status: 500 });
   }
 }

--- a/src/app/api/tasks/[id]/planning/route.ts
+++ b/src/app/api/tasks/[id]/planning/route.ts
@@ -185,7 +185,7 @@ Respond with ONLY valid JSON in this format:
     });
   } catch (error) {
     console.error('Failed to start planning:', error);
-    return NextResponse.json({ error: 'Failed to start planning: ' + (error as Error).message }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to start planning' }, { status: 500 });
   }
 }
 
@@ -236,6 +236,6 @@ export async function DELETE(
     return NextResponse.json({ success: true });
   } catch (error) {
     console.error('Failed to cancel planning:', error);
-    return NextResponse.json({ error: 'Failed to cancel planning: ' + (error as Error).message }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to cancel planning' }, { status: 500 });
   }
 }

--- a/src/app/api/webhooks/agent-completion/route.ts
+++ b/src/app/api/webhooks/agent-completion/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { v4 as uuidv4 } from 'uuid';
-import { createHmac } from 'crypto';
+import { createHmac, timingSafeEqual } from 'crypto';
 import { queryOne, queryAll, run } from '@/lib/db';
 import type { Task, Agent, OpenClawSession } from '@/lib/types';
 
@@ -24,7 +24,11 @@ function verifyWebhookSignature(signature: string, rawBody: string): boolean {
     .update(rawBody)
     .digest('hex');
 
-  return signature === expectedSignature;
+  // Use timing-safe comparison to prevent timing attacks
+  const sigBuf = Buffer.from(signature, 'utf-8');
+  const expectedBuf = Buffer.from(expectedSignature, 'utf-8');
+  if (sigBuf.length !== expectedBuf.length) return false;
+  return timingSafeEqual(sigBuf, expectedBuf);
 }
 
 /**

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,18 +1,71 @@
 /**
  * Server-Sent Events (SSE) broadcaster for real-time updates
  * Manages client connections and broadcasts events to all listeners
+ *
+ * Security: enforces MAX_CLIENTS cap and idle timeout to prevent
+ * resource exhaustion from leaked or malicious connections.
  */
 
 import type { SSEEvent } from './types';
 
+/** Hard cap on concurrent SSE connections */
+const MAX_CLIENTS = parseInt(process.env.SSE_MAX_CLIENTS || '100', 10);
+
+/** Idle timeout in ms — drop clients that haven't received a successful enqueue */
+const CLIENT_IDLE_TIMEOUT_MS = parseInt(process.env.SSE_IDLE_TIMEOUT_MS || '300000', 10); // 5 min
+
+interface ClientEntry {
+  controller: ReadableStreamDefaultController;
+  connectedAt: number;
+  lastActiveAt: number;
+}
+
 // Store active SSE client connections
-const clients = new Set<ReadableStreamDefaultController>();
+const clients = new Map<ReadableStreamDefaultController, ClientEntry>();
+
+// Periodic idle sweep (runs every 60 s)
+const idleSweep = setInterval(() => {
+  const now = Date.now();
+  for (const [ctrl, entry] of clients) {
+    if (now - entry.lastActiveAt > CLIENT_IDLE_TIMEOUT_MS) {
+      console.log(`[SSE] Removing idle client (idle ${Math.round((now - entry.lastActiveAt) / 1000)}s)`);
+      try { ctrl.close(); } catch { /* already closed */ }
+      clients.delete(ctrl);
+    }
+  }
+}, 60_000);
+if (idleSweep.unref) idleSweep.unref();
 
 /**
- * Register a new SSE client connection
+ * Register a new SSE client connection.
+ * Returns false if the connection was rejected (at capacity).
  */
-export function registerClient(controller: ReadableStreamDefaultController): void {
-  clients.add(controller);
+export function registerClient(controller: ReadableStreamDefaultController): boolean {
+  // Enforce max clients
+  if (clients.size >= MAX_CLIENTS) {
+    // Evict the oldest client to make room
+    let oldestCtrl: ReadableStreamDefaultController | null = null;
+    let oldestTime = Infinity;
+    for (const [ctrl, entry] of clients) {
+      if (entry.connectedAt < oldestTime) {
+        oldestTime = entry.connectedAt;
+        oldestCtrl = ctrl;
+      }
+    }
+    if (oldestCtrl) {
+      console.log('[SSE] Max clients reached, evicting oldest connection');
+      try { oldestCtrl.close(); } catch { /* already closed */ }
+      clients.delete(oldestCtrl);
+    }
+  }
+
+  const now = Date.now();
+  clients.set(controller, {
+    controller,
+    connectedAt: now,
+    lastActiveAt: now,
+  });
+  return true;
 }
 
 /**
@@ -30,15 +83,14 @@ export function broadcast(event: SSEEvent): void {
   const data = `data: ${JSON.stringify(event)}\n\n`;
   const encoded = encoder.encode(data);
 
-  // Send to all connected clients
-  const clientsArray = Array.from(clients);
-  for (const client of clientsArray) {
+  for (const [ctrl, entry] of clients) {
     try {
-      client.enqueue(encoded);
+      ctrl.enqueue(encoded);
+      entry.lastActiveAt = Date.now();
     } catch (error) {
       // Client disconnected, remove it
       console.error('Failed to send SSE event to client:', error);
-      clients.delete(client);
+      clients.delete(ctrl);
     }
   }
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,97 @@
+/**
+ * In-memory rate limiter using sliding window algorithm.
+ * No external dependencies — works with any Node.js runtime.
+ *
+ * Usage:
+ *   const limiter = createRateLimiter({ windowMs: 60_000, maxRequests: 60 });
+ *   const { allowed, remaining, resetMs } = limiter.check(ip);
+ */
+
+interface RateLimitEntry {
+  timestamps: number[];
+}
+
+interface RateLimiterOptions {
+  /** Time window in milliseconds (default: 60 000 = 1 min) */
+  windowMs?: number;
+  /** Max requests per window (default: 60) */
+  maxRequests?: number;
+  /** Cleanup interval in ms — removes stale entries (default: 5 min) */
+  cleanupIntervalMs?: number;
+}
+
+interface RateLimitResult {
+  allowed: boolean;
+  remaining: number;
+  resetMs: number;
+}
+
+export function createRateLimiter(opts: RateLimiterOptions = {}) {
+  const windowMs = opts.windowMs ?? 60_000;
+  const maxRequests = opts.maxRequests ?? 60;
+  const cleanupIntervalMs = opts.cleanupIntervalMs ?? 5 * 60_000;
+
+  const store = new Map<string, RateLimitEntry>();
+
+  // Periodic cleanup to prevent unbounded growth
+  const cleanup = setInterval(() => {
+    const now = Date.now();
+    for (const [key, entry] of store) {
+      entry.timestamps = entry.timestamps.filter((t) => now - t < windowMs);
+      if (entry.timestamps.length === 0) store.delete(key);
+    }
+  }, cleanupIntervalMs);
+
+  // Allow GC if the module is unloaded
+  if (cleanup.unref) cleanup.unref();
+
+  function check(key: string): RateLimitResult {
+    const now = Date.now();
+    let entry = store.get(key);
+    if (!entry) {
+      entry = { timestamps: [] };
+      store.set(key, entry);
+    }
+
+    // Slide the window — drop old timestamps
+    entry.timestamps = entry.timestamps.filter((t) => now - t < windowMs);
+
+    if (entry.timestamps.length >= maxRequests) {
+      const oldestInWindow = entry.timestamps[0];
+      return {
+        allowed: false,
+        remaining: 0,
+        resetMs: oldestInWindow + windowMs - now,
+      };
+    }
+
+    entry.timestamps.push(now);
+    return {
+      allowed: true,
+      remaining: maxRequests - entry.timestamps.length,
+      resetMs: windowMs,
+    };
+  }
+
+  return { check };
+}
+
+// ── Pre-configured limiters ─────────────────────────────────────────
+
+/** General API limiter: 100 req / 60 s per IP */
+export const apiLimiter = createRateLimiter({
+  windowMs: 60_000,
+  maxRequests: 100,
+});
+
+/** Webhook limiter: 30 req / 60 s per IP */
+export const webhookLimiter = createRateLimiter({
+  windowMs: 60_000,
+  maxRequests: 30,
+});
+
+/** Auth / sensitive endpoints: 10 req / 60 s per IP */
+export const authLimiter = createRateLimiter({
+  windowMs: 60_000,
+  maxRequests: 10,
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,9 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { apiLimiter, webhookLimiter } from '@/lib/rate-limit';
 
 // Log warning at startup if auth is disabled
 const MC_API_TOKEN = process.env.MC_API_TOKEN;
 if (!MC_API_TOKEN) {
   console.warn('[SECURITY WARNING] MC_API_TOKEN not set - API authentication is DISABLED (local dev mode)');
+}
+
+/**
+ * Extract client IP from request headers (respects proxies).
+ * Falls back to 'unknown' to ensure rate limiter still works.
+ */
+function getClientIp(request: NextRequest): string {
+  return (
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    request.headers.get('x-real-ip') ||
+    request.ip ||
+    'unknown'
+  );
 }
 
 /**
@@ -67,7 +81,26 @@ export function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // Demo mode: block all write operations
+  // ── Rate Limiting ────────────────────────────────────────────────
+  const ip = getClientIp(request);
+  const isWebhook = pathname.startsWith('/api/webhooks/');
+  const limiter = isWebhook ? webhookLimiter : apiLimiter;
+  const { allowed, remaining, resetMs } = limiter.check(ip);
+
+  if (!allowed) {
+    return NextResponse.json(
+      { error: 'Too many requests' },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': String(Math.ceil(resetMs / 1000)),
+          'X-RateLimit-Remaining': '0',
+        },
+      }
+    );
+  }
+
+  // ── Demo Mode ────────────────────────────────────────────────────
   if (DEMO_MODE) {
     const method = request.method.toUpperCase();
     if (method !== 'GET' && method !== 'HEAD' && method !== 'OPTIONS') {
@@ -76,24 +109,25 @@ export function middleware(request: NextRequest) {
         { status: 403 }
       );
     }
-    return NextResponse.next();
+    return addRateLimitHeaders(NextResponse.next(), remaining);
   }
 
+  // ── Auth ─────────────────────────────────────────────────────────
   // If MC_API_TOKEN is not set, auth is disabled (dev mode)
   if (!MC_API_TOKEN) {
-    return NextResponse.next();
+    return addRateLimitHeaders(NextResponse.next(), remaining);
   }
 
   // Allow same-origin browser requests (UI fetching its own API)
   if (isSameOriginRequest(request)) {
-    return NextResponse.next();
+    return addRateLimitHeaders(NextResponse.next(), remaining);
   }
 
   // Special case: /api/events/stream (SSE) - allow token as query param
   if (pathname === '/api/events/stream') {
     const queryToken = request.nextUrl.searchParams.get('token');
     if (queryToken && queryToken === MC_API_TOKEN) {
-      return NextResponse.next();
+      return addRateLimitHeaders(NextResponse.next(), remaining);
     }
     // Fall through to header check below
   }
@@ -117,7 +151,13 @@ export function middleware(request: NextRequest) {
     );
   }
 
-  return NextResponse.next();
+  return addRateLimitHeaders(NextResponse.next(), remaining);
+}
+
+/** Attach rate-limit headers to a successful response. */
+function addRateLimitHeaders(response: NextResponse, remaining: number): NextResponse {
+  response.headers.set('X-RateLimit-Remaining', String(remaining));
+  return response;
 }
 
 export const config = {


### PR DESCRIPTION
- Rate limiting: sliding window per IP (100/min API, 30/min webhooks) New src/lib/rate-limit.ts with configurable limits, auto-cleanup Middleware returns 429 + Retry-After header when exceeded

- SSE memory leak: max client cap (100, configurable via SSE_MAX_CLIENTS) Idle timeout eviction (5 min, configurable via SSE_IDLE_TIMEOUT_MS) Oldest connection evicted when at capacity

- Webhook HMAC: timing-safe comparison (timingSafeEqual) prevents timing attacks on signature validation

- Dispatch transaction: all post-dispatch DB writes wrapped in transaction() for atomicity — no partial state on failure

- Error message sanitization: removed error.message from 5 API responses (planning/start, planning/cancel, planning/answer, retry-dispatch, models). Internal details logged server-side only.

Addresses: crshdn/mission-control#18 (remaining findings)