### PR TITLE
refactor(mission-control): dynamic routing, canonical agent sync, and strict stage governance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mission-control",
-  "version": "1.3.1",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mission-control",
-      "version": "1.3.1",
+      "version": "1.5.0",
       "dependencies": {
         "@hello-pangea/dnd": "^17.0.0",
         "better-sqlite3": "^12.6.2",

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "version": "1.5.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack -p ${PORT:-4000}",
+    "dev": "next dev --turbo -p ${PORT:-4000}",
     "build": "next build",
     "start": "next start -p ${PORT:-4000}",
     "lint": "next lint",
+    "test": "mkdir -p .tmp && rm -f .tmp/mission-control-test.db* && NODE_ENV=test DATABASE_PATH=.tmp/mission-control-test.db tsx --test src/**/*.test.ts",
     "db:seed": "tsx src/lib/db/seed.ts",
     "db:backup": "sqlite3 mission-control.db 'PRAGMA wal_checkpoint(TRUNCATE);' && cp mission-control.db mission-control.db.backup && echo 'Backed up to mission-control.db.backup'",
     "db:restore": "cp mission-control.db.backup mission-control.db && echo 'Restored from backup'",

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -6,6 +6,8 @@ import { broadcast } from '@/lib/events';
 import { getProjectsPath, getMissionControlUrl } from '@/lib/config';
 import { getRelevantKnowledge, formatKnowledgeForDispatch } from '@/lib/learner';
 import { getTaskWorkflow } from '@/lib/workflow-engine';
+import { syncGatewayAgentsToCatalog } from '@/lib/agent-catalog-sync';
+import { pickDynamicAgent } from '@/lib/task-governance';
 import type { Task, Agent, OpenClawSession, WorkflowStage, TaskImage } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -23,6 +25,11 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
     const { id } = await params;
 
+    // Keep canonical agent catalog synced before every dispatch (best-effort)
+    await syncGatewayAgentsToCatalog({ reason: 'dispatch' }).catch(err => {
+      console.warn('[Dispatch] agent catalog sync failed:', err);
+    });
+
     // Get task with agent info
     const task = queryOne<Task & { assigned_agent_name?: string; workspace_id: string }>(
       `SELECT t.*, a.name as assigned_agent_name, a.is_master
@@ -36,9 +43,25 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       return NextResponse.json({ error: 'Task not found' }, { status: 404 });
     }
 
-    if (!task.assigned_agent_id) {
+    let assignedAgentId = task.assigned_agent_id;
+    if (!assignedAgentId) {
+      const statusRoleMap: Record<string, string> = {
+        assigned: 'builder',
+        in_progress: 'builder',
+        testing: 'tester',
+        review: 'reviewer',
+        verification: 'reviewer',
+      };
+      const dynamicAgent = pickDynamicAgent(id, statusRoleMap[task.status] || 'builder');
+      if (dynamicAgent) {
+        assignedAgentId = dynamicAgent.id;
+        run('UPDATE tasks SET assigned_agent_id = ?, updated_at = datetime(\'now\') WHERE id = ?', [assignedAgentId, id]);
+      }
+    }
+
+    if (!assignedAgentId) {
       return NextResponse.json(
-        { error: 'Task has no assigned agent' },
+        { error: 'Task has no routable agent' },
         { status: 400 }
       );
     }
@@ -46,7 +69,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     // Get agent details
     const agent = queryOne<Agent>(
       'SELECT * FROM agents WHERE id = ?',
-      [task.assigned_agent_id]
+      [assignedAgentId]
     );
 
     if (!agent) {

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { v4 as uuidv4 } from 'uuid';
-import { queryOne, run, queryAll } from '@/lib/db';
+import { queryOne, run } from '@/lib/db';
 import { broadcast } from '@/lib/events';
 import { getMissionControlUrl } from '@/lib/config';
 import { handleStageTransition, handleStageFailure, getTaskWorkflow, drainQueue, populateTaskRolesFromAgents } from '@/lib/workflow-engine';
-import { notifyLearner } from '@/lib/learner';
+import { hasStageEvidence, canUseBoardOverride, auditBoardOverride, taskCanBeDone, recordLearnerOnTransition } from '@/lib/task-governance';
+import { syncGatewayAgentsToCatalog } from '@/lib/agent-catalog-sync';
 import { UpdateTaskSchema } from '@/lib/validation';
 import type { Task, UpdateTaskRequest, Agent, TaskDeliverable } from '@/lib/types';
 
@@ -45,7 +46,7 @@ export async function PATCH(
 ) {
   try {
     const { id } = await params;
-    const body: UpdateTaskRequest & { updated_by_agent_id?: string } = await request.json();
+    const body: UpdateTaskRequest & { updated_by_agent_id?: string; board_override?: boolean; override_reason?: string } = await request.json();
 
     // Validate input with Zod
     const validation = UpdateTaskSchema.safeParse(body);
@@ -63,6 +64,11 @@ export async function PATCH(
     if (!existing) {
       return NextResponse.json({ error: 'Task not found' }, { status: 404 });
     }
+
+    // Keep OpenClaw agent catalog synced opportunistically on task updates
+    await syncGatewayAgentsToCatalog({ reason: 'task_patch' }).catch(err => {
+      console.warn('[Task PATCH] agent catalog sync failed:', err);
+    });
 
     const updates: string[] = [];
     const values: unknown[] = [];
@@ -104,6 +110,10 @@ export async function PATCH(
     if (validatedData.workflow_template_id !== undefined) {
       updates.push('workflow_template_id = ?');
       values.push(validatedData.workflow_template_id);
+    }
+    if (validatedData.status_reason !== undefined) {
+      updates.push('status_reason = ?');
+      values.push(validatedData.status_reason);
     }
 
     // Track if we need to dispatch task
@@ -152,8 +162,34 @@ export async function PATCH(
 
     // Handle status change
     if (nextStatus !== undefined && nextStatus !== existing.status) {
+      const boardOverrideRequested = Boolean(body.board_override);
+      const boardOverrideAllowed = boardOverrideRequested && canUseBoardOverride(request);
+
+      // Hard evidence gate for forward-stage transitions and completion
+      const enteringQualityStage = ['testing', 'review', 'verification', 'done'].includes(nextStatus);
+      if (enteringQualityStage && !boardOverrideAllowed && !hasStageEvidence(id)) {
+        return NextResponse.json(
+          { error: 'Evidence gate failed: stage transition requires at least one deliverable and one activity note' },
+          { status: 400 }
+        );
+      }
+
+      // Failure transitions must include status_reason
+      const failingBackwards = ['testing', 'review', 'verification'].includes(existing.status) && ['in_progress', 'assigned'].includes(nextStatus);
+      if (failingBackwards && !validatedData.status_reason) {
+        return NextResponse.json({ error: 'status_reason is required when failing a stage' }, { status: 400 });
+      }
+
+      if (nextStatus === 'done' && !boardOverrideAllowed && !taskCanBeDone(id)) {
+        return NextResponse.json({ error: 'Cannot mark done: validation/evidence requirements not met' }, { status: 400 });
+      }
+
       updates.push('status = ?');
       values.push(nextStatus);
+
+      if (boardOverrideAllowed) {
+        auditBoardOverride(id, existing.status, nextStatus, body.override_reason);
+      }
 
       // Auto-dispatch when moving to assigned (if we have a valid assignee)
       if (nextStatus === 'assigned' && effectiveAssignedAgentId) {
@@ -364,16 +400,11 @@ export async function PATCH(
       }
     }
 
-    // Notify learner on stage transitions (non-blocking)
+    // Learner must record every stage transition (non-blocking)
     if (nextStatus && nextStatus !== existing.status) {
-      const isForwardMove = !['inbox', 'assigned', 'planning', 'pending_dispatch'].includes(nextStatus);
-      if (isForwardMove) {
-        notifyLearner(id, {
-          previousStatus: existing.status,
-          newStatus: nextStatus,
-          passed: true,
-        }).catch(err => console.error('[Learner] notification failed:', err));
-      }
+      recordLearnerOnTransition(id, existing.status, nextStatus, true).catch(err =>
+        console.error('[Learner] notification failed:', err)
+      );
     }
 
     // Drain the review queue when a task reaches 'done' (frees the verification slot)

--- a/src/lib/agent-catalog-sync.ts
+++ b/src/lib/agent-catalog-sync.ts
@@ -1,0 +1,129 @@
+import { queryAll, queryOne, run, transaction } from '@/lib/db';
+import { getOpenClawClient } from '@/lib/openclaw/client';
+
+interface GatewayAgent {
+  id?: string;
+  name?: string;
+  label?: string;
+  model?: string;
+}
+
+const SYNC_INTERVAL_MS = Number(process.env.AGENT_CATALOG_SYNC_INTERVAL_MS || 60_000);
+let lastSyncAt = 0;
+let syncing: Promise<number> | null = null;
+
+function normalizeRole(name: string): string {
+  const n = name.toLowerCase();
+  if (n.includes('learn')) return 'learner';
+  if (n.includes('test')) return 'tester';
+  if (n.includes('review') || n.includes('verif')) return 'reviewer';
+  if (n.includes('fix')) return 'fixer';
+  if (n.includes('senior')) return 'senior';
+  if (n.includes('plan') || n.includes('orch')) return 'orchestrator';
+  return 'builder';
+}
+
+export async function syncGatewayAgentsToCatalog(options?: { force?: boolean; reason?: string }): Promise<number> {
+  const force = Boolean(options?.force);
+  const now = Date.now();
+  if (!force && now - lastSyncAt < SYNC_INTERVAL_MS) {
+    return 0;
+  }
+
+  if (syncing) return syncing;
+
+  syncing = (async () => {
+    const client = getOpenClawClient();
+    if (!client.isConnected()) {
+      await client.connect();
+    }
+
+    const gatewayAgents = (await client.listAgents()) as GatewayAgent[];
+    const existing = queryAll<{ id: string; gateway_agent_id: string | null }>(
+      `SELECT id, gateway_agent_id FROM agents WHERE gateway_agent_id IS NOT NULL`
+    );
+    const existingByGatewayId = new Map(existing.map((a) => [a.gateway_agent_id, a.id]));
+
+    let changed = 0;
+    const ts = new Date().toISOString();
+
+    transaction(() => {
+      for (const ga of gatewayAgents) {
+        const gatewayId = ga.id || ga.name;
+        if (!gatewayId) continue;
+
+        const name = ga.name || ga.label || gatewayId;
+        const role = normalizeRole(name);
+        const existingId = existingByGatewayId.get(gatewayId) || null;
+
+        if (existingId) {
+          run(
+            `UPDATE agents SET name = ?, role = ?, model = COALESCE(?, model), source = 'gateway', updated_at = ? WHERE id = ?`,
+            [name, role, ga.model || null, ts, existingId]
+          );
+        } else {
+          run(
+            `INSERT INTO agents (id, name, role, description, avatar_emoji, is_master, workspace_id, model, source, gateway_agent_id, created_at, updated_at)
+             VALUES (lower(hex(randomblob(16))), ?, ?, ?, '🔗', 0, 'default', ?, 'gateway', ?, ?, ?)`,
+            [name, role, `Auto-synced from OpenClaw (${gatewayId})`, ga.model || null, gatewayId, ts, ts]
+          );
+        }
+        changed += 1;
+      }
+
+      run(
+        `INSERT INTO events (id, type, message, metadata, created_at)
+         VALUES (lower(hex(randomblob(16))), 'system', ?, ?, ?)`,
+        [
+          `Agent catalog sync completed (${options?.reason || 'automatic'})`,
+          JSON.stringify({ changed, reason: options?.reason || 'automatic' }),
+          ts,
+        ]
+      );
+    });
+
+    lastSyncAt = Date.now();
+    return changed;
+  })();
+
+  try {
+    return await syncing;
+  } finally {
+    syncing = null;
+  }
+}
+
+export function ensureCatalogSyncScheduled(): void {
+  if (process.env.NODE_ENV === 'test') return;
+  const g = globalThis as unknown as { __mcAgentCatalogTimer?: NodeJS.Timeout };
+  if (g.__mcAgentCatalogTimer) return;
+  g.__mcAgentCatalogTimer = setInterval(() => {
+    syncGatewayAgentsToCatalog({ reason: 'scheduled' }).catch((err) => {
+      console.error('[AgentCatalog] scheduled sync failed:', err);
+    });
+  }, SYNC_INTERVAL_MS);
+  syncGatewayAgentsToCatalog({ reason: 'startup' }).catch((err) => {
+    console.error('[AgentCatalog] startup sync failed:', err);
+  });
+}
+
+export function getAgentByPreferredRoles(taskId: string, preferredRoles: string[]): { id: string; name: string } | null {
+  for (const role of preferredRoles) {
+    const byTaskRole = queryOne<{ id: string; name: string }>(
+      `SELECT a.id, a.name
+       FROM task_roles tr
+       JOIN agents a ON a.id = tr.agent_id
+       WHERE tr.task_id = ? AND tr.role = ? AND a.status != 'offline'
+       LIMIT 1`,
+      [taskId, role]
+    );
+    if (byTaskRole) return byTaskRole;
+
+    const byGlobalRole = queryOne<{ id: string; name: string }>(
+      `SELECT id, name FROM agents WHERE role = ? AND status != 'offline' ORDER BY updated_at DESC LIMIT 1`,
+      [role]
+    );
+    if (byGlobalRole) return byGlobalRole;
+  }
+  return null;
+}

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import fs from 'fs';
 import { schema } from './schema';
 import { runMigrations } from './migrations';
+import { ensureCatalogSyncScheduled } from '@/lib/agent-catalog-sync';
 
 const DB_PATH = process.env.DATABASE_PATH || path.join(process.cwd(), 'mission-control.db');
 
@@ -22,6 +23,9 @@ export function getDb(): Database.Database {
     // Run migrations for schema updates
     // This handles both new and existing databases
     runMigrations(db);
+
+    // Keep Mission Control's agent catalog synced with OpenClaw-installed agents
+    ensureCatalogSyncScheduled();
     
     if (isNewDb) {
       console.log('[DB] New database created at:', DB_PATH);

--- a/src/lib/task-governance.test.ts
+++ b/src/lib/task-governance.test.ts
@@ -1,0 +1,85 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { run, queryOne } from './db';
+import {
+  hasStageEvidence,
+  taskCanBeDone,
+  ensureFixerExists,
+  getFailureCountInStage,
+} from './task-governance';
+
+function seedTask(id: string, workspace = 'default') {
+  run(
+    `INSERT INTO tasks (id, title, status, priority, workspace_id, business_id, created_at, updated_at)
+     VALUES (?, 'T', 'review', 'normal', ?, 'default', datetime('now'), datetime('now'))`,
+    [id, workspace]
+  );
+}
+
+test('evidence gate requires deliverable + activity', () => {
+  const taskId = crypto.randomUUID();
+  seedTask(taskId);
+
+  assert.equal(hasStageEvidence(taskId), false);
+
+  run(
+    `INSERT INTO task_deliverables (id, task_id, deliverable_type, title, created_at)
+     VALUES (lower(hex(randomblob(16))), ?, 'file', 'index.html', datetime('now'))`,
+    [taskId]
+  );
+  assert.equal(hasStageEvidence(taskId), false);
+
+  run(
+    `INSERT INTO task_activities (id, task_id, activity_type, message, created_at)
+     VALUES (lower(hex(randomblob(16))), ?, 'completed', 'did thing', datetime('now'))`,
+    [taskId]
+  );
+
+  assert.equal(hasStageEvidence(taskId), true);
+});
+
+test('task cannot be done when status_reason indicates failure', () => {
+  const taskId = crypto.randomUUID();
+  seedTask(taskId);
+
+  run(`UPDATE tasks SET status_reason = 'Validation failed: CSS broken' WHERE id = ?`, [taskId]);
+  run(
+    `INSERT INTO task_deliverables (id, task_id, deliverable_type, title, created_at)
+     VALUES (lower(hex(randomblob(16))), ?, 'file', 'index.html', datetime('now'))`,
+    [taskId]
+  );
+  run(
+    `INSERT INTO task_activities (id, task_id, activity_type, message, created_at)
+     VALUES (lower(hex(randomblob(16))), ?, 'completed', 'did thing', datetime('now'))`,
+    [taskId]
+  );
+
+  assert.equal(taskCanBeDone(taskId), false);
+});
+
+test('ensureFixerExists creates fixer when missing', () => {
+  const fixer = ensureFixerExists('default');
+  assert.equal(fixer.created, true);
+
+  const stored = queryOne<{ id: string; role: string }>('SELECT id, role FROM agents WHERE id = ?', [fixer.id]);
+  assert.ok(stored);
+  assert.equal(stored?.role, 'fixer');
+});
+
+test('failure counter reads status_changed failure events', () => {
+  const taskId = crypto.randomUUID();
+  seedTask(taskId);
+
+  run(
+    `INSERT INTO task_activities (id, task_id, activity_type, message, created_at)
+     VALUES (lower(hex(randomblob(16))), ?, 'status_changed', 'Stage failed: verification → in_progress (reason: x)', datetime('now'))`,
+    [taskId]
+  );
+  run(
+    `INSERT INTO task_activities (id, task_id, activity_type, message, created_at)
+     VALUES (lower(hex(randomblob(16))), ?, 'status_changed', 'Stage failed: verification → in_progress (reason: y)', datetime('now'))`,
+    [taskId]
+  );
+
+  assert.equal(getFailureCountInStage(taskId, 'verification'), 2);
+});

--- a/src/lib/task-governance.ts
+++ b/src/lib/task-governance.ts
@@ -1,0 +1,149 @@
+import { queryAll, queryOne, run, transaction } from '@/lib/db';
+import { notifyLearner } from '@/lib/learner';
+import type { Task } from '@/lib/types';
+
+const ACTIVE_STATUSES = ['assigned', 'in_progress', 'testing', 'review', 'verification'];
+
+export function hasStageEvidence(taskId: string): boolean {
+  const deliverable = queryOne<{ count: number }>('SELECT COUNT(*) as count FROM task_deliverables WHERE task_id = ?', [taskId]);
+  const activity = queryOne<{ count: number }>(
+    `SELECT COUNT(*) as count FROM task_activities WHERE task_id = ? AND activity_type IN ('completed','file_created','updated')`,
+    [taskId]
+  );
+  return Number(deliverable?.count || 0) > 0 && Number(activity?.count || 0) > 0;
+}
+
+export function canUseBoardOverride(request: Request): boolean {
+  if (process.env.BOARD_OVERRIDE_ENABLED !== 'true') return false;
+  return request.headers.get('x-mc-board-override') === 'true';
+}
+
+export function auditBoardOverride(taskId: string, fromStatus: string, toStatus: string, reason?: string): void {
+  const now = new Date().toISOString();
+  run(
+    `INSERT INTO events (id, type, task_id, message, metadata, created_at)
+     VALUES (lower(hex(randomblob(16))), 'system', ?, ?, ?, ?)`,
+    [taskId, `Board override: ${fromStatus} → ${toStatus}`, JSON.stringify({ boardOverride: true, reason: reason || null }), now]
+  );
+}
+
+export function getFailureCountInStage(taskId: string, stage: string): number {
+  const row = queryOne<{ count: number }>(
+    `SELECT COUNT(*) as count
+     FROM task_activities
+     WHERE task_id = ? AND activity_type = 'status_changed' AND message LIKE ?`,
+    [taskId, `%Stage failed: ${stage}%`]
+  );
+  return Number(row?.count || 0);
+}
+
+export function ensureFixerExists(workspaceId: string): { id: string; name: string; created: boolean } {
+  const existing = queryOne<{ id: string; name: string }>(
+    `SELECT id, name FROM agents WHERE workspace_id = ? AND role IN ('fixer','senior') AND status != 'offline' ORDER BY role = 'fixer' DESC, updated_at DESC LIMIT 1`,
+    [workspaceId]
+  );
+  if (existing) return { ...existing, created: false };
+
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+  const name = 'Auto Fixer';
+  run(
+    `INSERT INTO agents (id, name, role, description, avatar_emoji, status, is_master, workspace_id, source, created_at, updated_at)
+     VALUES (?, ?, 'fixer', 'Auto-created fixer for repeated stage failures', '🛠️', 'standby', 0, ?, 'local', ?, ?)`,
+    [id, name, workspaceId, now, now]
+  );
+  return { id, name, created: true };
+}
+
+export async function escalateFailureIfNeeded(taskId: string, stage: string): Promise<void> {
+  const task = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
+  if (!task) return;
+
+  if (getFailureCountInStage(taskId, stage) < 2) return;
+
+  const fixer = ensureFixerExists(task.workspace_id);
+  const now = new Date().toISOString();
+  transaction(() => {
+    run('UPDATE tasks SET assigned_agent_id = ?, status_reason = ?, updated_at = ? WHERE id = ?', [
+      fixer.id,
+      `Escalated after repeated failures in ${stage}`,
+      now,
+      taskId,
+    ]);
+
+    run(
+      `INSERT OR REPLACE INTO task_roles (id, task_id, role, agent_id, created_at)
+       VALUES (COALESCE((SELECT id FROM task_roles WHERE task_id = ? AND role = 'fixer'), lower(hex(randomblob(16)))), ?, 'fixer', ?, ?)`,
+      [taskId, taskId, fixer.id, now]
+    );
+
+    run(
+      `INSERT INTO task_activities (id, task_id, agent_id, activity_type, message, created_at)
+       VALUES (lower(hex(randomblob(16))), ?, ?, 'status_changed', ?, ?)`,
+      [taskId, fixer.id, `Escalated to ${fixer.name} after repeated failures in ${stage}`, now]
+    );
+  });
+
+  if (fixer.created) {
+    await notifyLearner(taskId, {
+      previousStatus: stage,
+      newStatus: stage,
+      passed: true,
+      context: `Auto-created fixer agent (${fixer.name}) due to repeated stage failures.`,
+    });
+  }
+}
+
+export async function recordLearnerOnTransition(taskId: string, previousStatus: string, newStatus: string, passed = true, failReason?: string): Promise<void> {
+  await notifyLearner(taskId, { previousStatus, newStatus, passed, failReason });
+}
+
+export function taskCanBeDone(taskId: string): boolean {
+  const task = queryOne<{ status: string; status_reason?: string }>('SELECT status, status_reason FROM tasks WHERE id = ?', [taskId]);
+  if (!task) return false;
+  const hasValidationFailure = (task.status_reason || '').toLowerCase().includes('fail');
+  return !hasValidationFailure && hasStageEvidence(taskId);
+}
+
+export function isActiveStatus(status: string): boolean {
+  return ACTIVE_STATUSES.includes(status);
+}
+
+export function pickDynamicAgent(taskId: string, stageRole?: string | null): { id: string; name: string } | null {
+  const planningAgentsTask = queryOne<{ planning_agents?: string }>('SELECT planning_agents FROM tasks WHERE id = ?', [taskId]);
+  const plannerCandidates: string[] = [];
+  if (planningAgentsTask?.planning_agents) {
+    try {
+      const parsed = JSON.parse(planningAgentsTask.planning_agents) as Array<{ agent_id?: string; role?: string }>;
+      for (const a of parsed) {
+        if (a.role && stageRole && a.role.toLowerCase().includes(stageRole.toLowerCase()) && a.agent_id) plannerCandidates.push(a.agent_id);
+      }
+    } catch {}
+  }
+
+  const checked = new Set<string>();
+  for (const candidateId of plannerCandidates) {
+    const candidate = queryOne<{ id: string; name: string; is_master: number; status: string }>(
+      'SELECT id, name, is_master, status FROM agents WHERE id = ? LIMIT 1',
+      [candidateId]
+    );
+    if (!candidate || candidate.status === 'offline') continue;
+    checked.add(candidate.id);
+    return { id: candidate.id, name: candidate.name };
+  }
+
+  if (stageRole) {
+    const byRole = queryOne<{ id: string; name: string }>(
+      `SELECT id, name FROM agents WHERE role = ? AND status != 'offline' ORDER BY status = 'standby' DESC, updated_at DESC LIMIT 1`,
+      [stageRole]
+    );
+    if (byRole) return byRole;
+  }
+
+  const fallback = queryOne<{ id: string; name: string }>(
+    `SELECT id, name FROM agents WHERE status != 'offline' ORDER BY is_master ASC, updated_at DESC LIMIT 1`
+  );
+  if (fallback && !checked.has(fallback.id)) return fallback;
+
+  return null;
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -47,6 +47,9 @@ export const UpdateTaskSchema = z.object({
   workflow_template_id: z.string().optional().nullable(),
   due_date: z.string().optional().nullable(),
   updated_by_agent_id: z.string().uuid().optional(),
+  status_reason: z.string().max(2000).optional(),
+  board_override: z.boolean().optional(),
+  override_reason: z.string().max(2000).optional(),
 });
 
 // Activity validation schema

--- a/src/lib/workflow-engine.ts
+++ b/src/lib/workflow-engine.ts
@@ -6,6 +6,7 @@
  */
 
 import { queryOne, queryAll, run } from '@/lib/db';
+import { pickDynamicAgent, escalateFailureIfNeeded, recordLearnerOnTransition } from '@/lib/task-governance';
 import { getMissionControlUrl } from '@/lib/config';
 import { broadcast } from '@/lib/events';
 import type { Task, WorkflowTemplate, WorkflowStage, TaskRole } from '@/lib/types';
@@ -153,8 +154,12 @@ export async function handleStageTransition(
     }
   }
   if (!roleAgent) {
-    // No agent for this role — record error but don't block status change
-    const errorMsg = `No agent assigned for role: ${targetStage.role}. Assign an agent to this task.`;
+    // Dynamic routing fallback (planner+rules) when explicit role assignment is missing
+    roleAgent = pickDynamicAgent(taskId, targetStage.role);
+  }
+
+  if (!roleAgent) {
+    const errorMsg = `No eligible agent found for stage role: ${targetStage.role}.`;
     run(
       'UPDATE tasks SET planning_dispatch_error = ?, updated_at = datetime(\'now\') WHERE id = ?',
       [errorMsg, taskId]
@@ -179,6 +184,10 @@ export async function handleStageTransition(
       `Stage handoff: ${targetStage.label} → ${roleAgent.name}${options?.failReason ? ` (reason: ${options.failReason})` : ''}`,
       now
     ]
+  );
+
+  recordLearnerOnTransition(taskId, options?.previousStatus || newStatus, newStatus, true).catch(err =>
+    console.error('[Learner] transition record failed:', err)
   );
 
   if (options?.skipDispatch) {
@@ -255,6 +264,9 @@ export async function handleStageFailure(
   if (updatedTask) {
     broadcast({ type: 'task_updated', payload: updatedTask });
   }
+
+  await recordLearnerOnTransition(taskId, currentStatus, targetStatus, false, failReason);
+  await escalateFailureIfNeeded(taskId, currentStatus);
 
   // Trigger handoff to the agent that owns the fail target stage
   return handleStageTransition(taskId, targetStatus, {


### PR DESCRIPTION
## Summary
- add canonical OpenClaw agent catalog sync into Mission Control (startup/scheduled + dispatch/opportunistic triggers)
- introduce dynamic per-task hybrid routing (planner candidates + role/fallback safeguards)
- enforce learner recording on every stage transition
- add hard stage evidence gates (deliverable + activity required)
- require failure reason on fail-back transitions
- implement repeated-failure escalation (>=2 in same stage) with guaranteed fixer provisioning
- block inconsistent done-state when task has validation failure reason
- add board-only override path (disabled by default) with audit logging
- add governance unit tests

## Verification
- npm test ✅
- npm run lint ✅ (existing TaskImages warning only)
- npm run build ✅

## Smoke proof
- Task: 316e67d4-cf52-4891-87a5-a38ff7c03ae5
- Verified transitions with evidence present: inbox -> assigned -> testing -> review -> done
- Final state: done + reviewer assigned + no status_reason failure
