### PR TITLE
fix: normalise gateway agent model object to string — fix React error #31

### DIFF
--- a/src/app/api/agents/discover/route.ts
+++ b/src/app/api/agents/discover/route.ts
@@ -6,15 +6,27 @@ import type { Agent, DiscoveredAgent } from '@/lib/types';
 // This route must always be dynamic - it queries live Gateway state + DB
 export const dynamic = 'force-dynamic';
 
-// Shape of an agent returned by the OpenClaw Gateway `agents.list` call
+// Shape of an agent returned by the OpenClaw Gateway `agents.list` call.
+// `model` may be a plain string or an object like { primary: string, fallbacks: string[] }
+// depending on the OpenClaw version.
 interface GatewayAgent {
   id?: string;
   name?: string;
   label?: string;
-  model?: string;
+  model?: string | { primary?: string; fallbacks?: string[]; [key: string]: unknown };
   channel?: string;
   status?: string;
   [key: string]: unknown;
+}
+
+/** Normalise the gateway model field to a plain string. */
+function normaliseModel(
+  model: GatewayAgent['model'],
+): string | undefined {
+  if (!model) return undefined;
+  if (typeof model === 'string') return model;
+  // Object form: { primary: "provider/model", fallbacks: [...] }
+  return model.primary ?? undefined;
 }
 
 // GET /api/agents/discover - Discover existing agents from the OpenClaw Gateway
@@ -59,7 +71,9 @@ export async function GET() {
       existingAgents.map((a) => [a.gateway_agent_id, a.id])
     );
 
-    // Map gateway agents to our DiscoveredAgent type
+    // Map gateway agents to our DiscoveredAgent type.
+    // Normalise `model` to a string here so the UI never receives an object
+    // (which would trigger React error #31 — "Objects are not valid as a React child").
     const discovered: DiscoveredAgent[] = gatewayAgents.map((ga) => {
       const gatewayId = ga.id || ga.name || '';
       const alreadyImported = importedGatewayIds.has(gatewayId);
@@ -67,7 +81,7 @@ export async function GET() {
         id: gatewayId,
         name: ga.name || ga.label || gatewayId,
         label: ga.label,
-        model: ga.model,
+        model: normaliseModel(ga.model),
         channel: ga.channel,
         status: ga.status,
         already_imported: alreadyImported,

--- a/src/lib/agent-catalog-sync.ts
+++ b/src/lib/agent-catalog-sync.ts
@@ -5,7 +5,17 @@ interface GatewayAgent {
   id?: string;
   name?: string;
   label?: string;
-  model?: string;
+  // OpenClaw may return model as a string or as { primary: string, fallbacks: string[] }
+  model?: string | { primary?: string; fallbacks?: string[]; [key: string]: unknown };
+}
+
+/** Normalise the gateway model field to a plain string for DB storage. */
+function normaliseModel(
+  model: GatewayAgent['model'],
+): string | null {
+  if (!model) return null;
+  if (typeof model === 'string') return model;
+  return model.primary ?? null;
 }
 
 const SYNC_INTERVAL_MS = Number(process.env.AGENT_CATALOG_SYNC_INTERVAL_MS || 60_000);
@@ -59,13 +69,13 @@ export async function syncGatewayAgentsToCatalog(options?: { force?: boolean; re
         if (existingId) {
           run(
             `UPDATE agents SET name = ?, role = CASE WHEN role IS NULL OR role = 'builder' THEN ? ELSE role END, model = COALESCE(?, model), source = 'gateway', updated_at = ? WHERE id = ?`,
-            [name, role, ga.model || null, ts, existingId]
+            [name, role, normaliseModel(ga.model), ts, existingId]
           );
         } else {
           run(
             `INSERT INTO agents (id, name, role, description, avatar_emoji, is_master, workspace_id, model, source, gateway_agent_id, created_at, updated_at)
              VALUES (lower(hex(randomblob(16))), ?, ?, ?, '🔗', 0, 'default', ?, 'gateway', ?, ?, ?)`,
-            [name, role, `Auto-synced from OpenClaw (${gatewayId})`, ga.model || null, gatewayId, ts, ts]
+            [name, role, `Auto-synced from OpenClaw (${gatewayId})`, normaliseModel(ga.model), gatewayId, ts, ts]
           );
         }
         changed += 1;


### PR DESCRIPTION
Fixes #122

## Problem

OpenClaw gateway returns `model` as `{ primary: 'provider/model', fallbacks: [...] }` instead of a plain string. React error #31 ('Objects are not valid as a React child') crashes the Discover Agents modal when it tries to render this object.

PR #123 fixed this but was closed without merging.

## Fix

**`src/app/api/agents/discover/route.ts`** — normalise `model` at the API boundary:
- Widen `GatewayAgent.model` type to accept both forms
- Add `normaliseModel()` that extracts `.primary` from object, passes strings through
- Apply to every `DiscoveredAgent` in the response so the UI always gets a string

**`src/lib/agent-catalog-sync.ts`** — same fix for background catalog sync:
- Same type widening + `normaliseModel()` helper  
- Applied to INSERT and UPDATE so SQLite never receives an object

## Testing

1. Connect an OpenClaw gateway with agents that return `model` as an object
2. Open Discover Agents modal — should no longer crash
3. Import an agent — model field should be stored correctly as a string