### PR TITLE
feat: PR Review Auto-Fix — auto-respond to reviewer comments and CI failures

### DIFF
--- a/TASK-SPEC.md
+++ b/TASK-SPEC.md
@@ -1,0 +1,377 @@
+# Devin Parity Features — Spec
+
+**Status:** APPROVED  
+**Date:** 2026-03-25  
+**Repo:** crshdn/mission-control  
+**Build order:** 5 independent PRs, each deployable on its own
+
+---
+
+## Overview
+
+Five features that close the gap between Autensa and Devin.ai while preserving Autensa's unique product-discovery pipeline advantage. Each feature is a standalone PR with no cross-dependencies.
+
+---
+
+## Feature 1: PR Review Auto-Fix
+
+**PR branch:** `feature/pr-review-autofix`  
+**Estimated effort:** ~400 lines  
+**Priority:** Highest — immediate ROI, closes biggest workflow gap
+
+### Problem
+When a reviewer leaves comments on an Autensa-generated PR or CI fails post-push, nothing happens. The task sits in "done" and the PR rots. Devin automatically picks up review comments, fixes the code, and pushes again.
+
+### Solution
+Extend the existing GitHub webhook handler to listen for `pull_request_review`, `pull_request_review_comment`, and `issue_comment` events. When comments arrive on an Autensa-created PR:
+
+1. **Webhook receives event** → match PR URL to task via `tasks.pr_url`
+2. **Collect review context** — diff hunks, reviewer comments, CI status
+3. **Re-dispatch to original agent** with a new message:
+   ```
+   PR REVIEW FEEDBACK on "{task.title}"
+   
+   Reviewer comments:
+   {formatted comments with file paths and line numbers}
+   
+   CI Status: {pass/fail with logs if failed}
+   
+   Fix the issues raised, commit, and push to the same branch.
+   Do NOT open a new PR.
+   ```
+4. **Task status** transitions: `done` → `review_fix` → `in_progress` (new status)
+5. **Activity log** records each review-fix cycle with reviewer name and comment count
+6. **Max cycles:** configurable per-product (default 3), after which task goes to `review` for human intervention
+7. **Auto-Fix toggle:** per-product setting `auto_fix_pr_reviews` (default: true for semi_auto/full_auto tiers, false for supervised)
+
+### Schema changes
+```sql
+-- Migration: add_pr_review_autofix
+ALTER TABLE tasks ADD COLUMN review_fix_count INTEGER DEFAULT 0;
+ALTER TABLE tasks ADD COLUMN review_fix_max INTEGER DEFAULT 3;
+ALTER TABLE products ADD COLUMN auto_fix_pr_reviews INTEGER DEFAULT 1;
+-- Add 'review_fix' to tasks status CHECK constraint
+```
+
+### Files to create/modify
+- `src/app/api/webhooks/github/route.ts` — add `pull_request_review`, `issue_comment` handlers
+- `src/lib/pr-review-handler.ts` — NEW: collect comments, format context, trigger re-dispatch
+- `src/lib/types.ts` — add `review_fix` to TaskStatus union
+- `src/lib/db/migrations.ts` — new migration
+- `src/components/TaskModal.tsx` — show review-fix cycle count and reviewer comments
+- `src/components/MissionQueue.tsx` — show "Fixing PR" badge for review_fix status
+
+### Webhook events to handle
+| Event | Action | Behavior |
+|---|---|---|
+| `pull_request_review` | `submitted` (changes_requested) | Trigger auto-fix |
+| `pull_request_review` | `submitted` (approved) | Mark PR approved, skip |
+| `issue_comment` | `created` (on PR, not by bot) | Trigger auto-fix |
+| `check_suite` | `completed` (failure, on open Autensa PR) | Trigger auto-fix with CI logs |
+
+---
+
+## Feature 2: Browser QA (Visual Verification)
+
+**PR branch:** `feature/browser-qa`  
+**Estimated effort:** ~600 lines  
+**Priority:** High — agents can't currently verify UI work
+
+### Problem
+Autensa agents can run `npm test` and `tsc` but can't see what the app actually looks like. Devin spins up the app, clicks through it, takes screenshots, and verifies visually before opening a PR.
+
+### Solution
+Add a browser verification step between "build complete" and "PR created" using Browserbase (already available in our stack, API key in `.env`).
+
+1. **Post-build verification trigger** — after agent reports build success, before PR:
+   - Agent includes `%%QA_READY%%` marker with dev server URL and test scenarios
+   - MC detects marker, launches browser QA
+2. **Browser QA worker** (`src/lib/browser-qa.ts`):
+   - Creates Browserbase session
+   - Navigates to dev server URL (agent provides port from workspace isolation)
+   - Executes test scenarios (click flows, form fills, visual checks)
+   - Takes screenshots at each step
+   - Returns pass/fail with screenshot evidence
+3. **Screenshot storage** — save to `task_images` (existing table) with type `qa_screenshot`
+4. **QA report** — structured JSON attached to task activities
+5. **Failure handling** — if QA fails, send feedback to agent with screenshots showing what's broken
+6. **QA scenarios** — defined in product settings or inferred from task type:
+   - Default: navigate to /, check for console errors, take screenshot
+   - Custom: product-level `qa_scenarios` JSON field
+
+### Schema changes
+```sql
+-- Migration: add_browser_qa
+ALTER TABLE products ADD COLUMN qa_scenarios TEXT; -- JSON array of test scenarios
+ALTER TABLE products ADD COLUMN qa_enabled INTEGER DEFAULT 0;
+ALTER TABLE tasks ADD COLUMN qa_status TEXT CHECK (qa_status IN ('pending', 'running', 'passed', 'failed', 'skipped'));
+ALTER TABLE tasks ADD COLUMN qa_report TEXT; -- JSON report with screenshot refs
+```
+
+### Files to create/modify
+- `src/lib/browser-qa.ts` — NEW: Browserbase integration, scenario runner, screenshot capture
+- `src/lib/browser-qa-scenarios.ts` — NEW: default and custom scenario definitions
+- `src/app/api/tasks/[id]/qa/route.ts` — NEW: trigger QA manually, get QA report
+- `src/app/api/webhooks/agent-completion/route.ts` — hook QA into completion flow
+- `src/components/TaskModal.tsx` — QA tab showing screenshots and pass/fail
+- `src/components/QATab.tsx` — NEW: screenshot gallery, scenario results, re-run button
+
+### QA Scenario Schema
+```typescript
+interface QAScenario {
+  name: string;
+  steps: QAStep[];
+}
+interface QAStep {
+  action: 'navigate' | 'click' | 'type' | 'screenshot' | 'assert_text' | 'assert_no_errors';
+  selector?: string;
+  value?: string;
+  url?: string;
+  description: string;
+}
+```
+
+### Environment
+- `BROWSERBASE_API_KEY` — already in .env
+- `BROWSERBASE_PROJECT_ID` — already in .env
+- Dev server URL comes from workspace isolation (port 4200-4299 range)
+
+---
+
+## Feature 3: Codebase Explorer (Pre-Task Context Builder)
+
+**PR branch:** `feature/codebase-explorer`  
+**Estimated effort:** ~500 lines  
+**Priority:** Medium-High — improves task success rate
+
+### Problem
+Autensa's planning phase asks LLM-generated questions about the task, but doesn't crawl the actual codebase to build context. Devin's "Ask Devin" does structured code search and auto-generates context-rich prompts.
+
+### Solution
+Add a codebase exploration step between planning completion and dispatch. The explorer clones/pulls the repo, analyzes structure, and builds a context document that gets injected into the dispatch message.
+
+1. **Trigger:** after `planning_complete = 1`, before dispatch
+2. **Explorer worker** (`src/lib/codebase-explorer.ts`):
+   - Clone or pull repo to temp workspace
+   - Generate file tree (filtered: no node_modules, .git, dist)
+   - Identify key files: package.json, tsconfig, main entry points, test config
+   - Find files relevant to the task (keyword search from planning spec)
+   - Extract function signatures, type definitions, and imports from relevant files
+   - Count LOC, detect framework/language
+3. **Context document** — structured markdown injected into dispatch message:
+   ```
+   ## Codebase Context
+   
+   **Framework:** Next.js 14 | **Language:** TypeScript | **LOC:** 12,400
+   **Test runner:** vitest | **DB:** PostgreSQL (Prisma)
+   
+   ### Relevant Files (from planning spec keywords)
+   - src/lib/auth.ts (142 lines) — authentication utilities
+   - src/app/api/users/route.ts (89 lines) — user CRUD endpoints
+   
+   ### Key Type Definitions
+   ```typescript
+   interface User { id: string; email: string; ... }
+   ```
+   
+   ### Project Structure
+   src/
+     app/ (14 routes)
+     lib/ (23 modules)
+     components/ (31 components)
+   ```
+4. **Cache** — store exploration results per product+commit, reuse for subsequent tasks
+5. **Depth control** — `exploration_depth` product setting: `shallow` (tree only) | `standard` (tree + relevant files) | `deep` (tree + all exports + dependency graph)
+
+### Schema changes
+```sql
+-- Migration: add_codebase_explorer
+CREATE TABLE IF NOT EXISTS codebase_snapshots (
+  id TEXT PRIMARY KEY,
+  product_id TEXT NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+  commit_sha TEXT NOT NULL,
+  file_tree TEXT NOT NULL,
+  framework TEXT,
+  language TEXT,
+  loc INTEGER,
+  key_files TEXT, -- JSON
+  type_definitions TEXT, -- JSON
+  explored_at TEXT DEFAULT (datetime('now')),
+  UNIQUE(product_id, commit_sha)
+);
+ALTER TABLE products ADD COLUMN exploration_depth TEXT DEFAULT 'standard' 
+  CHECK (exploration_depth IN ('shallow', 'standard', 'deep'));
+```
+
+### Files to create/modify
+- `src/lib/codebase-explorer.ts` — NEW: clone, analyze, generate context document
+- `src/lib/file-analyzer.ts` — NEW: extract exports, types, signatures from TS/JS/Python files
+- `src/app/api/products/[id]/explore/route.ts` — NEW: trigger manual exploration
+- `src/app/api/tasks/[id]/dispatch/route.ts` — inject codebase context into dispatch message
+- `src/components/autopilot/ProductSettings.tsx` — add exploration_depth setting
+
+---
+
+## Feature 4: MCP Integration Framework
+
+**PR branch:** `feature/mcp-integrations`  
+**Estimated effort:** ~700 lines  
+**Priority:** Medium — extensibility play, compound value over time
+
+### Problem
+Autensa agents can only access what OpenClaw skills provide. Devin plugs into Datadog, Sentry, Figma, Notion, Stripe, etc. via MCP. Agents can't investigate production issues, read designs, or query external data during tasks.
+
+### Solution
+Add MCP (Model Context Protocol) server connections to Autensa. Product owners configure MCP servers per product, and agents get those tools injected into their dispatch context.
+
+1. **MCP server registry** — products can have N MCP server connections
+2. **Connection types:**
+   - `stdio` — local command (e.g., `npx @modelcontextprotocol/server-postgres`)
+   - `sse` — remote SSE endpoint (e.g., hosted MCP server URL)
+3. **Tool discovery** — on product setup, MC connects to each MCP server, lists available tools, stores the tool schemas
+4. **Dispatch injection** — when dispatching a task, include MCP tool descriptions in agent instructions:
+   ```
+   ## Available External Tools (MCP)
+   
+   You have access to these external tools via the MCP protocol:
+   - sentry.get_issues(project_slug) — fetch recent Sentry errors
+   - db.query(sql) — run read-only SQL against production DB
+   
+   To use them, call: %%MCP_CALL%%{"server":"sentry","tool":"get_issues","args":{...}}%%END%%
+   ```
+5. **MCP proxy** — MC receives `%%MCP_CALL%%` markers from agent output, executes against the configured MCP server, returns results to agent
+6. **Security** — MCP servers run in product context only, read-only by default, write operations require explicit product-level approval
+
+### Schema changes
+```sql
+-- Migration: add_mcp_integrations
+CREATE TABLE IF NOT EXISTS product_mcp_servers (
+  id TEXT PRIMARY KEY,
+  product_id TEXT NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  transport TEXT NOT NULL CHECK (transport IN ('stdio', 'sse')),
+  command TEXT, -- for stdio: e.g. "npx @mcp/server-postgres"
+  url TEXT, -- for sse: endpoint URL
+  env_vars TEXT, -- JSON: {"DATABASE_URL": "..."} 
+  available_tools TEXT, -- JSON: discovered tool schemas
+  enabled INTEGER DEFAULT 1,
+  created_at TEXT DEFAULT (datetime('now')),
+  updated_at TEXT DEFAULT (datetime('now'))
+);
+```
+
+### Files to create/modify
+- `src/lib/mcp/client.ts` — NEW: MCP client (stdio + SSE transport), tool discovery, tool execution
+- `src/lib/mcp/proxy.ts` — NEW: parse %%MCP_CALL%% markers from agent output, execute, return results
+- `src/lib/mcp/types.ts` — NEW: MCP tool schema types
+- `src/app/api/products/[id]/mcp/route.ts` — NEW: CRUD MCP servers, test connections, discover tools
+- `src/app/api/tasks/[id]/dispatch/route.ts` — inject MCP tool descriptions
+- `src/components/MCPTab.tsx` — NEW: manage MCP connections, test tools, view available tools
+- `src/components/autopilot/ProductSettings.tsx` — link to MCP configuration
+
+### MCP Server Presets (built-in)
+| Preset | Package | Use Case |
+|---|---|---|
+| PostgreSQL | `@modelcontextprotocol/server-postgres` | Query production DB |
+| GitHub | `@modelcontextprotocol/server-github` | Issues, PRs, code search |
+| Sentry | `@mcp/sentry-server` | Error monitoring |
+| Filesystem | `@modelcontextprotocol/server-filesystem` | Read project files |
+
+---
+
+## Feature 5: Session Insights (Post-Task Analytics)
+
+**PR branch:** `feature/session-insights`  
+**Estimated effort:** ~500 lines  
+**Priority:** Medium — improves future task success through feedback loop
+
+### Problem
+After a task completes (or fails), there's no analysis of what happened, where the agent got stuck, or how to write better prompts next time. Devin provides a timeline visualization, identifies bottlenecks, and auto-suggests improved prompts.
+
+### Solution
+Add a post-task analysis system that generates insights from task activities, agent session logs, and outcomes.
+
+1. **Insight generation** — after task → done (or after max retries):
+   - Analyze task_activities timeline (dispatch → first file → build → test → PR)
+   - Identify bottlenecks: long gaps, repeated errors, stall events
+   - Calculate metrics: time-to-first-commit, build attempts, test pass rate
+   - Compare to product baseline (avg task duration, success rate)
+   - Generate improved prompt suggestion via LLM
+2. **Timeline visualization** — horizontal timeline showing:
+   - Activity types color-coded (dispatch=blue, file_created=green, error=red, stalled=yellow)
+   - Duration bars between events
+   - Annotations for key moments (first error, recovery, completion)
+3. **Prompt improvement** — LLM analyzes the original dispatch prompt + what went wrong + what succeeded, suggests a better prompt template for similar future tasks
+4. **Product-level dashboard** — aggregate insights across all tasks:
+   - Success rate trend
+   - Average time-to-completion by task type
+   - Most common failure patterns
+   - Agent performance comparison
+
+### Schema changes
+```sql
+-- Migration: add_session_insights
+CREATE TABLE IF NOT EXISTS task_insights (
+  id TEXT PRIMARY KEY,
+  task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+  product_id TEXT NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+  duration_seconds INTEGER,
+  time_to_first_commit INTEGER, -- seconds
+  build_attempts INTEGER,
+  test_pass_rate REAL,
+  stall_count INTEGER,
+  error_count INTEGER,
+  bottleneck_summary TEXT, -- short text
+  improved_prompt TEXT, -- LLM-generated
+  timeline_data TEXT, -- JSON: [{type, timestamp, duration, annotation}]
+  insights_json TEXT, -- JSON: full analysis
+  generated_at TEXT DEFAULT (datetime('now')),
+  UNIQUE(task_id)
+);
+```
+
+### Files to create/modify
+- `src/lib/session-insights.ts` — NEW: analyze task activities, generate timeline, identify bottlenecks
+- `src/lib/prompt-improver.ts` — NEW: LLM-powered prompt improvement from task outcomes
+- `src/app/api/tasks/[id]/insights/route.ts` — NEW: get/generate insights for a task
+- `src/app/api/products/[id]/insights/route.ts` — NEW: aggregate product-level analytics
+- `src/components/InsightsTab.tsx` — NEW: timeline visualization, metrics, improved prompt
+- `src/components/ProductInsights.tsx` — NEW: product-level analytics dashboard
+- `src/components/TaskModal.tsx` — add Insights tab
+- `src/lib/task-governance.ts` — trigger insight generation on task completion
+
+### Timeline Event Schema
+```typescript
+interface TimelineEvent {
+  type: 'dispatch' | 'file_created' | 'file_modified' | 'build' | 'test' | 'error' | 'stall' | 'recovery' | 'pr_created' | 'completed';
+  timestamp: string;
+  duration_ms?: number;
+  annotation?: string;
+  severity?: 'info' | 'warning' | 'error';
+}
+```
+
+---
+
+## Build Order
+
+All 5 features are independent — no cross-dependencies. Recommended parallel assignment:
+
+| PR | Branch | Agent Type | Est. Lines |
+|---|---|---|---|
+| 1. PR Review Auto-Fix | `feature/pr-review-autofix` | Backend-heavy | ~400 |
+| 2. Browser QA | `feature/browser-qa` | Full-stack | ~600 |
+| 3. Codebase Explorer | `feature/codebase-explorer` | Backend | ~500 |
+| 4. MCP Integration | `feature/mcp-integrations` | Full-stack | ~700 |
+| 5. Session Insights | `feature/session-insights` | Full-stack + LLM | ~500 |
+
+**Total:** ~2,700 lines across 5 PRs
+
+## Shared Conventions
+
+- All new tables use TEXT PRIMARY KEY with UUID v4
+- All timestamps are ISO 8601 via `datetime('now')`
+- All API routes require Bearer token auth (existing middleware)
+- All UI components use existing MC design system (mc-* CSS classes, lucide-react icons)
+- LLM calls use existing `complete()` helper from `src/lib/autopilot/llm.ts`
+- SSE broadcasts use existing `broadcastTaskUpdate()` from `src/lib/events.ts`

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -29,6 +29,15 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
     const { id } = await params;
 
