### PR TITLE
Fix Autopilot OpenClaw chat completion routing

### DIFF
--- a/src/lib/autopilot/llm.test.ts
+++ b/src/lib/autopilot/llm.test.ts
@@ -1,0 +1,94 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { complete } from './llm';
+
+test('complete sends OpenClaw-compatible chat completion requests for provider models', async () => {
+  const originalFetch = global.fetch;
+  const originalGatewayUrl = process.env.OPENCLAW_GATEWAY_URL;
+  const originalGatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+  const originalAutopilotModel = process.env.AUTOPILOT_MODEL;
+
+  process.env.OPENCLAW_GATEWAY_URL = 'ws://127.0.0.1:18789';
+  process.env.OPENCLAW_GATEWAY_TOKEN = 'test-token';
+  process.env.AUTOPILOT_MODEL = 'openai-codex/gpt-5.4';
+
+  const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
+  global.fetch = (async (input, init) => {
+    calls.push({ url: String(input), init });
+    return new Response(JSON.stringify({
+      model: 'openclaw/default',
+      choices: [{ message: { content: '{"ok":true}' } }],
+      usage: { prompt_tokens: 12, completion_tokens: 8, total_tokens: 20 },
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as typeof fetch;
+
+  try {
+    const result = await complete('Say hi', { temperature: 0.1, maxTokens: 256 });
+
+    assert.equal(result.content, '{"ok":true}');
+    assert.equal(result.model, 'openai-codex/gpt-5.4');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, 'http://127.0.0.1:18789/v1/chat/completions');
+
+    const headers = calls[0].init?.headers as Record<string, string>;
+    assert.equal(headers['Authorization'], 'Bearer test-token');
+    assert.equal(headers['x-openclaw-model'], 'openai-codex/gpt-5.4');
+
+    const body = JSON.parse(String(calls[0].init?.body));
+    assert.equal(body.model, 'openclaw/default');
+    assert.equal(body.temperature, 0.1);
+    assert.equal(body.max_tokens, 256);
+    assert.deepEqual(body.messages, [{ role: 'user', content: 'Say hi' }]);
+  } finally {
+    global.fetch = originalFetch;
+    if (originalGatewayUrl === undefined) delete process.env.OPENCLAW_GATEWAY_URL;
+    else process.env.OPENCLAW_GATEWAY_URL = originalGatewayUrl;
+    if (originalGatewayToken === undefined) delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    else process.env.OPENCLAW_GATEWAY_TOKEN = originalGatewayToken;
+    if (originalAutopilotModel === undefined) delete process.env.AUTOPILOT_MODEL;
+    else process.env.AUTOPILOT_MODEL = originalAutopilotModel;
+  }
+});
+
+test('complete preserves direct OpenClaw model requests without override header', async () => {
+  const originalFetch = global.fetch;
+  const originalGatewayUrl = process.env.OPENCLAW_GATEWAY_URL;
+  const originalGatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+
+  process.env.OPENCLAW_GATEWAY_URL = 'ws://127.0.0.1:18789';
+  process.env.OPENCLAW_GATEWAY_TOKEN = 'test-token';
+
+  const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
+  global.fetch = (async (input, init) => {
+    calls.push({ url: String(input), init });
+    return new Response(JSON.stringify({
+      model: 'openclaw/researcher',
+      choices: [{ message: { content: 'ok' } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as typeof fetch;
+
+  try {
+    const result = await complete('Say hi', { model: 'openclaw/researcher' });
+    assert.equal(result.model, 'openclaw/researcher');
+
+    const headers = calls[0].init?.headers as Record<string, string>;
+    assert.equal(headers['x-openclaw-model'], undefined);
+
+    const body = JSON.parse(String(calls[0].init?.body));
+    assert.equal(body.model, 'openclaw/researcher');
+  } finally {
+    global.fetch = originalFetch;
+    if (originalGatewayUrl === undefined) delete process.env.OPENCLAW_GATEWAY_URL;
+    else process.env.OPENCLAW_GATEWAY_URL = originalGatewayUrl;
+    if (originalGatewayToken === undefined) delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    else process.env.OPENCLAW_GATEWAY_TOKEN = originalGatewayToken;
+  }
+});

--- a/src/lib/autopilot/llm.ts
+++ b/src/lib/autopilot/llm.ts
@@ -3,12 +3,30 @@
  * Uses /v1/chat/completions for stateless prompt→response (no agent sessions).
  */
 
-const GATEWAY_URL = process.env.OPENCLAW_GATEWAY_URL?.replace('ws://', 'http://').replace('wss://', 'https://') || 'http://127.0.0.1:18789';
-const GATEWAY_TOKEN = process.env.OPENCLAW_GATEWAY_TOKEN || '';
-const DEFAULT_MODEL = process.env.AUTOPILOT_MODEL || 'anthropic/claude-sonnet-4-6';
 const DEFAULT_TIMEOUT_MS = 300_000; // 5 minutes
 const MAX_RETRIES = 3;
 const RETRY_BASE_DELAY_MS = 5_000; // 5s, 10s, 20s exponential backoff
+const OPENCLAW_GATEWAY_MODEL = 'openclaw/default';
+
+function getGatewayUrl(): string {
+  return process.env.OPENCLAW_GATEWAY_URL?.replace('ws://', 'http://').replace('wss://', 'https://') || 'http://127.0.0.1:18789';
+}
+
+function getGatewayToken(): string {
+  return process.env.OPENCLAW_GATEWAY_TOKEN || '';
+}
+
+function getDefaultModel(): string {
+  return process.env.AUTOPILOT_MODEL || 'anthropic/claude-sonnet-4-6';
+}
+
+function resolveGatewayModel(model: string): { gatewayModel: string; modelOverride: string | null } {
+  if (model === 'openclaw' || model.startsWith('openclaw/')) {
+    return { gatewayModel: model, modelOverride: null };
+  }
+
+  return { gatewayModel: OPENCLAW_GATEWAY_MODEL, modelOverride: model };
+}
 
 export interface CompletionOptions {
   model?: string;
@@ -34,12 +52,13 @@ export interface CompletionResult {
  */
 export async function complete(prompt: string, options: CompletionOptions = {}): Promise<CompletionResult> {
   const {
-    model = DEFAULT_MODEL,
+    model = getDefaultModel(),
     systemPrompt,
     temperature = 0.7,
     maxTokens = 8192,
     timeoutMs = DEFAULT_TIMEOUT_MS,
   } = options;
+  const { gatewayModel, modelOverride } = resolveGatewayModel(model);
 
   const messages: Array<{ role: string; content: string }> = [];
   if (systemPrompt) {
@@ -60,14 +79,15 @@ export async function complete(prompt: string, options: CompletionOptions = {}):
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
     try {
-      const response = await fetch(`${GATEWAY_URL}/v1/chat/completions`, {
+      const response = await fetch(`${getGatewayUrl()}/v1/chat/completions`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${GATEWAY_TOKEN}`,
+          'Authorization': `Bearer ${getGatewayToken()}`,
+          ...(modelOverride ? { 'x-openclaw-model': modelOverride } : {}),
         },
         body: JSON.stringify({
-          model,
+          model: gatewayModel,
           messages,
           temperature,
           max_tokens: maxTokens,
@@ -87,12 +107,13 @@ export async function complete(prompt: string, options: CompletionOptions = {}):
       };
 
       const content = data.choices?.[0]?.message?.content || '';
+      const resolvedModel = modelOverride || data.model || gatewayModel;
 
-      console.log(`[LLM] Response usage:`, JSON.stringify(data.usage || null), `model: ${data.model}`);
+      console.log(`[LLM] Response usage:`, JSON.stringify(data.usage || null), `model: ${resolvedModel}`);
 
       return {
         content,
-        model: data.model || model,
+        model: resolvedModel,
         usage: {
           promptTokens: data.usage?.prompt_tokens || 0,
           completionTokens: data.usage?.completion_tokens || 0,


### PR DESCRIPTION
## Summary
- route provider models through `openclaw/default` when Autopilot calls OpenClaw's OpenAI-compatible chat completions endpoint
- send the requested provider model via `x-openclaw-model`
- preserve direct `openclaw/*` requests without an override header

## Problem
Autopilot was posting provider model names directly to `/v1/chat/completions`, which caused research runs to fail with:

`LLM completion failed (404): Not Found`

## Root Cause
OpenClaw's OpenAI-compatible endpoint expected provider models to be routed through the gateway model with the original model specified separately, but `src/lib/autopilot/llm.ts` sent the requested provider model directly in the request body.

## Fix
- add gateway model resolution for provider vs. direct OpenClaw models
- use `model: openclaw/default` plus `x-openclaw-model` for provider models
- keep direct `openclaw/*` models unchanged
- add a regression test covering both cases

## Verification
- `npx tsx --test src/lib/autopilot/llm.test.ts`
- `npm run build`