### PR TITLE
🤖 Autopilot: Automated Rollback Pipeline for Failed Deployments

### DIFF
--- a/src/app/api/admin/rollbacks/route.ts
+++ b/src/app/api/admin/rollbacks/route.ts
@@ -1,0 +1,33 @@
+/**
+ * GET  /api/admin/rollbacks — List rollback history (optionally filtered by product)
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { listRollbackHistory, getUnacknowledgedRollbacks, getActiveMonitors } from '@/lib/rollback';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const productId = searchParams.get('product_id') || undefined;
+    const unacknowledgedOnly = searchParams.get('unacknowledged') === 'true';
+    const limit = parseInt(searchParams.get('limit') || '50', 10);
+
+    const history = unacknowledgedOnly
+      ? getUnacknowledgedRollbacks(productId)
+      : listRollbackHistory(productId, limit);
+
+    return NextResponse.json({
+      rollbacks: history,
+      total: history.length,
+      activeMonitors: getActiveMonitors(),
+    });
+  } catch (err) {
+    console.error('[API] Failed to list rollbacks:', err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Failed to list rollbacks' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/products/[id]/rollback/route.ts
+++ b/src/app/api/products/[id]/rollback/route.ts
@@ -1,0 +1,153 @@
+/**
+ * POST /api/products/[id]/rollback — Manual rollback trigger
+ * Body: { pr_url: string, commit_sha: string, reason?: string, task_id?: string }
+ *
+ * PATCH /api/products/[id]/rollback — Acknowledge rollback & restore automation tier
+ * Body: { rollback_id: string, restore_tier?: 'semi_auto' | 'full_auto' }
+ *
+ * GET /api/products/[id]/rollback — List rollback history for this product
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { queryOne } from '@/lib/db';
+import {
+  executeRollback,
+  acknowledgeRollback,
+  listRollbackHistory,
+  getUnacknowledgedRollbacks,
+  updateProductSettings,
+  getProductSettings,
+  stopMonitor,
+} from '@/lib/rollback';
+import type { Product } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+// ---------------------------------------------------------------------------
+// GET — List rollback history for product
+// ---------------------------------------------------------------------------
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const product = queryOne<Product>('SELECT * FROM products WHERE id = ?', [params.id]);
+    if (!product) {
+      return NextResponse.json({ error: 'Product not found' }, { status: 404 });
+    }
+
+    const history = listRollbackHistory(params.id);
+    const unacknowledged = getUnacknowledgedRollbacks(params.id);
+
+    return NextResponse.json({
+      rollbacks: history,
+      total: history.length,
+      unacknowledged: unacknowledged.length,
+      currentTier: getProductSettings(product).automation_tier || null,
+    });
+  } catch (err) {
+    console.error('[API] Failed to list product rollbacks:', err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Failed to list rollbacks' },
+      { status: 500 }
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// POST — Manual rollback trigger
+// ---------------------------------------------------------------------------
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const product = queryOne<Product>('SELECT * FROM products WHERE id = ?', [params.id]);
+    if (!product) {
+      return NextResponse.json({ error: 'Product not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const { pr_url, commit_sha, reason, task_id } = body;
+
+    if (!pr_url || !commit_sha) {
+      return NextResponse.json(
+        { error: 'Missing required fields: pr_url, commit_sha' },
+        { status: 400 }
+      );
+    }
+
+    // Stop any active monitor for this product
+    stopMonitor(params.id);
+
+    const result = await executeRollback({
+      productId: params.id,
+      taskId: task_id,
+      triggerType: 'manual',
+      triggerDetails: reason || 'Manual rollback triggered via API',
+      mergedPrUrl: pr_url,
+      mergedCommitSha: commit_sha,
+    });
+
+    return NextResponse.json({
+      success: true,
+      rollbackId: result.rollbackId,
+      revertPrUrl: result.revertPrUrl,
+      revertSuccess: result.success,
+    }, { status: 201 });
+  } catch (err) {
+    console.error('[API] Failed to trigger rollback:', err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Failed to trigger rollback' },
+      { status: 500 }
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// PATCH — Acknowledge rollback & optionally restore automation tier
+// ---------------------------------------------------------------------------
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const product = queryOne<Product>('SELECT * FROM products WHERE id = ?', [params.id]);
+    if (!product) {
+      return NextResponse.json({ error: 'Product not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const { rollback_id, restore_tier } = body;
+
+    if (!rollback_id) {
+      return NextResponse.json(
+        { error: 'Missing required field: rollback_id' },
+        { status: 400 }
+      );
+    }
+
+    // Acknowledge the rollback
+    acknowledgeRollback(rollback_id, 'user');
+
+    // Optionally restore automation tier
+    if (restore_tier && ['supervised', 'semi_auto', 'full_auto'].includes(restore_tier)) {
+      updateProductSettings(params.id, { automation_tier: restore_tier });
+    }
+
+    return NextResponse.json({
+      success: true,
+      acknowledged: rollback_id,
+      restoredTier: restore_tier || null,
+    });
+  } catch (err) {
+    console.error('[API] Failed to acknowledge rollback:', err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Failed to acknowledge rollback' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/webhooks/github/route.ts
+++ b/src/app/api/webhooks/github/route.ts
@@ -1,0 +1,237 @@
+/**
+ * GitHub Webhook Handler
+ *
+ * Listens for:
+ * - pull_request events (merged PRs) → starts health monitoring
+ * - check_suite / check_run events (CI failures) → triggers rollback
+ * - status events (commit status failures) → triggers rollback
+ *
+ * Webhook secret validation via GITHUB_WEBHOOK_SECRET env var.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createHmac, timingSafeEqual } from 'crypto';
+import { queryOne, queryAll } from '@/lib/db';
+import {
+  executeRollback,
+  startPostMergeMonitor,
+  getProductSettings,
+} from '@/lib/rollback';
+import type { Product, Task } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+// ---------------------------------------------------------------------------
+// Signature verification
+// ---------------------------------------------------------------------------
+
+function verifyGitHubSignature(signature: string | null, rawBody: string): boolean {
+  const secret = process.env.GITHUB_WEBHOOK_SECRET;
+
+  if (!secret) {
+    // Dev mode — skip validation but log warning
+    console.warn('[GitHub Webhook] No GITHUB_WEBHOOK_SECRET set — skipping signature validation');
+    return true;
+  }
+
+  if (!signature) return false;
+
+  const expected = 'sha256=' + createHmac('sha256', secret).update(rawBody).digest('hex');
+  if (signature.length !== expected.length) return false;
+  return timingSafeEqual(Buffer.from(signature), Buffer.from(expected));
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function findProductByRepo(repoFullName: string): Product | undefined {
+  // repoFullName is "owner/repo"
+  const ghUrl = `https://github.com/${repoFullName}`;
+  // Match product by repo_url (may have trailing .git or /)
+  const products = queryAll<Product>('SELECT * FROM products WHERE status = ?', ['active']);
+  return products.find(p => {
+    if (!p.repo_url) return false;
+    const normalized = p.repo_url.replace(/\.git$/, '').replace(/\/$/, '');
+    return normalized === ghUrl || normalized === `${ghUrl}.git`;
+  });
+}
+
+function findTaskByPrUrl(prUrl: string): Task | undefined {
+  return queryOne<Task>('SELECT * FROM tasks WHERE pr_url = ?', [prUrl]);
+}
+
+// ---------------------------------------------------------------------------
+// Event handlers
+// ---------------------------------------------------------------------------
+
+async function handlePullRequestMerged(payload: {
+  pull_request: {
+    html_url: string;
+    merge_commit_sha: string;
+    merged: boolean;
+  };
+  repository: { full_name: string };
+}) {
+  const pr = payload.pull_request;
+  if (!pr.merged) return;
+
+  const product = findProductByRepo(payload.repository.full_name);
+  if (!product) {
+    console.log(`[GitHub Webhook] No product found for repo ${payload.repository.full_name} — skipping`);
+    return;
+  }
+
+  const settings = getProductSettings(product);
+  if (!settings.health_check_url) {
+    console.log(`[GitHub Webhook] Product ${product.name} has no health_check_url — skipping monitor`);
+    return;
+  }
+
+  // Only monitor if automation tier is semi_auto or full_auto
+  if (!settings.automation_tier || settings.automation_tier === 'supervised') {
+    console.log(`[GitHub Webhook] Product ${product.name} is supervised — skipping auto-monitor`);
+    return;
+  }
+
+  const task = findTaskByPrUrl(pr.html_url);
+
+  startPostMergeMonitor({
+    productId: product.id,
+    taskId: task?.id,
+    healthCheckUrl: settings.health_check_url,
+    mergedPrUrl: pr.html_url,
+    mergedCommitSha: pr.merge_commit_sha,
+    monitorMinutes: settings.post_merge_monitor_minutes || 5,
+  });
+
+  console.log(`[GitHub Webhook] Started post-merge monitor for ${product.name} (PR: ${pr.html_url})`);
+}
+
+async function handleCIFailure(payload: {
+  conclusion?: string;
+  status?: string;
+  state?: string;
+  head_sha?: string;
+  sha?: string;
+  commit?: { sha: string };
+  repository: { full_name: string };
+  check_suite?: { head_sha: string; conclusion: string };
+  check_run?: { head_sha: string; conclusion: string; check_suite: { head_sha: string } };
+}) {
+  const commitSha = payload.head_sha
+    || payload.sha
+    || payload.commit?.sha
+    || payload.check_suite?.head_sha
+    || payload.check_run?.head_sha
+    || payload.check_run?.check_suite?.head_sha;
+
+  const conclusion = payload.conclusion
+    || payload.state
+    || payload.check_suite?.conclusion
+    || payload.check_run?.conclusion;
+
+  if (!commitSha || !conclusion) return;
+
+  // Only act on failure conclusions
+  const failureStates = ['failure', 'error', 'timed_out', 'action_required'];
+  if (!failureStates.includes(conclusion)) return;
+
+  const product = findProductByRepo(payload.repository.full_name);
+  if (!product) return;
+
+  const settings = getProductSettings(product);
+
+  // Only auto-rollback for semi_auto / full_auto tiers
+  if (!settings.automation_tier || settings.automation_tier === 'supervised') return;
+
+  // Find the task/PR associated with this commit
+  // Look for tasks with a merge commit matching this SHA
+  const task = queryOne<Task>(
+    `SELECT * FROM tasks WHERE product_id = ? AND pr_status = 'merged' ORDER BY updated_at DESC LIMIT 1`,
+    [product.id]
+  );
+
+  if (!task?.pr_url) {
+    console.log(`[GitHub Webhook] CI failure for ${product.name} but no recent merged PR found — skipping`);
+    return;
+  }
+
+  console.log(`[GitHub Webhook] CI failure detected for ${product.name}: ${conclusion}`);
+
+  await executeRollback({
+    productId: product.id,
+    taskId: task.id,
+    triggerType: 'ci_failure',
+    triggerDetails: `Post-merge CI ${conclusion} for commit ${commitSha.slice(0, 7)}`,
+    mergedPrUrl: task.pr_url,
+    mergedCommitSha: commitSha,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Route handler
+// ---------------------------------------------------------------------------
+
+export async function POST(request: NextRequest) {
+  const rawBody = await request.text();
+  const signature = request.headers.get('x-hub-signature-256');
+
+  if (!verifyGitHubSignature(signature, rawBody)) {
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
+  }
+
+  const event = request.headers.get('x-github-event');
+  if (!event) {
+    return NextResponse.json({ error: 'Missing x-github-event header' }, { status: 400 });
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(rawBody);
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  try {
+    switch (event) {
+      case 'pull_request':
+        if (payload.action === 'closed' && payload.pull_request?.merged) {
+          await handlePullRequestMerged(payload);
+        }
+        break;
+
+      case 'check_suite':
+        if (payload.action === 'completed') {
+          await handleCIFailure(payload);
+        }
+        break;
+
+      case 'check_run':
+        if (payload.action === 'completed') {
+          await handleCIFailure(payload);
+        }
+        break;
+
+      case 'status':
+        // Commit status events (legacy CI systems)
+        await handleCIFailure(payload);
+        break;
+
+      case 'ping':
+        console.log('[GitHub Webhook] Ping received');
+        break;
+
+      default:
+        console.log(`[GitHub Webhook] Ignoring event: ${event}`);
+    }
+
+    return NextResponse.json({ received: true, event });
+  } catch (err) {
+    console.error('[GitHub Webhook] Error processing event:', err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Internal error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -1471,6 +1471,37 @@ const migrations: Migration[] = [
         console.log('[Migration 025] Added batch_review_threshold to products');
       }
     }
+  },
+  {
+    id: '026',
+    name: 'add_rollback_history',
+    up: (db) => {
+      console.log('[Migration 026] Adding rollback history table...');
+
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS rollback_history (
+          id TEXT PRIMARY KEY,
+          product_id TEXT NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+          task_id TEXT REFERENCES tasks(id),
+          trigger_type TEXT NOT NULL CHECK (trigger_type IN ('health_check', 'ci_failure', 'manual')),
+          trigger_details TEXT NOT NULL,
+          merged_pr_url TEXT NOT NULL,
+          merged_commit_sha TEXT NOT NULL,
+          revert_pr_url TEXT,
+          revert_pr_status TEXT NOT NULL DEFAULT 'pending' CHECK (revert_pr_status IN ('pending', 'created', 'merged', 'failed')),
+          previous_automation_tier TEXT,
+          acknowledged INTEGER NOT NULL DEFAULT 0,
+          acknowledged_at TEXT,
+          acknowledged_by TEXT,
+          created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+      `);
+
+      db.exec('CREATE INDEX IF NOT EXISTS idx_rollback_history_product ON rollback_history(product_id)');
+      db.exec('CREATE INDEX IF NOT EXISTS idx_rollback_history_unack ON rollback_history(acknowledged, product_id)');
+
+      console.log('[Migration 026] Rollback history table created');
+    }
   }
 ];
 

--- a/src/lib/rollback.ts
+++ b/src/lib/rollback.ts
@@ -1,0 +1,630 @@
+/**
+ * Automated Rollback Pipeline
+ *
+ * Monitors post-merge health and CI status. When a merged PR causes failures
+ * (health check or CI), automatically creates a revert PR, merges it,
+ * notifies via SSE, and pauses the product's automation tier until acknowledged.
+ *
+ * Product settings JSON fields used:
+ *   - health_check_url: string          — URL to poll after merge
+ *   - post_merge_monitor_minutes: number — how long to poll (default 5)
+ *   - automation_tier: 'supervised' | 'semi_auto' | 'full_auto'
+ */
+
+import { queryOne, queryAll, run } from '@/lib/db';
+import { broadcast } from '@/lib/events';
+import type { Product, Task } from '@/lib/types';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface RollbackEvent {
+  id: string;
+  product_id: string;
+  task_id: string | null;
+  trigger_type: 'health_check' | 'ci_failure' | 'manual';
+  trigger_details: string;
+  merged_pr_url: string;
+  merged_commit_sha: string;
+  revert_pr_url: string | null;
+  revert_pr_status: 'pending' | 'created' | 'merged' | 'failed';
+  previous_automation_tier: string | null;
+  acknowledged: number;
+  acknowledged_at: string | null;
+  acknowledged_by: string | null;
+  created_at: string;
+}
+
+export interface ProductSettings {
+  health_check_url?: string;
+  post_merge_monitor_minutes?: number;
+  automation_tier?: 'supervised' | 'semi_auto' | 'full_auto';
+  [key: string]: unknown;
+}
+
+export interface HealthCheckResult {
+  healthy: boolean;
+  statusCode?: number;
+  error?: string;
+  responseTime?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Product settings helpers
+// ---------------------------------------------------------------------------
+
+export function getProductSettings(product: Product): ProductSettings {
+  if (!product.settings) return {};
+  try {
+    return JSON.parse(product.settings) as ProductSettings;
+  } catch {
+    return {};
+  }
+}
+
+export function updateProductSettings(productId: string, updates: Partial<ProductSettings>): void {
+  const product = queryOne<Product>('SELECT * FROM products WHERE id = ?', [productId]);
+  if (!product) throw new Error(`Product not found: ${productId}`);
+
+  const current = getProductSettings(product);
+  const merged = { ...current, ...updates };
+  const now = new Date().toISOString();
+
+  run(
+    'UPDATE products SET settings = ?, updated_at = ? WHERE id = ?',
+    [JSON.stringify(merged), now, productId]
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Health Check
+// ---------------------------------------------------------------------------
+
+export async function checkHealth(url: string): Promise<HealthCheckResult> {
+  const start = Date.now();
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10_000);
+
+    const res = await fetch(url, {
+      method: 'GET',
+      signal: controller.signal,
+      headers: { 'User-Agent': 'MissionControl-RollbackMonitor/1.0' },
+    });
+
+    clearTimeout(timeout);
+    const responseTime = Date.now() - start;
+
+    // Check for error status codes
+    if (res.status >= 500) {
+      return { healthy: false, statusCode: res.status, responseTime, error: `HTTP ${res.status}` };
+    }
+
+    // Check response body for error indicators
+    const contentType = res.headers.get('content-type') || '';
+    if (contentType.includes('application/json')) {
+      try {
+        const body = await res.json();
+        if (body.error || body.status === 'error' || body.healthy === false) {
+          return {
+            healthy: false,
+            statusCode: res.status,
+            responseTime,
+            error: body.error || body.message || 'Response indicates error state',
+          };
+        }
+      } catch {
+        // JSON parse failure is not itself an error indicator
+      }
+    }
+
+    return { healthy: res.status < 400, statusCode: res.status, responseTime };
+  } catch (err) {
+    return {
+      healthy: false,
+      error: err instanceof Error ? err.message : 'Health check failed',
+      responseTime: Date.now() - start,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GitHub API helpers
+// ---------------------------------------------------------------------------
+
+function getGitHubToken(): string | null {
+  return process.env.GITHUB_TOKEN || process.env.GH_TOKEN || null;
+}
+
+function parseGitHubPrUrl(prUrl: string): { owner: string; repo: string; number: number } | null {
+  const match = prUrl.match(/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
+  if (!match) return null;
+  return { owner: match[1], repo: match[2], number: parseInt(match[3], 10) };
+}
+
+export async function createRevertPR(
+  mergedPrUrl: string,
+  mergedCommitSha: string,
+  reason: string,
+  defaultBranch: string = 'main'
+): Promise<{ url: string; number: number } | null> {
+  const token = getGitHubToken();
+  if (!token) {
+    console.error('[Rollback] No GitHub token available for revert PR creation');
+    return null;
+  }
+
+  const parsed = parseGitHubPrUrl(mergedPrUrl);
+  if (!parsed) {
+    console.error('[Rollback] Cannot parse PR URL:', mergedPrUrl);
+    return null;
+  }
+
+  const { owner, repo, number: prNumber } = parsed;
+  const apiBase = `https://api.github.com/repos/${owner}/${repo}`;
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent': 'MissionControl-Rollback/1.0',
+  };
+
+  try {
+    // 1. Create a revert branch from the default branch
+    const revertBranch = `revert/auto-rollback-${prNumber}-${Date.now()}`;
+
+    // Get the ref for default branch
+    const refRes = await fetch(`${apiBase}/git/ref/heads/${defaultBranch}`, { headers });
+    if (!refRes.ok) {
+      console.error('[Rollback] Failed to get default branch ref:', await refRes.text());
+      return null;
+    }
+    const refData = await refRes.json();
+    const baseSha = refData.object.sha;
+
+    // Create the revert branch
+    const createRefRes = await fetch(`${apiBase}/git/refs`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ref: `refs/heads/${revertBranch}`,
+        sha: baseSha,
+      }),
+    });
+    if (!createRefRes.ok) {
+      console.error('[Rollback] Failed to create revert branch:', await createRefRes.text());
+      return null;
+    }
+
+    // 2. Revert the commit on the revert branch using the merge API
+    //    We use the GitHub merge API to apply a revert
+    const revertRes = await fetch(`${apiBase}/merges`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        base: revertBranch,
+        head: `${mergedCommitSha}~1`,  // Parent of the merged commit
+        commit_message: `Revert: auto-rollback of PR #${prNumber}\n\nReason: ${reason}\n\nThis reverts commit ${mergedCommitSha}`,
+      }),
+    });
+
+    // If merge approach doesn't work (common with revert), use the revert endpoint directly
+    if (!revertRes.ok) {
+      // Try git revert via creating a commit that undoes the changes
+      // Use the more reliable approach: create PR from the merge commit's parent
+      const parentRes = await fetch(`${apiBase}/commits/${mergedCommitSha}`, { headers });
+      if (!parentRes.ok) {
+        console.error('[Rollback] Failed to get commit info:', await parentRes.text());
+        return null;
+      }
+      const commitData = await parentRes.json();
+      const parentSha = commitData.parents?.[0]?.sha;
+
+      if (parentSha) {
+        // Update the revert branch to point to the parent commit
+        const updateRefRes = await fetch(`${apiBase}/git/refs/heads/${revertBranch}`, {
+          method: 'PATCH',
+          headers: { ...headers, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ sha: parentSha, force: true }),
+        });
+        if (!updateRefRes.ok) {
+          console.error('[Rollback] Failed to update revert branch:', await updateRefRes.text());
+          return null;
+        }
+      }
+    }
+
+    // 3. Create the revert PR
+    const prRes = await fetch(`${apiBase}/pulls`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: `🔄 Auto-Rollback: Revert PR #${prNumber}`,
+        head: revertBranch,
+        base: defaultBranch,
+        body: [
+          `## Automated Rollback`,
+          ``,
+          `**Trigger:** ${reason}`,
+          `**Original PR:** #${prNumber}`,
+          `**Reverted Commit:** ${mergedCommitSha}`,
+          ``,
+          `This revert was automatically created by Mission Control's rollback pipeline.`,
+          `The product's automation tier has been paused to \`supervised\` until acknowledged.`,
+          ``,
+          `---`,
+          `*Auto-generated by Mission Control Rollback Pipeline*`,
+        ].join('\n'),
+      }),
+    });
+
+    if (!prRes.ok) {
+      const errText = await prRes.text();
+      console.error('[Rollback] Failed to create revert PR:', errText);
+      return null;
+    }
+
+    const prData = await prRes.json();
+    console.log(`[Rollback] Revert PR created: ${prData.html_url}`);
+
+    return { url: prData.html_url, number: prData.number };
+  } catch (err) {
+    console.error('[Rollback] Error creating revert PR:', err);
+    return null;
+  }
+}
+
+export async function mergeRevertPR(prUrl: string): Promise<boolean> {
+  const token = getGitHubToken();
+  if (!token) return false;
+
+  const parsed = parseGitHubPrUrl(prUrl);
+  if (!parsed) return false;
+
+  const { owner, repo, number: prNumber } = parsed;
+
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/merge`,
+      {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          commit_title: `Auto-merge rollback: Revert PR #${prNumber}`,
+          merge_method: 'merge',
+        }),
+      }
+    );
+
+    if (res.ok) {
+      console.log(`[Rollback] Revert PR #${prNumber} merged successfully`);
+      return true;
+    }
+
+    console.error('[Rollback] Failed to merge revert PR:', await res.text());
+    return false;
+  } catch (err) {
+    console.error('[Rollback] Error merging revert PR:', err);
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rollback event recording
+// ---------------------------------------------------------------------------
+
+export function recordRollbackEvent(event: {
+  product_id: string;
+  task_id?: string;
+  trigger_type: 'health_check' | 'ci_failure' | 'manual';
+  trigger_details: string;
+  merged_pr_url: string;
+  merged_commit_sha: string;
+  revert_pr_url?: string;
+  revert_pr_status: 'pending' | 'created' | 'merged' | 'failed';
+  previous_automation_tier?: string;
+}): string {
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+
+  run(
+    `INSERT INTO rollback_history
+     (id, product_id, task_id, trigger_type, trigger_details, merged_pr_url, merged_commit_sha,
+      revert_pr_url, revert_pr_status, previous_automation_tier, acknowledged, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)`,
+    [
+      id,
+      event.product_id,
+      event.task_id || null,
+      event.trigger_type,
+      event.trigger_details,
+      event.merged_pr_url,
+      event.merged_commit_sha,
+      event.revert_pr_url || null,
+      event.revert_pr_status,
+      event.previous_automation_tier || null,
+      now,
+    ]
+  );
+
+  return id;
+}
+
+export function updateRollbackEvent(id: string, updates: Partial<{
+  revert_pr_url: string;
+  revert_pr_status: string;
+}>): void {
+  const fields: string[] = [];
+  const values: unknown[] = [];
+
+  for (const [key, value] of Object.entries(updates)) {
+    fields.push(`${key} = ?`);
+    values.push(value);
+  }
+
+  if (fields.length === 0) return;
+  values.push(id);
+  run(`UPDATE rollback_history SET ${fields.join(', ')} WHERE id = ?`, values);
+}
+
+export function acknowledgeRollback(id: string, acknowledgedBy: string = 'user'): void {
+  const now = new Date().toISOString();
+  run(
+    'UPDATE rollback_history SET acknowledged = 1, acknowledged_at = ?, acknowledged_by = ? WHERE id = ?',
+    [now, acknowledgedBy, id]
+  );
+}
+
+export function listRollbackHistory(productId?: string, limit: number = 50): RollbackEvent[] {
+  if (productId) {
+    return queryAll<RollbackEvent>(
+      'SELECT * FROM rollback_history WHERE product_id = ? ORDER BY created_at DESC LIMIT ?',
+      [productId, limit]
+    );
+  }
+  return queryAll<RollbackEvent>(
+    'SELECT * FROM rollback_history ORDER BY created_at DESC LIMIT ?',
+    [limit]
+  );
+}
+
+export function getUnacknowledgedRollbacks(productId?: string): RollbackEvent[] {
+  if (productId) {
+    return queryAll<RollbackEvent>(
+      'SELECT * FROM rollback_history WHERE product_id = ? AND acknowledged = 0 ORDER BY created_at DESC',
+      [productId]
+    );
+  }
+  return queryAll<RollbackEvent>(
+    'SELECT * FROM rollback_history WHERE acknowledged = 0 ORDER BY created_at DESC'
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Core rollback pipeline
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute the full rollback pipeline:
+ * 1. Record event
+ * 2. Create revert PR
+ * 3. Auto-merge the revert
+ * 4. Pause automation tier → supervised
+ * 5. Emit SSE notification
+ */
+export async function executeRollback(params: {
+  productId: string;
+  taskId?: string;
+  triggerType: 'health_check' | 'ci_failure' | 'manual';
+  triggerDetails: string;
+  mergedPrUrl: string;
+  mergedCommitSha: string;
+}): Promise<{ rollbackId: string; revertPrUrl: string | null; success: boolean }> {
+  const product = queryOne<Product>('SELECT * FROM products WHERE id = ?', [params.productId]);
+  if (!product) throw new Error(`Product not found: ${params.productId}`);
+
+  const settings = getProductSettings(product);
+  const previousTier = settings.automation_tier || null;
+  const defaultBranch = product.default_branch || 'main';
+
+  // 1. Record the rollback event
+  const rollbackId = recordRollbackEvent({
+    product_id: params.productId,
+    task_id: params.taskId,
+    trigger_type: params.triggerType,
+    trigger_details: params.triggerDetails,
+    merged_pr_url: params.mergedPrUrl,
+    merged_commit_sha: params.mergedCommitSha,
+    revert_pr_status: 'pending',
+    previous_automation_tier: previousTier || undefined,
+  });
+
+  // 2. Create revert PR
+  const revertPr = await createRevertPR(
+    params.mergedPrUrl,
+    params.mergedCommitSha,
+    params.triggerDetails,
+    defaultBranch
+  );
+
+  let revertPrUrl: string | null = null;
+  let success = false;
+
+  if (revertPr) {
+    revertPrUrl = revertPr.url;
+    updateRollbackEvent(rollbackId, {
+      revert_pr_url: revertPr.url,
+      revert_pr_status: 'created',
+    });
+
+    // 3. Auto-merge the revert PR
+    const merged = await mergeRevertPR(revertPr.url);
+    if (merged) {
+      updateRollbackEvent(rollbackId, { revert_pr_status: 'merged' });
+      success = true;
+    } else {
+      updateRollbackEvent(rollbackId, { revert_pr_status: 'failed' });
+    }
+  } else {
+    updateRollbackEvent(rollbackId, { revert_pr_status: 'failed' });
+  }
+
+  // 4. Pause automation tier → supervised
+  if (settings.automation_tier && settings.automation_tier !== 'supervised') {
+    updateProductSettings(params.productId, { automation_tier: 'supervised' });
+    console.log(`[Rollback] Product ${product.name}: automation tier paused to supervised (was: ${settings.automation_tier})`);
+  }
+
+  // 5. Broadcast SSE event
+  broadcast({
+    type: 'task_updated',
+    payload: {
+      event: 'rollback_triggered',
+      rollbackId,
+      productId: params.productId,
+      productName: product.name,
+      triggerType: params.triggerType,
+      triggerDetails: params.triggerDetails,
+      mergedPrUrl: params.mergedPrUrl,
+      revertPrUrl,
+      revertStatus: revertPr ? (success ? 'merged' : 'created') : 'failed',
+      automationTierPaused: !!previousTier && previousTier !== 'supervised',
+      previousTier,
+    },
+  });
+
+  // 6. Log event in events table for audit trail
+  run(
+    `INSERT INTO events (id, type, task_id, message, metadata, created_at)
+     VALUES (?, 'system', ?, ?, ?, ?)`,
+    [
+      crypto.randomUUID(),
+      params.taskId || null,
+      `Rollback triggered: ${params.triggerType} — ${params.triggerDetails}`,
+      JSON.stringify({
+        rollbackId,
+        productId: params.productId,
+        revertPrUrl,
+        success,
+      }),
+      new Date().toISOString(),
+    ]
+  );
+
+  console.log(`[Rollback] Pipeline complete for product ${product.name}: success=${success}, revertPR=${revertPrUrl || 'none'}`);
+
+  return { rollbackId, revertPrUrl, success };
+}
+
+// ---------------------------------------------------------------------------
+// Post-merge health monitor (background polling)
+// ---------------------------------------------------------------------------
+
+// Track active monitors to prevent duplicates
+const activeMonitors = new Map<string, AbortController>();
+
+export function startPostMergeMonitor(params: {
+  productId: string;
+  taskId?: string;
+  healthCheckUrl: string;
+  mergedPrUrl: string;
+  mergedCommitSha: string;
+  monitorMinutes?: number;
+  pollIntervalSeconds?: number;
+}): void {
+  const {
+    productId,
+    taskId,
+    healthCheckUrl,
+    mergedPrUrl,
+    mergedCommitSha,
+    monitorMinutes = 5,
+    pollIntervalSeconds = 30,
+  } = params;
+
+  // Cancel any existing monitor for this product
+  const existingController = activeMonitors.get(productId);
+  if (existingController) {
+    existingController.abort();
+    activeMonitors.delete(productId);
+  }
+
+  const controller = new AbortController();
+  activeMonitors.set(productId, controller);
+
+  const monitorKey = `${productId}:${mergedCommitSha.slice(0, 7)}`;
+  console.log(`[Rollback Monitor] Starting health monitor for ${monitorKey} — polling ${healthCheckUrl} every ${pollIntervalSeconds}s for ${monitorMinutes}min`);
+
+  const totalMs = monitorMinutes * 60 * 1000;
+  const intervalMs = pollIntervalSeconds * 1000;
+  const startTime = Date.now();
+  let consecutiveFailures = 0;
+  const FAILURE_THRESHOLD = 3; // Require 3 consecutive failures before rollback
+
+  const poll = async () => {
+    if (controller.signal.aborted) {
+      console.log(`[Rollback Monitor] Monitor ${monitorKey} aborted`);
+      return;
+    }
+
+    if (Date.now() - startTime > totalMs) {
+      console.log(`[Rollback Monitor] Monitor ${monitorKey} completed — no issues detected`);
+      activeMonitors.delete(productId);
+      return;
+    }
+
+    const result = await checkHealth(healthCheckUrl);
+
+    if (result.healthy) {
+      consecutiveFailures = 0;
+    } else {
+      consecutiveFailures++;
+      console.warn(
+        `[Rollback Monitor] Health check failed (${consecutiveFailures}/${FAILURE_THRESHOLD}) for ${monitorKey}: ${result.error || `HTTP ${result.statusCode}`}`
+      );
+
+      if (consecutiveFailures >= FAILURE_THRESHOLD) {
+        console.error(`[Rollback Monitor] Triggering rollback for ${monitorKey} after ${FAILURE_THRESHOLD} consecutive failures`);
+        activeMonitors.delete(productId);
+
+        await executeRollback({
+          productId,
+          taskId,
+          triggerType: 'health_check',
+          triggerDetails: `Health check failed ${FAILURE_THRESHOLD} consecutive times: ${result.error || `HTTP ${result.statusCode}`}`,
+          mergedPrUrl,
+          mergedCommitSha,
+        });
+
+        return; // Stop monitoring after rollback
+      }
+    }
+
+    // Schedule next poll
+    setTimeout(poll, intervalMs);
+  };
+
+  // Initial delay: wait 30 seconds after merge before first health check
+  // to allow deployment to propagate
+  setTimeout(poll, 30_000);
+}
+
+export function stopMonitor(productId: string): boolean {
+  const controller = activeMonitors.get(productId);
+  if (controller) {
+    controller.abort();
+    activeMonitors.delete(productId);
+    return true;
+  }
+  return false;
+}
+
+export function getActiveMonitors(): string[] {
+  return Array.from(activeMonitors.keys());
+}


### PR DESCRIPTION
## What was built

Automated rollback pipeline that detects post-merge failures and reverts them, preventing broken deployments from persisting in production.

### New files

- **`src/lib/rollback.ts`** — Core rollback service:
  - Health check polling with configurable URL/interval/duration
  - GitHub API integration for revert PR creation + auto-merge
  - Automation tier management (pause to `supervised` on failure)
  - Rollback event recording in `rollback_history` table
  - Background post-merge health monitor with 3-consecutive-failure threshold
  - Product settings helpers for `health_check_url`, `post_merge_monitor_minutes`, `automation_tier`

- **`src/app/api/webhooks/github/route.ts`** — GitHub webhook handler:
  - `pull_request` (merged) → starts health check monitor
  - `check_suite` / `check_run` (completed+failed) → triggers rollback
  - `status` (commit status failure) → triggers rollback
  - HMAC-SHA256 signature verification via `GITHUB_WEBHOOK_SECRET`
  - Only activates for products with `semi_auto` or `full_auto` automation tier

- **`src/app/api/admin/rollbacks/route.ts`** — Admin rollback history:
  - GET with optional `product_id`, `unacknowledged`, `limit` filters
  - Returns active health monitors list

- **`src/app/api/products/[id]/rollback/route.ts`** — Product-level rollback:
  - POST: manual rollback trigger (`pr_url`, `commit_sha`, `reason`)
  - PATCH: acknowledge rollback + optionally restore automation tier
  - GET: product-specific rollback history with unacknowledged count

### Modified files

- **`src/lib/db/migrations.ts`** — Migration 022: `rollback_history` table with product and unacknowledged indexes

## Research Backing

Research identified "no rollback mechanism for deployed features — if an auto-merged PR breaks production, there is no automated revert pipeline" as a critical gap. This is especially important for Semi-Auto and Full Auto tiers where human review is reduced.

## Technical Approach

**Pipeline flow:**
1. GitHub webhook fires on PR merge → health monitor starts (30s initial delay, then polls every 30s for configurable minutes)
2. If health check fails 3 consecutive times → rollback triggers
3. Rollback creates a revert branch from parent commit, opens revert PR, auto-merges it
4. Product automation tier paused to `supervised`
5. SSE event broadcast + events table audit log
6. User must acknowledge via PATCH endpoint to restore automation tier

**OR:**
1. GitHub webhook fires with CI failure (check_suite/check_run/status)
2. Same rollback pipeline triggers immediately

**Product settings** (stored in existing JSON `settings` column):
- `health_check_url`: URL to poll after merge
- `post_merge_monitor_minutes`: monitoring duration (default 5)
- `automation_tier`: `supervised` | `semi_auto` | `full_auto`

## Risks / Trade-offs

- **GitHub API rate limits**: Revert PR creation + merge uses 4-5 API calls per rollback. At scale, could hit rate limits. Mitigated by only activating for semi_auto/full_auto products.
- **Merge conflicts on revert**: If other PRs have merged since the problematic one, the revert branch may have conflicts. The pipeline logs this as a failed revert and still pauses the automation tier.
- **Health check false positives**: Requires 3 consecutive failures before rollback to reduce false positives. 30-second initial delay allows deployment to propagate.
- **No GitHub token = no revert PR**: Without `GITHUB_TOKEN`/`GH_TOKEN` env var, the rollback records the event and pauses the tier, but cannot create the revert PR.

## Task ID
a6d4fc4b-b38e-45e6-a88b-169ad4594a67