### PR TITLE
fix: preserve local agent roles during gateway catalog sync

### DIFF
--- a/src/lib/agent-catalog-sync.ts
+++ b/src/lib/agent-catalog-sync.ts
@@ -58,7 +58,7 @@ export async function syncGatewayAgentsToCatalog(options?: { force?: boolean; re
 
         if (existingId) {
           run(
-            `UPDATE agents SET name = ?, role = ?, model = COALESCE(?, model), source = 'gateway', updated_at = ? WHERE id = ?`,
+            `UPDATE agents SET name = ?, role = CASE WHEN role IS NULL OR role = 'builder' THEN ? ELSE role END, model = COALESCE(?, model), source = 'gateway', updated_at = ? WHERE id = ?`,
             [name, role, ga.model || null, ts, existingId]
           );
         } else {


### PR DESCRIPTION
### What changed
The gateway agent catalog sync now preserves existing non-default agent roles
instead of overwriting them on every sync cycle.

### Why
Mission Control stores agent roles in its local `agents` table and uses those
roles as workflow metadata for task routing, role assignment, and governance.

At the moment, the sync query always writes `role = ?` when a gateway-backed
agent already exists. That means any role adjusted locally inside Mission
Control can be silently reset on the next sync cycle.

This is especially risky because `role` is not just display metadata:
- the agents API allows local role updates
- workflow code reads agent roles for task-role population and routing
- governance logic also selects agents by role

So the current behavior can silently erase local workflow configuration.

### Fix
Only overwrite `role` when the current value is NULL or still the default
`builder` role:

```sql
role = CASE WHEN role IS NULL OR role = 'builder' THEN ? ELSE role END
```

### Result
- new/default agents still receive auto-derived roles from sync
- locally curated non-default roles are preserved
- no schema changes or migrations are required

### Verification
- manually assigned non-default roles persist across sync cycles
- new agents still get auto-assigned roles normally
- existing agents with default `builder` role still update as before
