### PR TITLE
docs: fix setup typo in README install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ cd mission-control
 # Install dependencies
 npm install
 
-# Configure
+# Setup
 cp .env.example .env.local
 ```
 


### PR DESCRIPTION
## Summary
- replace the install-section comment typo by changing '# Configure' to '# Setup' in README.md

## Testing
- not run (docs-only change)