### PR TITLE
fix(task-chat): capture replies without SSE and reduce stale waiting state

### DIFF
--- a/src/app/api/tasks/[id]/chat/route.ts
+++ b/src/app/api/tasks/[id]/chat/route.ts
@@ -2,12 +2,18 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createNote, getTaskNotes, getActiveSessionForTask, markNotesDelivered } from '@/lib/task-notes';
 import { getOpenClawClient } from '@/lib/openclaw/client';
 import { getMissionControlUrl } from '@/lib/config';
-import { expectReply } from '@/lib/chat-listener';
+import { attachChatListener, expectReply } from '@/lib/chat-listener';
 import { queryOne } from '@/lib/db';
 import { broadcast } from '@/lib/events';
 import type { Task } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
+
+// Ensure reply listener is attached even when the task chat UI is used without
+// an SSE subscriber. TaskChatTab polls /api/tasks/:id/chat directly and may
+// never open /api/events/stream, so relying on the SSE route to attach the
+// listener causes agent replies to be missed.
+attachChatListener();
 
 interface RouteParams {
   params: Promise<{ id: string }>;

--- a/src/components/TaskChatTab.tsx
+++ b/src/components/TaskChatTab.tsx
@@ -39,15 +39,20 @@ export function TaskChatTab({ taskId }: TaskChatTabProps) {
     fetch(`/api/tasks/${taskId}/read`, { method: 'POST' }).catch(() => {});
   }, [taskId]);
 
-  // Derive "waiting" from data: last message is from user, delivered, and less than 5 min old
+  // Derive "waiting" conservatively.
+  // Old behavior used a 5-minute window for any last user message, which caused
+  // stale "waiting" bubbles even after the task was effectively done or no reply
+  // was realistically coming. Show waiting only while a user message is still
+  // pending delivery, or for a short period right after a delivered user message.
   const waiting = useMemo(() => {
     if (notes.length === 0) return false;
     const last = notes[notes.length - 1];
-    if (last.role === 'assistant') return false;
     if (last.role !== 'user') return false;
-    // Check if the message is recent (< 5 minutes)
+
+    if (last.status === 'pending') return true;
+
     const age = Date.now() - new Date(last.created_at).getTime();
-    return age < 300000;
+    return age < 15000;
   }, [notes]);
 
   // Auto-scroll on new notes or waiting state change

--- a/src/components/chat/ChatConversation.tsx
+++ b/src/components/chat/ChatConversation.tsx
@@ -44,10 +44,10 @@ export function ChatConversation({ taskId, onMarkRead }: ChatConversationProps) 
   const waiting = useMemo(() => {
     if (notes.length === 0) return false;
     const last = notes[notes.length - 1];
-    if (last.role === 'assistant') return false;
     if (last.role !== 'user') return false;
+    if (last.status === 'pending') return true;
     const age = Date.now() - new Date(last.created_at).getTime();
-    return age < 300000;
+    return age < 15000;
   }, [notes]);
 
   useEffect(() => {


### PR DESCRIPTION
## What this fixes

This PR addresses two task chat issues:

1. Agent replies could be missed when task chat was used without the SSE stream route being active
2. The task chat UI could remain in a stale "waiting" state for too long

## Root cause

### Reply capture
`attachChatListener()` was only initialized from `/api/events/stream`.

That meant task chat usage through `/api/tasks/[id]/chat` polling could occur without the reply listener ever being attached, so replies generated by the agent were not always persisted back into `task_notes`.

### Waiting state
The UI considered task chat to be "waiting" whenever the latest message was a user message less than 5 minutes old.

This was too broad and could misrepresent the real state after reply delivery or task completion.

## Changes

- Ensure the chat listener is attached from the task chat API path as well
- Narrow waiting-state logic in task chat UI:
  - show waiting when the latest user message is still `pending`
  - or briefly after a just-delivered user message
  - avoid long-lived stale waiting indicators

## Why this is safe

- No change to task chat message schema
- No change to agent dispatch format
- Listener attachment is idempotent
- Waiting-state change is UI-only and reduces false positives

## Result

- Task chat no longer depends on SSE route initialization to capture agent replies
- Users are less likely to see stale "waiting" UI after a reply has already been produced
