### PR TITLE
Fix agent status not reset to standby when task completed

### DIFF
--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -352,6 +352,14 @@ export async function PATCH(
       drainQueue(id, existing.workspace_id).catch(err =>
         console.error('[Workflow] drainQueue after done failed:', err)
       );
+
+      // Reset agent status to standby when task is completed
+      if (existing.assigned_agent_id) {
+        run(
+          'UPDATE agents SET status = ?, updated_at = ? WHERE id = ?',
+          ['standby', now, existing.assigned_agent_id]
+        );
+      }
     }
 
     return NextResponse.json(task);


### PR DESCRIPTION
Fixes #61. When a task is marked as done, the assigned agent's status was not being reset back to 'standby', causing agents to remain tagged as 'working' indefinitely. This fix resets the agent status to 'standby' when the task reaches 'done' status.