### PR TITLE
fix(openclaw): remove dynamic device identity path in fs operations

### DIFF
--- a/src/lib/openclaw/device-identity.ts
+++ b/src/lib/openclaw/device-identity.ts
@@ -55,10 +55,11 @@ function generateIdentity(): DeviceIdentity {
 }
 
 // Load existing identity or create a new one
-export function loadOrCreateDeviceIdentity(filePath: string = IDENTITY_FILE): DeviceIdentity {
+export function loadOrCreateDeviceIdentity(): DeviceIdentity {
+  const identityPath = IDENTITY_FILE;
   try {
-    if (fs.existsSync(filePath)) {
-      const raw = fs.readFileSync(filePath, 'utf8');
+    if (fs.existsSync(identityPath)) {
+      const raw = fs.readFileSync(identityPath, 'utf8');
       const parsed = JSON.parse(raw);
       if (parsed?.version === 1 && parsed.deviceId && parsed.publicKeyPem && parsed.privateKeyPem) {
         // Verify deviceId matches public key
@@ -75,7 +76,7 @@ export function loadOrCreateDeviceIdentity(filePath: string = IDENTITY_FILE): De
   }
 
   const identity = generateIdentity();
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.mkdirSync(path.dirname(identityPath), { recursive: true });
   const stored = {
     version: 1,
     deviceId: identity.deviceId,
@@ -83,7 +84,7 @@ export function loadOrCreateDeviceIdentity(filePath: string = IDENTITY_FILE): De
     privateKeyPem: identity.privateKeyPem,
     createdAtMs: Date.now(),
   };
-  fs.writeFileSync(filePath, JSON.stringify(stored, null, 2) + '\n', { mode: 0o600 });
+  fs.writeFileSync(identityPath, JSON.stringify(stored, null, 2) + '\n', { mode: 0o600 });
   return identity;
 }
 


### PR DESCRIPTION
## Summary
This PR fixes TP1004 filesystem lint warnings in OpenClaw device identity loading by removing a dynamic path parameter from file access operations.

## Problem
`loadOrCreateDeviceIdentity` accepted a `filePath` parameter and passed it into:
- `fs.existsSync(filePath)`
- `fs.readFileSync(filePath, 'utf8')`

Static analysis flagged this as overly dynamic filesystem access (`TP1004`).

## Changes
- Updated `loadOrCreateDeviceIdentity` to no longer accept a path parameter.
- Bound file operations to the module constant `IDENTITY_FILE` via a local `identityPath` variable.
- Updated all internal calls in the function to use `identityPath` for read/write/mkdir operations.

## Why this is safe
- There is only one call site in the codebase (`src/lib/openclaw/client.ts`) and it already called `loadOrCreateDeviceIdentity()` with no arguments.
- Runtime behavior remains the same: identity is loaded from and written to the same file (`~/.mission-control/identity/device.json`).

## Validation
- Ran `npm run -s lint`.
- Result: no new lint errors from this change; only an unrelated existing warning in `src/components/TaskImages.tsx` about `<img>` usage.

## Scope
- 1 file changed:
  - `src/lib/openclaw/device-identity.ts`
- No API behavior changes outside this module.
