### PR TITLE
fix(#113-116): normalise gateway model object + remove hardcoded LLM model

### DIFF
--- a/src/app/api/agents/discover/route.ts
+++ b/src/app/api/agents/discover/route.ts
@@ -6,12 +6,13 @@ import type { Agent, DiscoveredAgent } from '@/lib/types';
 // This route must always be dynamic - it queries live Gateway state + DB
 export const dynamic = 'force-dynamic';
 
-// Shape of an agent returned by the OpenClaw Gateway `agents.list` call
+// Shape of an agent returned by the OpenClaw Gateway `agents.list` call.
+// `model` may be a string or an object like { primary: "provider/model" }.
 interface GatewayAgent {
   id?: string;
   name?: string;
   label?: string;
-  model?: string;
+  model?: string | { primary?: string; [key: string]: unknown };
   channel?: string;
   status?: string;
   [key: string]: unknown;
@@ -67,7 +68,8 @@ export async function GET() {
         id: gatewayId,
         name: ga.name || ga.label || gatewayId,
         label: ga.label,
-        model: ga.model,
+        // Gateway may return model as { primary: "..." } — normalise to string
+        model: typeof ga.model === 'string' ? ga.model : ga.model?.primary,
         channel: ga.channel,
         status: ga.status,
         already_imported: alreadyImported,

--- a/src/app/api/products/generate-description/route.ts
+++ b/src/app/api/products/generate-description/route.ts
@@ -121,8 +121,10 @@ ${context.join('\n\n')}
 
 Respond with ONLY the description text, nothing else. No quotes, no labels, no markdown.`;
 
+    // No explicit model — complete() reads AUTOPILOT_MODEL env var (default: anthropic/claude-sonnet-4-6).
+    // Do NOT hardcode a model here: OpenClaw's /v1/chat/completions only accepts
+    // 'openclaw' or 'openclaw/<agentId>', not raw provider model IDs (causes 400).
     const result = await complete(prompt, {
-      model: 'anthropic/claude-sonnet-4-6',
       temperature: 0.3,
       maxTokens: 300,
       timeoutMs: 30_000,

--- a/src/lib/agent-catalog-sync.ts
+++ b/src/lib/agent-catalog-sync.ts
@@ -5,7 +5,8 @@ interface GatewayAgent {
   id?: string;
   name?: string;
   label?: string;
-  model?: string;
+  // Gateway may return model as a string or as { primary: "provider/model" }
+  model?: string | { primary?: string; [key: string]: unknown };
 }
 
 const SYNC_INTERVAL_MS = Number(process.env.AGENT_CATALOG_SYNC_INTERVAL_MS || 60_000);
@@ -54,18 +55,20 @@ export async function syncGatewayAgentsToCatalog(options?: { force?: boolean; re
 
         const name = ga.name || ga.label || gatewayId;
         const role = normalizeRole(name);
+        // Normalise model: Gateway may return { primary: "..." } instead of a string
+        const modelStr = typeof ga.model === 'string' ? ga.model : (ga.model?.primary ?? null);
         const existingId = existingByGatewayId.get(gatewayId) || null;
 
         if (existingId) {
           run(
             `UPDATE agents SET name = ?, role = ?, model = COALESCE(?, model), source = 'gateway', updated_at = ? WHERE id = ?`,
-            [name, role, ga.model || null, ts, existingId]
+            [name, role, modelStr, ts, existingId]
           );
         } else {
           run(
             `INSERT INTO agents (id, name, role, description, avatar_emoji, is_master, workspace_id, model, source, gateway_agent_id, created_at, updated_at)
              VALUES (lower(hex(randomblob(16))), ?, ?, ?, '🔗', 0, 'default', ?, 'gateway', ?, ?, ?)`,
-            [name, role, `Auto-synced from OpenClaw (${gatewayId})`, ga.model || null, gatewayId, ts, ts]
+            [name, role, `Auto-synced from OpenClaw (${gatewayId})`, modelStr, gatewayId, ts, ts]
           );
         }
         changed += 1;


### PR DESCRIPTION
Fixes issues #113, #114, #115, #116 — all share the same root cause (Gateway returning `model` as an object instead of a string).

## #115 + #116 — Hardcoded model in generate-description route

**File:** `src/app/api/products/generate-description/route.ts`

Removed explicit `model: 'anthropic/claude-sonnet-4-6'` from the `complete()` call. The shared `complete()` already reads `AUTOPILOT_MODEL` env var. Hardcoding a raw provider model ID causes 400 on OpenClaw's `/v1/chat/completions` (only accepts `openclaw` or `openclaw/<agentId>`).

## #114 — UI crash on Import from Gateway

**File:** `src/app/api/agents/discover/route.ts`

Gateway returns `model` as `{ primary: '...' }` (object), not a string. Rendering the object directly crashes React. Fix: normalise to string before returning to UI. Updated `GatewayAgent` interface to accept `string | { primary?: string }`.

## #113 — AgentCatalog sync RangeError

**File:** `src/lib/agent-catalog-sync.ts`

Same root cause — model object passed to SQLite driver → type error surfacing as `RangeError: Too few parameter values`. Fix: same normalisation, interface updated.