### PR TITLE
Add session key prefix support in agent management and UI

### DIFF
--- a/src/app/api/agents/[id]/route.ts
+++ b/src/app/api/agents/[id]/route.ts
@@ -89,6 +89,10 @@ export async function PATCH(
       updates.push('model = ?');
       values.push(body.model);
     }
+    if (body.session_key_prefix !== undefined) {
+      updates.push('session_key_prefix = ?');
+      values.push(body.session_key_prefix);
+    }
 
     if (updates.length === 0) {
       return NextResponse.json({ error: 'No updates provided' }, { status: 400 });

--- a/src/app/api/tasks/[id]/planning/poll/route.ts
+++ b/src/app/api/tasks/[id]/planning/poll/route.ts
@@ -32,9 +32,17 @@ async function handlePlanningCompletion(taskId: string, parsed: any, messages: a
     const allowDynamicAgents = process.env.ALLOW_DYNAMIC_AGENTS !== 'false';
 
     if (allowDynamicAgents && parsed.agents && parsed.agents.length > 0) {
+      // Get the master agent's session_key_prefix to use for new agents
+      const task = db.prepare('SELECT workspace_id FROM tasks WHERE id = ?').get(taskId) as { workspace_id: string } | undefined;
+      const masterAgent = task ? db.prepare(
+        `SELECT session_key_prefix FROM agents WHERE is_master = 1 AND workspace_id = ? ORDER BY created_at ASC LIMIT 1`
+      ).get(task.workspace_id) as { session_key_prefix?: string } | undefined : undefined;
+      
+      const sessionKeyPrefix = masterAgent?.session_key_prefix || 'agent:main:';
+
       const insertAgent = db.prepare(`
-        INSERT INTO agents (id, workspace_id, name, role, description, avatar_emoji, status, soul_md, created_at, updated_at)
-        VALUES (?, (SELECT workspace_id FROM tasks WHERE id = ?), ?, ?, ?, ?, 'standby', ?, datetime('now'), datetime('now'))
+        INSERT INTO agents (id, workspace_id, name, role, description, avatar_emoji, status, soul_md, session_key_prefix, created_at, updated_at)
+        VALUES (?, (SELECT workspace_id FROM tasks WHERE id = ?), ?, ?, ?, ?, 'standby', ?, ?, datetime('now'), datetime('now'))
       `);
 
       for (const agent of parsed.agents) {
@@ -48,7 +56,8 @@ async function handlePlanningCompletion(taskId: string, parsed: any, messages: a
           agent.role,
           agent.instructions || '',
           agent.avatar_emoji || '🤖',
-          agent.soul_md || ''
+          agent.soul_md || '',
+          sessionKeyPrefix
         );
       }
     } else if (!allowDynamicAgents && parsed.agents && parsed.agents.length > 0) {

--- a/src/app/api/tasks/[id]/planning/route.ts
+++ b/src/app/api/tasks/[id]/planning/route.ts
@@ -75,6 +75,9 @@ export async function POST(
   const { id: taskId } = await params;
 
   try {
+    const body = await request.json().catch(() => ({}));
+    const customSessionKeyPrefix = body.session_key_prefix;
+
     // Get task
     const task = getDb().prepare('SELECT * FROM tasks WHERE id = ?').get(taskId) as {
       id: string;
@@ -102,6 +105,14 @@ export async function POST(
       [task.workspace_id]
     );
 
+    // Get assigned agent if any (for session_key_prefix)
+    const taskWithAgent = getDb().prepare(`
+      SELECT a.session_key_prefix 
+      FROM tasks t 
+      LEFT JOIN agents a ON t.assigned_agent_id = a.id 
+      WHERE t.id = ?
+    `).get(taskId) as { session_key_prefix?: string } | undefined;
+
     const otherOrchestrators = queryAll<{
       id: string;
       name: string;
@@ -125,8 +136,9 @@ export async function POST(
     }
 
     // Create session key for this planning task
-    // Use the master agent's session_key_prefix if set, otherwise default to 'agent:main:'
-    const planningPrefix = (defaultMaster?.session_key_prefix || DEFAULT_SESSION_KEY_PREFIX) + 'planning:';
+    // Priority: custom prefix > assigned agent's prefix > master agent's prefix > default prefix
+    const basePrefix = customSessionKeyPrefix || taskWithAgent?.session_key_prefix || defaultMaster?.session_key_prefix || DEFAULT_SESSION_KEY_PREFIX;
+    const planningPrefix = basePrefix + 'planning:';
     const sessionKey = `${planningPrefix}${taskId}`;
 
     // Build the initial planning prompt

--- a/src/components/AgentModal.tsx
+++ b/src/components/AgentModal.tsx
@@ -33,6 +33,7 @@ export function AgentModal({ agent, onClose, workspaceId, onAgentCreated }: Agen
     user_md: agent?.user_md || '',
     agents_md: agent?.agents_md || '',
     model: agent?.model || '',
+    session_key_prefix: agent?.session_key_prefix || '',
   });
 
   // Fetch fresh agent data when modal opens (store data may be stale)
@@ -289,6 +290,21 @@ export function AgentModal({ agent, onClose, workspaceId, onAgentCreated }: Agen
                 )}
                 <p className="text-xs text-mc-text-secondary mt-1">
                   AI model used by this agent. Leave empty to use OpenClaw default.
+                </p>
+              </div>
+
+              {/* Session Key Prefix */}
+              <div>
+                <label className="block text-sm font-medium mb-1">Session Key Prefix</label>
+                <input
+                  type="text"
+                  value={form.session_key_prefix}
+                  onChange={(e) => setForm({ ...form, session_key_prefix: e.target.value })}
+                  className="w-full min-h-11 bg-mc-bg border border-mc-border rounded px-3 py-2 text-sm focus:outline-none focus:border-mc-accent"
+                  placeholder="agent:main:"
+                />
+                <p className="text-xs text-mc-text-secondary mt-1">
+                  OpenClaw session routing prefix. Defaults to "agent:main:" if not set.
                 </p>
               </div>
             </div>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -323,6 +323,7 @@ export interface CreateAgentRequest {
   user_md?: string;
   agents_md?: string;
   model?: string;
+  session_key_prefix?: string;
 }
 
 export interface UpdateAgentRequest extends Partial<CreateAgentRequest> {


### PR DESCRIPTION
This pull request introduces support for configuring a custom `session_key_prefix` for agents, allowing more flexible session routing and organization. The changes ensure that this prefix can be set, updated, and propagated throughout agent creation, planning, and UI workflows. The most important changes are grouped below:

**Backend logic and database integration:**

* The `PATCH` endpoint for agents (`src/app/api/agents/[id]/route.ts`) now allows updating the `session_key_prefix` field for an agent. ([src/app/api/agents/[id]/route.tsR92-R95](diffhunk://#diff-653308b6b8223240d09e4b02e6b8e90fbee17950a1cfd94290c140f0092f6e9bR92-R95))
* When dynamically creating new agents during task planning, the system now inherits the `session_key_prefix` from the master agent of the workspace, defaulting to `'agent:main:'` if not set. The prefix is included in agent creation. ([src/app/api/tasks/[id]/planning/poll/route.tsR35-R45](diffhunk://#diff-8aef0f9baefe947f5e70302da10a1e80f8a145a0d411690e43743f71d8cb2effR35-R45), [src/app/api/tasks/[id]/planning/poll/route.tsL51-R60](diffhunk://#diff-8aef0f9baefe947f5e70302da10a1e80f8a145a0d411690e43743f71d8cb2effL51-R60))
* In the planning endpoint (`src/app/api/tasks/[id]/planning/route.ts`), the session key prefix used for planning is determined by the following priority: custom prefix from request > assigned agent's prefix > master agent's prefix > default. ([src/app/api/tasks/[id]/planning/route.tsR78-R80](diffhunk://#diff-7dcf0c01c4a0f51f319648ac7f08ce660ad2c787b8fbebb532ab0a9e6ddfb194R78-R80), [src/app/api/tasks/[id]/planning/route.tsR108-R115](diffhunk://#diff-7dcf0c01c4a0f51f319648ac7f08ce660ad2c787b8fbebb532ab0a9e6ddfb194R108-R115), [src/app/api/tasks/[id]/planning/route.tsL128-R141](diffhunk://#diff-7dcf0c01c4a0f51f319648ac7f08ce660ad2c787b8fbebb532ab0a9e6ddfb194L128-R141))

**UI and type definitions:**

* The `AgentModal` component now includes a field for editing the `session_key_prefix`, allowing users to set or update this value from the UI. [[1]](diffhunk://#diff-ef9f184b648fd577631e4cee629913eedc34ecbf136c05fa15e8ec7a4418f4f2R36) [[2]](diffhunk://#diff-ef9f184b648fd577631e4cee629913eedc34ecbf136c05fa15e8ec7a4418f4f2R295-R309)
* The `CreateAgentRequest` and `UpdateAgentRequest` types now include the optional `session_key_prefix` property, ensuring type safety throughout the codebase.