### PR TITLE
fix: promote inbox tasks to in_progress on dispatch

### DIFF
--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -445,9 +445,10 @@ If you need help or clarification, ask the orchestrator.`;
         idempotencyKey: `dispatch-${task.id}-${Date.now()}`
       });
 
-      // Only move to in_progress for builder dispatch (task is in 'assigned' status)
-      // For tester/reviewer/verifier, the task status is already correct
-      if (task.status === 'assigned') {
+      // Move builder tasks into the active queue once the message has been delivered.
+      // Direct dispatch from inbox should still surface as active work in the UI/health checks.
+      // For tester/reviewer/verifier, the task status is already correct.
+      if (task.status === 'assigned' || task.status === 'inbox') {
         run(
           'UPDATE tasks SET status = ?, updated_at = ? WHERE id = ?',
           ['in_progress', now, id]


### PR DESCRIPTION
### What changed
- Dispatch now promotes builder tasks from `inbox` to `in_progress` once the message is delivered.
- This fixes the false-negative state where Mission Control showed tasks as stuck even though the agent had received the job.

### Why
- Mission Control was successfully delivering `chat.send`, but direct dispatch from `inbox` did not update task status.
- That made the UI/health look broken and hid active work.

### Verification
- Confirmed no remaining tasks were left in `inbox` after a dispatch event.
- Ran lint/tests locally; existing warnings remain but no new blocking errors were introduced.

### Notes
- Left unrelated local changes out of the PR.
