### PR TITLE
fix: use AUTOPILOT_MODEL env var for description generation

### DIFF
--- a/src/app/api/products/generate-description/route.ts
+++ b/src/app/api/products/generate-description/route.ts
@@ -122,7 +122,6 @@ ${context.join('\n\n')}
 Respond with ONLY the description text, nothing else. No quotes, no labels, no markdown.`;
 
     const result = await complete(prompt, {
-      model: 'anthropic/claude-sonnet-4-6',
       temperature: 0.3,
       maxTokens: 300,
       timeoutMs: 30_000,


### PR DESCRIPTION
## Summary
- Removes hardcoded `anthropic/claude-sonnet-4-6` model override in the generate-description route
- The shared `complete()` function in `src/lib/autopilot/llm.ts` already reads `AUTOPILOT_MODEL` env var with the correct fallback — this route was bypassing it

## Problem
OpenClaw's `/v1/chat/completions` endpoint only accepts `openclaw` or `openclaw/<agentId>` as the model field, not raw provider model IDs. The hardcoded model causes a 400 error for Docker deployments using the chat completions endpoint.

## Test plan
- [ ] Set `AUTOPILOT_MODEL=openclaw` in environment
- [ ] Create a new product with a repo URL
- [ ] Click "Auto-generate from repo & site" — should generate description without 400 error
- [ ] Without `AUTOPILOT_MODEL` set, verify it falls back to `anthropic/claude-sonnet-4-6`

Fixes #115