### PR TITLE
fix: persist source_id when creating cost events

### DIFF
--- a/src/lib/costs/tracker.ts
+++ b/src/lib/costs/tracker.ts
@@ -16,20 +16,21 @@ export function recordCostEvent(input: {
   tokens_input?: number;
   tokens_output?: number;
   cost_usd: number;
+  source_id?: string | null;
   metadata?: string;
 }): CostEvent {
   const id = uuidv4();
   const workspaceId = input.workspace_id || 'default';
 
   run(
-    `INSERT INTO cost_events (id, product_id, workspace_id, task_id, cycle_id, agent_id, event_type, provider, model, tokens_input, tokens_output, cost_usd, metadata)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO cost_events (id, product_id, workspace_id, task_id, cycle_id, agent_id, event_type, provider, model, tokens_input, tokens_output, cost_usd, source_id, metadata)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       id, input.product_id || null, workspaceId, input.task_id || null,
       input.cycle_id || null, input.agent_id || null, input.event_type,
       input.provider || null, input.model || null,
       input.tokens_input || 0, input.tokens_output || 0,
-      input.cost_usd, input.metadata || null
+      input.cost_usd, input.source_id || null, input.metadata || null
     ]
   );
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -695,6 +695,7 @@ export interface CostEvent {
   tokens_input: number;
   tokens_output: number;
   cost_usd: number;
+  source_id?: string;
   metadata?: string; // JSON
   created_at: string;
 }

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -167,6 +167,7 @@ export const CreateCostEventSchema = z.object({
   tokens_input: z.number().int().min(0).optional(),
   tokens_output: z.number().int().min(0).optional(),
   cost_usd: z.number().min(0),
+  source_id: z.string().optional().nullable(),
   metadata: z.string().optional(),
 });
 


### PR DESCRIPTION
### What changed
Mission Control now accepts and persists `source_id` when cost events are created through the API/tracker path.

### Why
The `cost_events` table already includes a `source_id` column, but the app-layer create flow was inconsistent:

- `CreateCostEventSchema` did not accept `source_id`
- `recordCostEvent()` did not include `source_id` in the insert
- `CostEvent` did not expose the field in the TypeScript interface

As a result, callers could provide a `source_id`, but it would be dropped before insert.

### Why this matters
`source_id` is the natural stable identifier for deduplication and idempotent ingestion.

If the app drops it on write:
- repeated backfill/ingest flows cannot reliably identify already-recorded events
- deduplication logic becomes brittle or impossible
- the persisted row no longer matches the intended input contract

This is especially important for cost ingestion flows that may be safely re-run.

### Fix
- allow `source_id` in `CreateCostEventSchema`
- include `source_id` in the `CostEvent` interface
- persist `source_id` in `recordCostEvent()`

### Result
- cost event creation now preserves `source_id`
- callers can safely use stable source identifiers for deduplication/idempotency
- no schema or migration changes required

### Verification
- submitted a cost event with a test `source_id`
- confirmed the API response included the field
- confirmed the inserted DB row preserved the exact `source_id`
