### PR TITLE
fix: nullify knowledge_entries.task_id when deleting a task

### DIFF
--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -516,8 +516,9 @@ export async function DELETE(
     run('DELETE FROM work_checkpoints WHERE task_id = ?', [id]);
     run('DELETE FROM openclaw_sessions WHERE task_id = ?', [id]);
     run('DELETE FROM events WHERE task_id = ?', [id]);
-    // Conversations reference tasks - nullify or delete
+    // Conversations and Knowledge reference tasks - nullify or delete
     run('UPDATE conversations SET task_id = NULL WHERE task_id = ?', [id]);
+    run('UPDATE knowledge_entries SET task_id = NULL WHERE task_id = ?', [id]);
 
     // Now delete the task (cascades to task_activities and task_deliverables)
     run('DELETE FROM tasks WHERE id = ?', [id]);


### PR DESCRIPTION
## Problem

When a task is deleted, the DELETE handler correctly nullifies `conversations.task_id` but was missing the equivalent update for `knowledge_entries`. This leaves dangling foreign key references pointing to a non-existent task.

## Fix

Added the missing `UPDATE knowledge_entries SET task_id = NULL WHERE task_id = ?` alongside the existing conversations nullify, consistent with the comment that says *"Conversations and Knowledge reference tasks"*.

```ts
// Conversations and Knowledge reference tasks - nullify or delete
run('UPDATE conversations SET task_id = NULL WHERE task_id = ?', [id]);
run('UPDATE knowledge_entries SET task_id = NULL WHERE task_id = ?', [id]); // ← added
```

## Impact

Without this fix, deleted tasks leave orphaned `knowledge_entries` rows that can cause unexpected behaviour when querying knowledge by task.