### PR TITLE
fix: cascade delete workflow_templates and knowledge_entries when deleting workspace

### DIFF
--- a/src/app/api/workspaces/[id]/route.ts
+++ b/src/app/api/workspaces/[id]/route.ts
@@ -104,7 +104,7 @@ export async function DELETE(
       return NextResponse.json({ error: 'Workspace not found' }, { status: 404 });
     }
     
-    // Check if workspace has tasks or agents
+    // Check if workspace has tasks or agents (cannot delete)
     const taskCount = db.prepare(
       'SELECT COUNT(*) as count FROM tasks WHERE workspace_id = ?'
     ).get(id) as { count: number };
@@ -120,6 +120,10 @@ export async function DELETE(
         agentCount: agentCount.count
       }, { status: 400 });
     }
+    
+    // Delete associated records that don't block deletion
+    db.prepare('DELETE FROM workflow_templates WHERE workspace_id = ?').run(id);
+    db.prepare('DELETE FROM knowledge_entries WHERE workspace_id = ?').run(id);
     
     db.prepare('DELETE FROM workspaces WHERE id = ?').run(id);
     


### PR DESCRIPTION
## Summary

Fixes #70 

This PR adds cascade deletion for `workflow_templates` and `knowledge_entries` when deleting a workspace, preventing `SQLITE_CONSTRAINT_FOREIGNKEY` errors.

## Problem

Deleting a workspace fails when the workspace has associated `workflow_templates` (which are auto-created for every new workspace). The API returns:

```json
{"error":"Failed to delete workspace"}
```

Logs show:
```
Failed to delete workspace: SqliteError: FOREIGN KEY constraint failed
  code: 'SQLITE_CONSTRAINT_FOREIGNKEY'
```

## Solution

Delete `workflow_templates` and `knowledge_entries` before deleting the workspace. These records don't block user workflows (unlike tasks and agents) and should be cleaned up automatically.

## Changes

- Added cascade delete for `workflow_templates` before workspace deletion
- Added cascade delete for `knowledge_entries` before workspace deletion
- Updated comment for clarity

## Testing

1. Create a new workspace
2. Attempt to delete it via API or UI
3. Workspace should be deleted successfully

Before: `SQLITE_CONSTRAINT_FOREIGNKEY` error
After: `{"success":true}`

## Checklist

- [x] Code follows existing style
- [x] Fix addresses root cause
- [x] Tested manually