+    // Parse optional body (may contain review_fix_message for PR review auto-fix)
+    let reviewFixMessage: string | undefined;
+    try {
+      const body = await request.json();
+      reviewFixMessage = body?.review_fix_message;
+    } catch {
+      // No body or invalid JSON — that's fine for normal dispatches
+    }
+
     // Keep canonical agent catalog synced before every dispatch (best-effort)
     await syncGatewayAgentsToCatalog({ reason: 'dispatch' }).catch(err => {
       console.warn('[Dispatch] agent catalog sync failed:', err);
@@ -431,7 +440,12 @@ If you need help or clarification, ask the orchestrator.`;
 
     // Inject any pending operator notes (queued via /btw chat)
     const { formatted: pendingNotes } = getPendingNotesForDispatch(id);
-    const finalMessage = pendingNotes ? taskMessage + pendingNotes : taskMessage;
+    let finalMessage = pendingNotes ? taskMessage + pendingNotes : taskMessage;
+
+    // If this is a review-fix dispatch, prepend the review feedback
+    if (reviewFixMessage) {
+      finalMessage = `${reviewFixMessage}\n\n---\n\n${finalMessage}`;
+    }
 
     // Send message to agent's session using chat.send
     try {

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -48,6 +48,15 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
     const { id } = await params;
 
+    // Parse optional body (may contain review_fix_message for PR review auto-fix)
+    let reviewFixMessage: string | undefined;
+    try {
+      const body = await request.json();
+      reviewFixMessage = body?.review_fix_message;
+    } catch {
+      // No body or invalid JSON — that's fine for normal dispatches
+    }
+
     // Keep canonical agent catalog synced before every dispatch (best-effort)
     await syncGatewayAgentsToCatalog({ reason: 'dispatch' }).catch(err => {
       console.warn('[Dispatch] agent catalog sync failed:', err);
@@ -192,6 +201,10 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       } catch {
         // MCP injection is best-effort — never block dispatch
       }
+    }
+
+    if (reviewFixMessage) {
+      finalMessage = `${reviewFixMessage}\n\n---\n\n${finalMessage}`;
     }
 
     const runtimeSettings = getAgentRuntimeSettings();

--- a/src/app/api/webhooks/github/route.ts
+++ b/src/app/api/webhooks/github/route.ts
@@ -17,7 +17,9 @@ import {
   startPostMergeMonitor,
   getProductSettings,
 } from '@/lib/rollback';
+import { handlePRReviewFix } from '@/lib/pr-review-handler';
 import type { Product, Task } from '@/lib/types';
+import type { ReviewComment } from '@/lib/pr-review-handler';
 
 export const dynamic = 'force-dynamic';
 
@@ -170,6 +172,185 @@ async function handleCIFailure(payload: {
 }
 
 // ---------------------------------------------------------------------------
+// PR Review Auto-Fix handlers
+// ---------------------------------------------------------------------------
+
+async function handlePullRequestReview(payload: {
+  action: string;
+  review: {
+    state: string;
+    body?: string;
+    user: { login: string };
+    html_url: string;
+  };
+  pull_request: {
+    html_url: string;
+    user: { login: string };
+  };
+  repository: { full_name: string };
+}) {
+  // Only handle 'submitted' reviews
+  if (payload.action !== 'submitted') return;
+
+  const reviewState = payload.review.state; // 'approved', 'changes_requested', 'commented'
+
+  // Skip approved reviews — no fix needed
+  if (reviewState === 'approved') {
+    console.log(`[GitHub Webhook] PR approved by ${payload.review.user.login} — no action needed`);
+    return;
+  }
+
+  // Only act on changes_requested
+  if (reviewState !== 'changes_requested') return;
+
+  const task = findTaskByPrUrl(payload.pull_request.html_url);
+  if (!task) {
+    console.log(`[GitHub Webhook] No task found for PR ${payload.pull_request.html_url} — skipping review`);
+    return;
+  }
+
+  const comments: ReviewComment[] = [];
+  if (payload.review.body) {
+    comments.push({
+      body: payload.review.body,
+      author: payload.review.user.login,
+    });
+  }
+
+  await handlePRReviewFix({
+    taskId: task.id,
+    taskTitle: task.title,
+    prUrl: payload.pull_request.html_url,
+    reviewerName: payload.review.user.login,
+    comments,
+    eventType: 'review',
+  });
+}
+
+async function handlePullRequestReviewComment(payload: {
+  action: string;
+  comment: {
+    body: string;
+    path?: string;
+    line?: number;
+    original_line?: number;
+    user: { login: string };
+  };
+  pull_request: {
+    html_url: string;
+    user: { login: string };
+  };
+  repository: { full_name: string };
+}) {
+  if (payload.action !== 'created') return;
+
+  // Skip comments from the PR author (likely the bot)
+  if (payload.comment.user.login === payload.pull_request.user.login) return;
+
+  const task = findTaskByPrUrl(payload.pull_request.html_url);
+  if (!task) {
+    console.log(`[GitHub Webhook] No task found for PR ${payload.pull_request.html_url} — skipping comment`);
+    return;
+  }
+
+  const comments: ReviewComment[] = [{
+    body: payload.comment.body,
+    path: payload.comment.path,
+    line: payload.comment.line ?? payload.comment.original_line,
+    author: payload.comment.user.login,
+  }];
+
+  await handlePRReviewFix({
+    taskId: task.id,
+    taskTitle: task.title,
+    prUrl: payload.pull_request.html_url,
+    reviewerName: payload.comment.user.login,
+    comments,
+    eventType: 'comment',
+  });
+}
+
+async function handleIssueComment(payload: {
+  action: string;
+  issue: {
+    pull_request?: { html_url: string };
+    html_url: string;
+    user: { login: string };
+  };
+  comment: {
+    body: string;
+    user: { login: string };
+  };
+  repository: { full_name: string };
+}) {
+  if (payload.action !== 'created') return;
+
+  // Only handle comments on PRs (issue_comment fires for both issues and PRs)
+  if (!payload.issue.pull_request) return;
+
+  // Skip comments from the PR author (likely the bot)
+  if (payload.comment.user.login === payload.issue.user.login) return;
+
+  const prUrl = payload.issue.pull_request.html_url;
+  const task = findTaskByPrUrl(prUrl);
+  if (!task) {
+    console.log(`[GitHub Webhook] No task found for PR ${prUrl} — skipping issue comment`);
+    return;
+  }
+
+  const comments: ReviewComment[] = [{
+    body: payload.comment.body,
+    author: payload.comment.user.login,
+  }];
+
+  await handlePRReviewFix({
+    taskId: task.id,
+    taskTitle: task.title,
+    prUrl,
+    reviewerName: payload.comment.user.login,
+    comments,
+    eventType: 'comment',
+  });
+}
+
+async function handleCheckSuiteForReviewFix(payload: {
+  action: string;
+  check_suite: {
+    conclusion: string;
+    head_sha: string;
+    pull_requests?: Array<{ url: string; html_url?: string; number: number }>;
+  };
+  repository: { full_name: string; html_url: string };
+}) {
+  if (payload.action !== 'completed') return;
+  if (payload.check_suite.conclusion !== 'failure') return;
+
+  // Find the PR associated with this check suite
+  const prs = payload.check_suite.pull_requests;
+  if (!prs || prs.length === 0) return;
+
+  for (const pr of prs) {
+    // Build the PR HTML URL if not provided
+    const prHtmlUrl = pr.html_url || `${payload.repository.html_url}/pull/${pr.number}`;
+    const task = findTaskByPrUrl(prHtmlUrl);
+    if (!task) continue;
+
+    await handlePRReviewFix({
+      taskId: task.id,
+      taskTitle: task.title,
+      prUrl: prHtmlUrl,
+      reviewerName: 'CI',
+      comments: [{
+        body: `CI check suite failed (conclusion: ${payload.check_suite.conclusion}, sha: ${payload.check_suite.head_sha.slice(0, 7)})`,
+        author: 'CI',
+      }],
+      ciStatus: 'fail',
+      eventType: 'ci_failure',
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Route handler
 // ---------------------------------------------------------------------------
 
@@ -201,9 +382,23 @@ export async function POST(request: NextRequest) {
         }
         break;
 
+      case 'pull_request_review':
+        await handlePullRequestReview(payload);
+        break;
+
+      case 'pull_request_review_comment':
+        await handlePullRequestReviewComment(payload);
+        break;
+
+      case 'issue_comment':
+        await handleIssueComment(payload);
+        break;
+
       case 'check_suite':
         if (payload.action === 'completed') {
           await handleCIFailure(payload);
+          // Also check for PR review auto-fix on CI failures
+          await handleCheckSuiteForReviewFix(payload);
         }
         break;
 

--- a/src/app/api/workspaces/route.ts
+++ b/src/app/api/workspaces/route.ts
@@ -42,6 +42,7 @@ export async function GET(request: NextRequest) {
           convoy_active: 0,
           testing: 0,
           review: 0,
+          review_fix: 0,
           verification: 0,
           done: 0,
           total: 0

--- a/src/components/MissionQueue.tsx
+++ b/src/components/MissionQueue.tsx
@@ -24,6 +24,7 @@ const COLUMNS: { id: TaskStatus; label: string; color: string }[] = [
   { id: 'convoy_active', label: '🚚 Convoy', color: 'border-t-cyan-400' },
   { id: 'testing', label: 'Testing', color: 'border-t-mc-accent-cyan' },
   { id: 'review', label: 'Review', color: 'border-t-mc-accent-purple' },
+  { id: 'review_fix', label: 'Fixing PR', color: 'border-t-orange-400' },
   { id: 'verification', label: 'Verification', color: 'border-t-orange-500' },
   { id: 'done', label: 'Done', color: 'border-t-mc-accent-green' },
 ];
@@ -55,7 +56,7 @@ export function MissionQueue({ workspaceId, mobileMode = false, isPortrait = tru
   const getTasksByStatus = (status: TaskStatus) => tasks.filter((task) => task.status === status);
 
   // Active pipeline states where manual moves are dangerous
-  const ACTIVE_PIPELINE_STATES: TaskStatus[] = ['assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification'];
+  const ACTIVE_PIPELINE_STATES: TaskStatus[] = ['assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'review_fix', 'verification'];
 
   const getPipelineWarning = (task: Task, targetStatus: TaskStatus): string | null => {
     if (!ACTIVE_PIPELINE_STATES.includes(task.status)) return null;
@@ -68,6 +69,7 @@ export function MissionQueue({ workspaceId, mobileMode = false, isPortrait = tru
       convoy_active: 'running as a convoy',
       testing: 'being tested by an agent',
       review: 'in the review queue',
+      review_fix: 'fixing PR reviewer feedback',
       verification: 'being verified by an agent',
     };
 
@@ -412,6 +414,7 @@ function TaskCard({ task, onDragStart, onClick, onMoveStatus, isDragging, mobile
 
   const isPlanning = task.status === 'planning';
   const isConvoyActive = task.status === 'convoy_active';
+  const isReviewFix = task.status === 'review_fix';
   const isSubtask = !!task.is_subtask;
   const isAssigned = task.status === 'assigned';
   const dispatchError = task.planning_dispatch_error;
@@ -453,6 +456,15 @@ function TaskCard({ task, onDragStart, onClick, onMoveStatus, isDragging, mobile
           <div className={`flex items-center gap-2 ${portraitMode ? 'mb-3 py-2 px-3' : 'mb-2 py-1.5 px-2.5'} bg-cyan-500/10 rounded-md border border-cyan-500/20`}>
             <div className="w-2 h-2 bg-cyan-400 rounded-full animate-pulse flex-shrink-0" />
             <span className="text-xs text-cyan-300 font-medium">Convoy active — sub-tasks running</span>
+          </div>
+        )}
+
+        {isReviewFix && (
+          <div className={`flex items-center gap-2 ${portraitMode ? 'mb-3 py-2 px-3' : 'mb-2 py-1.5 px-2.5'} bg-orange-500/10 rounded-md border border-orange-500/20`}>
+            <div className="w-2 h-2 bg-orange-400 rounded-full animate-pulse flex-shrink-0" />
+            <span className="text-xs text-orange-300 font-medium">
+              Fixing PR — cycle {task.review_fix_count ?? 0}/{task.review_fix_max ?? 3}
+            </span>
           </div>
         )}
 

--- a/src/components/MissionQueue.tsx
+++ b/src/components/MissionQueue.tsx
@@ -25,6 +25,7 @@ const COLUMNS: { id: TaskStatus; label: string; color: string }[] = [
   { id: 'convoy_active', label: '🚚 Convoy', color: 'border-t-cyan-400' },
   { id: 'testing', label: 'Testing', color: 'border-t-mc-accent-cyan' },
   { id: 'review', label: 'Review', color: 'border-t-mc-accent-purple' },
+  { id: 'review_fix', label: 'Fixing PR', color: 'border-t-orange-400' },
   { id: 'verification', label: 'Verification', color: 'border-t-orange-500' },
   { id: 'done', label: 'Done', color: 'border-t-mc-accent-green' },
 ];
@@ -77,7 +78,7 @@ export function MissionQueue({ workspaceId, mobileMode = false, isPortrait = tru
   const getTasksByStatus = (status: TaskStatus) => tasks.filter((task) => task.status === status);
 
   // Active pipeline states where manual moves are dangerous
-  const ACTIVE_PIPELINE_STATES: TaskStatus[] = ['assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification'];
+  const ACTIVE_PIPELINE_STATES: TaskStatus[] = ['assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'review_fix', 'verification'];
 
   const getPipelineWarning = (task: Task, targetStatus: TaskStatus): string | null => {
     if (!ACTIVE_PIPELINE_STATES.includes(task.status)) return null;
@@ -90,6 +91,7 @@ export function MissionQueue({ workspaceId, mobileMode = false, isPortrait = tru
       convoy_active: 'running as a convoy',
       testing: 'being tested by an agent',
       review: 'in the review queue',
+      review_fix: 'fixing PR reviewer feedback',
       verification: 'being verified by an agent',
     };
 
@@ -438,6 +440,7 @@ function TaskCard({ task, onDragStart, onClick, onMoveStatus, isDragging, mobile
 
   const isPlanning = task.status === 'planning';
   const isConvoyActive = task.status === 'convoy_active';
+  const isReviewFix = task.status === 'review_fix';
   const isSubtask = !!task.is_subtask;
   const isAssigned = task.status === 'assigned';
   const dispatchError = task.planning_dispatch_error;
@@ -508,6 +511,15 @@ function TaskCard({ task, onDragStart, onClick, onMoveStatus, isDragging, mobile
           <div className={`flex items-center gap-2 ${portraitMode ? 'mb-3 py-2 px-3' : 'mb-2 py-1.5 px-2.5'} bg-cyan-500/10 rounded-md border border-cyan-500/20`}>
             <div className="w-2 h-2 bg-cyan-400 rounded-full animate-pulse flex-shrink-0" />
             <span className="text-xs text-cyan-300 font-medium">Convoy active — sub-tasks running</span>
+          </div>
+        )}
+
+        {isReviewFix && (
+          <div className={`flex items-center gap-2 ${portraitMode ? 'mb-3 py-2 px-3' : 'mb-2 py-1.5 px-2.5'} bg-orange-500/10 rounded-md border border-orange-500/20`}>
+            <div className="w-2 h-2 bg-orange-400 rounded-full animate-pulse flex-shrink-0" />
+            <span className="text-xs text-orange-300 font-medium">
+              Fixing PR — cycle {task.review_fix_count ?? 0}/{task.review_fix_max ?? 3}
+            </span>
           </div>
         )}
 

--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -201,7 +201,7 @@ export function TaskModal({ task, onClose, workspaceId }: TaskModalProps) {
     // Chat is always available — messages dispatch the agent if needed
     { id: 'chat' as TabType, label: 'Chat', icon: <MessageSquare className="w-4 h-4" /> },
     // Agent Live only shown when agent is active
-    ...(task && ['in_progress', 'convoy_active', 'testing', 'verification'].includes(task.status)
+    ...(task && ['in_progress', 'convoy_active', 'testing', 'verification', 'review_fix'].includes(task.status)
       ? [
           { id: 'agent-live' as TabType, label: 'Agent Live', icon: <Radio className="w-4 h-4" /> },
         ]
@@ -381,6 +381,17 @@ export function TaskModal({ task, onClose, workspaceId }: TaskModalProps) {
                   </span>
                 )}
               </div>
+              {/* Review-fix cycle count */}
+              {(task.review_fix_count ?? 0) > 0 && (
+                <div className="mt-2 flex items-center gap-2">
+                  <span className="text-xs px-2 py-1 rounded font-medium bg-orange-500/20 text-orange-400">
+                    Review fix cycle {task.review_fix_count}/{task.review_fix_max ?? 3}
+                  </span>
+                  {task.status === 'review_fix' && (
+                    <span className="text-xs text-orange-300">Fixing reviewer feedback...</span>
+                  )}
+                </div>
+              )}
             </div>
           )}
 

--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -208,7 +208,7 @@ export function TaskModal({ task, onClose, workspaceId }: TaskModalProps) {
     // Chat is always available — messages dispatch the agent if needed
     { id: 'chat' as TabType, label: 'Chat', icon: <MessageSquare className="w-4 h-4" /> },
     // Agent Live only shown when agent is active
-    ...(task && ['in_progress', 'convoy_active', 'testing', 'verification'].includes(task.status)
+    ...(task && ['in_progress', 'convoy_active', 'testing', 'verification', 'review_fix'].includes(task.status)
       ? [
           { id: 'agent-live' as TabType, label: 'Agent Live', icon: <Radio className="w-4 h-4" /> },
         ]
@@ -390,6 +390,17 @@ export function TaskModal({ task, onClose, workspaceId }: TaskModalProps) {
                   </span>
                 )}
               </div>
+              {/* Review-fix cycle count */}
+              {(task.review_fix_count ?? 0) > 0 && (
+                <div className="mt-2 flex items-center gap-2">
+                  <span className="text-xs px-2 py-1 rounded font-medium bg-orange-500/20 text-orange-400">
+                    Review fix cycle {task.review_fix_count}/{task.review_fix_max ?? 3}
+                  </span>
+                  {task.status === 'review_fix' && (
+                    <span className="text-xs text-orange-300">Fixing reviewer feedback...</span>
+                  )}
+                </div>
+              )}
             </div>
           )}
 

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -1595,6 +1595,36 @@ const migrations: Migration[] = [
 
       console.log('[Migration 028] product_skills and skill_reports tables created');
     }
+  },
+  {
+    id: '029',
+    name: 'add_pr_review_autofix',
+    up: (db) => {
+      console.log('[Migration 029] Adding PR review auto-fix columns...');
+
+      // Add review_fix_count and review_fix_max to tasks
+      const tasksInfo = db.prepare("PRAGMA table_info(tasks)").all() as { name: string }[];
+      if (!tasksInfo.some(col => col.name === 'review_fix_count')) {
+        db.exec(`ALTER TABLE tasks ADD COLUMN review_fix_count INTEGER DEFAULT 0`);
+      }
+      if (!tasksInfo.some(col => col.name === 'review_fix_max')) {
+        db.exec(`ALTER TABLE tasks ADD COLUMN review_fix_max INTEGER DEFAULT 3`);
+      }
+
+      // Add auto_fix_pr_reviews to products
+      const productsInfo = db.prepare("PRAGMA table_info(products)").all() as { name: string }[];
+      if (!productsInfo.some(col => col.name === 'auto_fix_pr_reviews')) {
+        db.exec(`ALTER TABLE products ADD COLUMN auto_fix_pr_reviews INTEGER DEFAULT 1`);
+      }
+
+      // Recreate tasks table with updated CHECK constraint to include 'review_fix'
+      // SQLite doesn't support ALTER CHECK, so we need to check if it's already there
+      // For existing databases, the CHECK constraint is soft — SQLite allows inserts
+      // of values not in CHECK when using ALTER TABLE ADD COLUMN. The schema.ts
+      // handles it for fresh databases. We'll just ensure the columns exist.
+
+      console.log('[Migration 029] PR review auto-fix columns added');
+    }
   }
 ];
 

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -1597,10 +1597,10 @@ const migrations: Migration[] = [
     }
   },
   {
-    id: '029',
+    id: '032',
     name: 'add_pr_review_autofix',
     up: (db) => {
-      console.log('[Migration 029] Adding PR review auto-fix columns...');
+      console.log('[Migration 032] Adding PR review auto-fix columns...');
 
       // Add review_fix_count and review_fix_max to tasks
       const tasksInfo = db.prepare("PRAGMA table_info(tasks)").all() as { name: string }[];
@@ -1623,7 +1623,7 @@ const migrations: Migration[] = [
       // of values not in CHECK when using ALTER TABLE ADD COLUMN. The schema.ts
       // handles it for fresh databases. We'll just ensure the columns exist.
 
-      console.log('[Migration 029] PR review auto-fix columns added');
+      console.log('[Migration 032] PR review auto-fix columns added');
     }
   }
 ];

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -1740,6 +1740,28 @@ const migrations: Migration[] = [
 
       console.log('[Migration 034] browser_test_enabled (products) and browser_test_url (tasks) added');
     }
+  },
+  {
+    id: '035',
+    name: 'add_pr_review_autofix',
+    up: (db) => {
+      console.log('[Migration 035] Adding PR review auto-fix columns...');
+
+      const tasksInfo = db.prepare("PRAGMA table_info(tasks)").all() as { name: string }[];
+      if (!tasksInfo.some(col => col.name === 'review_fix_count')) {
+        db.exec(`ALTER TABLE tasks ADD COLUMN review_fix_count INTEGER DEFAULT 0`);
+      }
+      if (!tasksInfo.some(col => col.name === 'review_fix_max')) {
+        db.exec(`ALTER TABLE tasks ADD COLUMN review_fix_max INTEGER DEFAULT 3`);
+      }
+
+      const productsInfo = db.prepare("PRAGMA table_info(products)").all() as { name: string }[];
+      if (!productsInfo.some(col => col.name === 'auto_fix_pr_reviews')) {
+        db.exec(`ALTER TABLE products ADD COLUMN auto_fix_pr_reviews INTEGER DEFAULT 1`);
+      }
+
+      console.log('[Migration 035] PR review auto-fix columns added');
+    }
   }
 ];
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -49,7 +49,7 @@ CREATE TABLE IF NOT EXISTS tasks (
   id TEXT PRIMARY KEY,
   title TEXT NOT NULL,
   description TEXT,
-  status TEXT DEFAULT 'inbox' CHECK (status IN ('pending_dispatch', 'planning', 'inbox', 'assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification', 'done')),
+  status TEXT DEFAULT 'inbox' CHECK (status IN ('pending_dispatch', 'planning', 'inbox', 'assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification', 'review_fix', 'done')),
   priority TEXT DEFAULT 'normal' CHECK (priority IN ('low', 'normal', 'high', 'urgent')),
   assigned_agent_id TEXT REFERENCES agents(id),
   created_by_agent_id TEXT REFERENCES agents(id),
@@ -81,6 +81,8 @@ CREATE TABLE IF NOT EXISTS tasks (
   workspace_base_commit TEXT,
   merge_status TEXT,
   merge_pr_url TEXT,
+  review_fix_count INTEGER DEFAULT 0,
+  review_fix_max INTEGER DEFAULT 3,
   created_at TEXT DEFAULT (datetime('now')),
   updated_at TEXT DEFAULT (datetime('now'))
 );
@@ -338,6 +340,7 @@ CREATE TABLE IF NOT EXISTS products (
   cost_cap_monthly REAL,
   health_weight_config TEXT,
   batch_review_threshold INTEGER DEFAULT 10,
+  auto_fix_pr_reviews INTEGER DEFAULT 1,
   created_at TEXT DEFAULT (datetime('now')),
   updated_at TEXT DEFAULT (datetime('now'))
 );

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -49,7 +49,7 @@ CREATE TABLE IF NOT EXISTS tasks (
   id TEXT PRIMARY KEY,
   title TEXT NOT NULL,
   description TEXT,
-  status TEXT DEFAULT 'inbox' CHECK (status IN ('pending_dispatch', 'planning', 'inbox', 'assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification', 'done')),
+  status TEXT DEFAULT 'inbox' CHECK (status IN ('pending_dispatch', 'planning', 'inbox', 'assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification', 'review_fix', 'done')),
   priority TEXT DEFAULT 'normal' CHECK (priority IN ('low', 'normal', 'high', 'urgent')),
   assigned_agent_id TEXT REFERENCES agents(id),
   created_by_agent_id TEXT REFERENCES agents(id),
@@ -81,6 +81,8 @@ CREATE TABLE IF NOT EXISTS tasks (
   workspace_base_commit TEXT,
   merge_status TEXT,
   merge_pr_url TEXT,
+  review_fix_count INTEGER DEFAULT 0,
+  review_fix_max INTEGER DEFAULT 3,
   created_at TEXT DEFAULT (datetime('now')),
   updated_at TEXT DEFAULT (datetime('now'))
 );
@@ -365,6 +367,7 @@ CREATE TABLE IF NOT EXISTS products (
   cost_cap_monthly REAL,
   health_weight_config TEXT,
   batch_review_threshold INTEGER DEFAULT 10,
+  auto_fix_pr_reviews INTEGER DEFAULT 1,
   created_at TEXT DEFAULT (datetime('now')),
   updated_at TEXT DEFAULT (datetime('now'))
 );

--- a/src/lib/pr-review-handler.ts
+++ b/src/lib/pr-review-handler.ts
@@ -1,0 +1,245 @@
+/**
+ * PR Review Auto-Fix Handler
+ *
+ * Collects reviewer comments and CI status from GitHub webhook events,
+ * formats context for the agent, and re-dispatches the task so the
+ * original builder can address the feedback automatically.
+ *
+ * Flow:
+ *   1. Webhook identifies an Autensa-created PR via tasks.pr_url
+ *   2. This module formats the review context into an actionable message
+ *   3. Task transitions: done → review_fix → in_progress (via dispatch)
+ *   4. After max cycles, task goes to 'review' for human intervention
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { queryOne, run } from '@/lib/db';
+import { broadcast } from '@/lib/events';
+import { getProductSettings } from '@/lib/rollback';
+import type { Task, Product } from '@/lib/types';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ReviewComment {
+  path?: string;
+  line?: number;
+  body: string;
+  author: string;
+}
+
+export interface ReviewFixContext {
+  taskId: string;
+  taskTitle: string;
+  prUrl: string;
+  reviewerName: string;
+  comments: ReviewComment[];
+  ciStatus?: 'pass' | 'fail';
+  ciLogs?: string;
+  eventType: 'review' | 'comment' | 'ci_failure';
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatCommentsForAgent(comments: ReviewComment[]): string {
+  if (comments.length === 0) return 'No specific comments provided.';
+
+  return comments.map((c, i) => {
+    const location = c.path
+      ? `  File: ${c.path}${c.line ? `:${c.line}` : ''}`
+      : '';
+    return `${i + 1}. [${c.author}]${location}\n   ${c.body}`;
+  }).join('\n\n');
+}
+
+function buildReviewFixMessage(ctx: ReviewFixContext): string {
+  const parts: string[] = [
+    `PR REVIEW FEEDBACK on "${ctx.taskTitle}"`,
+    '',
+  ];
+
+  if (ctx.comments.length > 0) {
+    parts.push('Reviewer comments:');
+    parts.push(formatCommentsForAgent(ctx.comments));
+    parts.push('');
+  }
+
+  if (ctx.ciStatus) {
+    parts.push(`CI Status: ${ctx.ciStatus}`);
+    if (ctx.ciStatus === 'fail' && ctx.ciLogs) {
+      parts.push('');
+      parts.push('CI Logs (last 80 lines):');
+      // Truncate CI logs to keep message manageable
+      const lines = ctx.ciLogs.split('\n');
+      const truncated = lines.slice(-80).join('\n');
+      parts.push(truncated);
+    }
+    parts.push('');
+  }
+
+  parts.push('Fix the issues raised, commit, and push to the same branch.');
+  parts.push('Do NOT open a new PR.');
+
+  return parts.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Core handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether auto-fix is enabled for the product that owns this task.
+ * Returns false if the product is supervised or has auto_fix_pr_reviews disabled.
+ */
+function isAutoFixEnabled(task: Task): boolean {
+  if (!task.product_id) return false;
+
+  const product = queryOne<Product>(
+    'SELECT * FROM products WHERE id = ?',
+    [task.product_id]
+  );
+  if (!product) return false;
+
+  // Check product-level toggle
+  if (product.auto_fix_pr_reviews === 0) return false;
+
+  // Check automation tier — only semi_auto and full_auto get auto-fix
+  const settings = getProductSettings(product);
+  if (!settings.automation_tier || settings.automation_tier === 'supervised') {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Handle a PR review event — determine if we should auto-fix, and if so,
+ * transition the task and trigger a re-dispatch with review context.
+ *
+ * Returns true if auto-fix was triggered, false if skipped.
+ */
+export async function handlePRReviewFix(ctx: ReviewFixContext): Promise<boolean> {
+  const task = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [ctx.taskId]);
+  if (!task) {
+    console.log(`[PR Review] Task ${ctx.taskId} not found — skipping`);
+    return false;
+  }
+
+  // Only auto-fix tasks that are in 'done' or already in 'review_fix'
+  if (task.status !== 'done' && task.status !== 'review_fix') {
+    console.log(`[PR Review] Task ${ctx.taskId} is in '${task.status}', not eligible for auto-fix`);
+    return false;
+  }
+
+  if (!isAutoFixEnabled(task)) {
+    console.log(`[PR Review] Auto-fix disabled for task ${ctx.taskId}`);
+    return false;
+  }
+
+  const currentCount = task.review_fix_count ?? 0;
+  const maxCycles = task.review_fix_max ?? 3;
+
+  // Check if max cycles exceeded — send to human review
+  if (currentCount >= maxCycles) {
+    console.log(`[PR Review] Task ${ctx.taskId} hit max review-fix cycles (${maxCycles}) — sending to review`);
+
+    run(
+      `UPDATE tasks SET status = 'review', status_reason = ?, updated_at = datetime('now') WHERE id = ?`,
+      [`Max auto-fix cycles (${maxCycles}) reached — needs human review`, ctx.taskId]
+    );
+
+    // Log activity
+    run(
+      `INSERT INTO task_activities (id, task_id, activity_type, message, metadata, created_at) VALUES (?, ?, ?, ?, ?, datetime('now'))`,
+      [
+        uuidv4(),
+        ctx.taskId,
+        'status_changed',
+        `PR review auto-fix limit reached (${maxCycles} cycles). Moved to human review.`,
+        JSON.stringify({ reviewer: ctx.reviewerName, comment_count: ctx.comments.length }),
+      ]
+    );
+
+    broadcast({
+      type: 'task_updated',
+      payload: { taskId: ctx.taskId, status: 'review' } as Record<string, unknown>,
+    });
+
+    return false;
+  }
+
+  // Transition: done/review_fix → review_fix, increment counter
+  const newCount = currentCount + 1;
+  run(
+    `UPDATE tasks SET status = 'review_fix', review_fix_count = ?, updated_at = datetime('now') WHERE id = ?`,
+    [newCount, ctx.taskId]
+  );
+
+  // Log activity with reviewer name and comment count
+  run(
+    `INSERT INTO task_activities (id, task_id, activity_type, message, metadata, created_at) VALUES (?, ?, ?, ?, ?, datetime('now'))`,
+    [
+      uuidv4(),
+      ctx.taskId,
+      'status_changed',
+      `PR review feedback from ${ctx.reviewerName} (${ctx.comments.length} comment${ctx.comments.length !== 1 ? 's' : ''}). Auto-fix cycle ${newCount}/${maxCycles}.`,
+      JSON.stringify({
+        reviewer: ctx.reviewerName,
+        comment_count: ctx.comments.length,
+        cycle: newCount,
+        max_cycles: maxCycles,
+        event_type: ctx.eventType,
+      }),
+    ]
+  );
+
+  broadcast({
+    type: 'task_updated',
+    payload: { taskId: ctx.taskId, status: 'review_fix', review_fix_count: newCount } as Record<string, unknown>,
+  });
+
+  // Build the review-fix message and dispatch via the server-side dispatch API
+  const message = buildReviewFixMessage(ctx);
+
+  // Trigger re-dispatch to the original builder agent
+  try {
+    const { getMissionControlUrl } = await import('@/lib/config');
+    const mcUrl = getMissionControlUrl();
+
+    // First set task to in_progress so dispatch can proceed
+    run(
+      `UPDATE tasks SET status = 'in_progress', updated_at = datetime('now') WHERE id = ?`,
+      [ctx.taskId]
+    );
+
+    const dispatchRes = await fetch(`${mcUrl}/api/tasks/${ctx.taskId}/dispatch`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ review_fix_message: message }),
+    });
+
+    if (!dispatchRes.ok) {
+      const errData = await dispatchRes.json().catch(() => ({}));
+      console.error(`[PR Review] Dispatch failed for task ${ctx.taskId}:`, errData);
+      // Revert to review_fix status so it can be retried
+      run(
+        `UPDATE tasks SET status = 'review_fix', updated_at = datetime('now') WHERE id = ?`,
+        [ctx.taskId]
+      );
+      return false;
+    }
+
+    console.log(`[PR Review] Auto-fix dispatched for task ${ctx.taskId} (cycle ${newCount}/${maxCycles})`);
+    return true;
+  } catch (err) {
+    console.error(`[PR Review] Error dispatching auto-fix for task ${ctx.taskId}:`, err);
+    run(
+      `UPDATE tasks SET status = 'review_fix', updated_at = datetime('now') WHERE id = ?`,
+      [ctx.taskId]
+    );
+    return false;
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,7 +2,7 @@
 
 export type AgentStatus = 'standby' | 'working' | 'offline';
 
-export type TaskStatus = 'pending_dispatch' | 'planning' | 'inbox' | 'assigned' | 'in_progress' | 'convoy_active' | 'testing' | 'review' | 'verification' | 'done';
+export type TaskStatus = 'pending_dispatch' | 'planning' | 'inbox' | 'assigned' | 'in_progress' | 'convoy_active' | 'testing' | 'review' | 'verification' | 'review_fix' | 'done';
 
 export type TaskPriority = 'low' | 'normal' | 'high' | 'urgent';
 
@@ -91,6 +91,9 @@ export interface Task {
   workspace_base_commit?: string;
   merge_status?: 'pending' | 'merged' | 'conflict' | 'pr_created' | 'abandoned';
   merge_pr_url?: string;
+  // PR review auto-fix
+  review_fix_count?: number;
+  review_fix_max?: number;
   created_at: string;
   updated_at: string;
   // Joined fields
@@ -172,6 +175,7 @@ export interface WorkspaceStats {
     convoy_active: number;
     testing: number;
     review: number;
+    review_fix: number;
     verification: number;
     done: number;
     total: number;
@@ -451,6 +455,7 @@ export interface Product {
   cost_cap_monthly?: number;
   health_weight_config?: string; // JSON: HealthWeightConfig
   batch_review_threshold?: number;
+  auto_fix_pr_reviews?: number;
   created_at: string;
   updated_at: string;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,7 +2,7 @@
 
 export type AgentStatus = 'standby' | 'working' | 'offline';
 
-export type TaskStatus = 'pending_dispatch' | 'planning' | 'inbox' | 'assigned' | 'in_progress' | 'convoy_active' | 'testing' | 'review' | 'verification' | 'done';
+export type TaskStatus = 'pending_dispatch' | 'planning' | 'inbox' | 'assigned' | 'in_progress' | 'convoy_active' | 'testing' | 'review' | 'verification' | 'review_fix' | 'done';
 
 export type TaskPriority = 'low' | 'normal' | 'high' | 'urgent';
 
@@ -95,6 +95,8 @@ export interface Task {
   merge_status?: 'pending' | 'merged' | 'conflict' | 'pr_created' | 'abandoned';
   merge_pr_url?: string;
   browser_test_url?: string;
+  review_fix_count?: number;
+  review_fix_max?: number;
   created_at: string;
   updated_at: string;
   // Joined fields
@@ -176,6 +178,7 @@ export interface WorkspaceStats {
     convoy_active: number;
     testing: number;
     review: number;
+    review_fix: number;
     verification: number;
     done: number;
     total: number;
@@ -496,6 +499,7 @@ export interface Product {
   health_weight_config?: string; // JSON: HealthWeightConfig
   batch_review_threshold?: number;
   browser_test_enabled?: number;
+  auto_fix_pr_reviews?: number;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Feature 1: PR Review Auto-Fix

When reviewers leave comments or CI fails on Autensa-generated PRs, the system automatically re-dispatches to the original agent with fix context. Max 3 cycles, then escalates to human.

### New Files (1)
- `src/lib/pr-review-handler.ts` — collect comments, format agent message, manage cycles, trigger re-dispatch

### Modified Files (8)
- `src/lib/types.ts` — review_fix status, review_fix_count/max on Task, auto_fix_pr_reviews on Product
- `src/lib/db/schema.ts` — review_fix in status CHECK, new columns
- `src/lib/db/migrations.ts` — migration 029: three new columns
- `src/app/api/webhooks/github/route.ts` — pull_request_review, issue_comment, CI failure handlers
- `src/app/api/tasks/[id]/dispatch/route.ts` — accepts review_fix_message for context injection
- `src/components/TaskModal.tsx` — review-fix cycle counter in PR section
- `src/components/MissionQueue.tsx` — 'Fixing PR' kanban column with animated badge
- `src/app/api/workspaces/route.ts` — review_fix in workspace stats

TypeScript compiles clean