### PR TITLE
feat: web-downloadable deliverables + task archiving

### DIFF
--- a/docs/ISSUE-01-LOCAL-GUIDE.md
+++ b/docs/ISSUE-01-LOCAL-GUIDE.md
@@ -1,0 +1,240 @@
+# Issue #1: Stalled Tasks Deadlock — Local Worker Guide
+
+**Source:** <https://github.com/smb209/mission-control/issues/1>
+**Status:** FIXED (pending release)
+**Summary:** Tasks used to become permanently deadlocked when they had no
+properly-typed activities and no deliverables — the evidence gate blocked
+every forward transition AND `POST /fail` returned 500, so operators had no
+supported path to release, cancel, or delete the task.
+
+Resolved by migration `029` + the endpoints documented under **Operator
+escape hatch** below. The original write-up is preserved in
+*Historical context* for provenance.
+
+---
+
+## Operator escape hatch
+
+### 1. Cancel a stalled task (primary tool)
+
+```bash
+MC="http://localhost:4000"; AUTH="Authorization: Bearer $TOK"
+
+curl -s -X POST "$MC/api/tasks/$TASK_ID/admin/release-stall" \
+  -H "$AUTH" -H "Content-Type: application/json" \
+  -d '{"reason":"agent_stalled_no_activity","terminal_state":"cancelled"}'
+```
+
+- Bypasses the evidence gate.
+- Terminates `openclaw_sessions` for the task AND every convoy sub-task.
+- Unassigns the agent, sets `status = 'cancelled'`, writes
+  `status_reason = 'released_by_admin: <reason>'`.
+- Dissolves the convoy (sets `convoys.status = 'failed'`) if the task is
+  a convoy parent.
+- Audit trail in both `task_activities` (`activity_type: admin_release`)
+  and `events`.
+- Terminal: cancelled tasks cannot transition back to active. Use `DELETE
+  /api/tasks/:id` to remove, or create a fresh task.
+
+Accepts `terminal_state: 'done'` if the operator considers the work
+effectively complete; default is `'cancelled'`.
+
+### 2. Fail a task with a real error (now 400, not 500)
+
+`POST /api/tasks/:id/fail` used to return a bare 500 when
+`handleStageFailure` couldn't resolve a `fail_target`. It now returns a
+400 with a structured error and a hint pointing to `release-stall` when
+recovery isn't possible. Use this when a testing/review/verification
+stage should bounce back for rework; use `release-stall` when nothing
+can bring the task back.
+
+### 3. Scan for stalled tasks on demand
+
+```bash
+curl -s -X POST "$MC/api/tasks/scan-stalls" -H "$AUTH"
+```
+
+Returns `{ scanned, flagged: [...] }`. The scanner also runs automatically
+every 2 minutes as part of `runHealthCheckCycle` (piggybacks on the SSE
+stream). Flagged convoy sub-tasks message the coordinator agent via
+`agent_mailbox`; non-convoy tasks fall through to
+`MC_STALL_WEBHOOK_URL` if that env var is set. Threshold defaults to
+30 min idle — override via `STALL_DETECTION_MINUTES`.
+
+---
+
+## What was broken (historical context)
+
+---
+
+## What Happens
+
+1. Task is created and dispatched to an agent
+2. Agent runs heartbeat pings (~every 2 min) but logs them as `type: null` instead of real activity types ("progress", "deliverable", etc.)
+3. Agent stalls without producing a deliverable
+4. Task stuck in `in_progress`, `verification`, or `convoy_active`
+5. All API operations fail:
+   - `POST /api/tasks/{id}/fail` → Internal server error
+   - `PATCH /api/tasks/{id}` with `status: completed` → "Evidence gate failed"
+   - `DELETE /api/tasks/{id}` → "Failed to delete task"
+
+### Root Causes
+
+- **No automatic activity logging** — agents must manually POST activities with proper types; heartbeat timestamps alone don't satisfy the evidence gate
+- **No admin bypass for the evidence gate** — no endpoint to override quality gates for stalled tasks
+- **No stall detection** — tasks can remain idle indefinitely with no alerting
+- **Checkpoints not working** — `checkpoint/restore` returns "No checkpoint to restore from" even after hours of activity
+
+---
+
+## Proposed Fixes
+
+### Priority 1 — Admin escape hatch
+
+Add an admin-only endpoint to bypass the evidence gate:
+
+```
+POST /api/tasks/{id}/admin/release-stall
+{
+  "reason": "agent_stalled_no_activity",
+  "released_by": "admin-token-or-api-key"
+}
+```
+
+This allows transitioning any task to a terminal state regardless of evidence requirements.
+
+### Priority 2 — Server-side activity logging
+
+The server should automatically record meaningful interactions as activities with proper types:
+- Agent health check responses → `type: "heartbeat"`
+- Deliverable registration attempts → `type: "deliverable_attempt"`
+- Dispatch events → `type: "dispatched"`
+- Planning events → `type: "planning_*"`
+
+### Priority 3 — Stall detection + alerting
+
+Periodic health checks flagging tasks that:
+- Same status for > X minutes (configurable, default 30 min)
+- No deliverables registered
+- No activities with non-null `type`
+
+When flagged: set `status_reason`, send notification via Discord/webhook, optionally auto-create a cleanup task.
+
+### Priority 4 — Fix checkpoint system
+
+Ensure checkpoints are created during normal task lifecycle so `checkpoint/restore` is viable recovery. Currently returns empty even for long-running tasks.
+
+---
+
+## Current Workaround
+
+```bash
+MC="http://localhost:4001"
+TOK="<token>"
+AUTH="Authorization: Bearer $TOK"
+
+# 1. Force-complete planning (moves to inbox)
+curl -X POST "$MC/api/tasks/{id}/planning/force-complete" \
+  -H "$AUTH" -H "Content-Type: application/json" -d '{}'
+
+# 2. Unassign agent (bypasses evidence gate)
+curl -X PATCH "$MC/api/tasks/{id}" \
+  -H "$AUTH" -H "Content-Type: application/json" \
+  -d '{"assigned_agent_id":null}'
+
+# 3. Delete
+curl -X DELETE "$MC/api/tasks/{id}" -H "$AUTH"
+```
+
+---
+
+## Local Machine Resources
+
+### Repo & Checkout
+| Resource | Path / URL |
+|----------|-----------|
+| Fork (active source) | <https://github.com/smb209/mission-control> |
+| Local checkout | `/Users/snappytwo/snappytwo-sandbox/mission-control` |
+| GitHub access | `research-sc` has **owner** access |
+| Upstream remote | Removed — only work with our fork |
+
+### Running Container
+| Resource | Detail |
+|----------|--------|
+| Container name | `mission-control` |
+| Image | `mission-control:latest` |
+| Host port | `4000` → container `4000` |
+| Internal API base | `http://localhost:4001` (proxied) |
+| DB path (in container) | `/app/data/mission-control.db` |
+| Workspace volume | `/app/workspace/` |
+
+### Docker Compose
+- **Compose file:** `/Users/snappytwo/snappytwo-sandbox/mission-control/docker-compose.yml`
+- **Dockerfile:** `/Users/snappytwo/snappytwo-sandbox/mission-control/Dockerfile`
+- **Volumes:** Named volumes `mission-control-data` (DB) + `mission-control-workspace` (deliverables)
+- **Host data bind:** `/Users/snappytwo/docker/mission-control/` maps to container paths
+
+### OpenClaw Gateway Connection
+- **Gateway URL:** `ws://host.docker.internal:18789` (set in container environment)
+- **Gateway Token:** Stored in container env (`OPENCLAW_GATEWAY_TOKEN`)
+- **Gateway local:** `http://localhost:18789`
+
+### Build & Run
+```bash
+# Build the Docker image from fork
+cd /Users/snappytwo/snappytwo-sandbox/mission-control
+docker compose build
+
+# Start (volumes persist DB + workspace)
+docker compose up -d
+
+# Rebuild after code changes
+docker compose up -d --build
+
+# View logs
+docker logs mission-control -f
+
+# Exec into running container
+docker exec -it mission-control sh
+
+# Stop
+docker compose down
+```
+
+### Local Dev (non-Docker)
+```bash
+cd /Users/snappytwo/snappytwo-sandbox/mission-control
+npm install
+npm run build          # Next.js production build
+npm run db:seed         # Seed database (creates default agents like "Charlie")
+npm start               # Start on port 4000
+```
+
+### Database
+- **SQLite DB location (host):** `/Users/snappytwo/docker/mission-control/mission-control.db`
+- **Backups:** `/Users/snappytwo/docker/mission-control/data/db-backups/`
+- **NEVER mutate SQLite directly.** Use the REST API or `docker exec` to run seed scripts.
+
+### Workspace / Deliverables
+- **Host path:** `/Users/snappytwo/docker/mission-control/workspace/`
+- Files saved here are readable by agents at `/app/workspace/<filename>` inside container
+
+---
+
+## Key Files to Modify for This Fix
+
+| File | Purpose |
+|------|---------|
+| `src/app/api/tasks/[id]/fail/route.ts` | Where `POST /api/tasks/{id}/fail` fails with internal error |
+| `src/app/api/tasks/[id]/route.ts` (PATCH) | Evidence gate validation logic |
+| `src/app/api/tasks/[id]/delete/route.ts` | Deletion blocking |
+| `src/models/task.ts` or similar | Evidence gate model/validation |
+| `src/lib/checkpoints.ts` | Checkpoint creation logic (currently broken) |
+| New file: `src/app/api/tasks/[id]/admin/release-stall/route.ts` | Admin escape hatch endpoint |
+
+## Notes for Future Workers
+
+- This fork (`smb209/mission-control`) is our source of truth. Do NOT push to or file issues against upstream.
+- The running Docker image is built from this fork. Any fixes should be made here first.
+- If agents don't show up in the UI after a rebuild: check gateway connectivity, run `/api/agents/discover`, verify `openclaw_session_id` linkage via `/api/agents/{id}`.
+- Database resets (`db:seed`) will wipe custom agents. Always back up before reseeding.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mission-control",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mission-control",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1014.0",
         "@hello-pangea/dnd": "^17.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1014.0",
         "@hello-pangea/dnd": "^17.0.0",
+        "@types/archiver": "^7.0.0",
+        "archiver": "^7.0.1",
         "better-sqlite3": "^12.6.2",
         "clsx": "^2.1.1",
         "css-tree": "^3.1.0",
@@ -1514,7 +1516,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -1532,7 +1533,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1545,7 +1545,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -1821,7 +1820,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -2602,6 +2600,15 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/archiver": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-7.0.0.tgz",
+      "integrity": "sha512-/3vwGwx9n+mCQdYZ2IKGGHEFL30I96UgBlk8EtRDDFQ9uxM1l4O5Ci6r00EMAkiDaTqD9DQ6nVrWRICnBPtzzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/readdir-glob": "*"
+      }
+    },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
@@ -2630,7 +2637,6 @@
       "version": "20.19.30",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
       "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2662,6 +2668,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/readdir-glob": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
+      "integrity": "sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/use-sync-external-store": {
@@ -3222,6 +3237,18 @@
         "win32"
       ]
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -3266,7 +3293,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3276,7 +3302,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3307,6 +3332,148 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/archiver/node_modules/b4a": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/archiver/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/archiver/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/archiver/node_modules/tar-stream": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
       }
     },
     "node_modules/arg": {
@@ -3500,6 +3667,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -3587,8 +3760,98 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.7.tgz",
+      "integrity": "sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
+      "integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.1.tgz",
+      "integrity": "sha512-fZapLWNB25gS+etK27NV9KgBNXgo2yeYHuj+OyPblQd6GYAE3JVy6aKxszMV5jhGGFwraXQKA5fldvf3lMyEqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -3753,6 +4016,15 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/busboy": {
@@ -3936,7 +4208,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3949,7 +4220,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -3962,6 +4232,62 @@
         "node": ">= 6"
       }
     },
+    "node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/compress-commons/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/compress-commons/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3969,11 +4295,81 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/crc32-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/crc32-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4237,7 +4633,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/echarts": {
@@ -4267,7 +4662,6 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/end-of-stream": {
@@ -4969,6 +5363,33 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -4983,6 +5404,12 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -5165,7 +5592,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -5351,7 +5777,6 @@
       "version": "10.3.10",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
       "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -5387,7 +5812,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -5397,7 +5821,6 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -5846,7 +6269,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5996,6 +6418,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
@@ -6104,7 +6538,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
@@ -6129,7 +6562,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
       "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -6253,6 +6685,54 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -6303,6 +6783,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -6326,7 +6812,6 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/lucide-react": {
@@ -6422,7 +6907,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -6602,7 +7086,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6870,7 +7353,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6887,7 +7369,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -7192,6 +7673,21 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -7352,6 +7848,36 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/readdirp": {
@@ -7681,7 +8207,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -7694,7 +8219,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7780,7 +8304,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -7872,6 +8395,17 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -7885,7 +8419,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -7904,7 +8437,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -7919,14 +8451,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width/node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7939,7 +8469,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -8068,7 +8597,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -8082,7 +8610,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -8262,6 +8789,38 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/text-decoder/node_modules/b4a": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
       }
     },
     "node_modules/text-table": {
@@ -8573,7 +9132,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -8693,7 +9251,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -8808,7 +9365,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -8827,7 +9383,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -8845,14 +9400,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -8867,7 +9420,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -8880,7 +9432,6 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -8893,7 +9444,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -8922,6 +9472,60 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/zip-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/zip-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1014.0",
     "@hello-pangea/dnd": "^17.0.0",
+    "@types/archiver": "^7.0.0",
+    "archiver": "^7.0.1",
     "better-sqlite3": "^12.6.2",
     "clsx": "^2.1.1",
     "css-tree": "^3.1.0",

--- a/src/app/api/agents/[id]/mail/route.ts
+++ b/src/app/api/agents/[id]/mail/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getUnreadMail, markAsRead } from '@/lib/mailbox';
+import { queryOne } from '@/lib/db';
+import { getUnreadMail, markAsRead, sendMail } from '@/lib/mailbox';
+import { recordRollCallReplyIfMatch } from '@/lib/rollcall';
+import type { Agent } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
 
@@ -15,6 +18,87 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json(messages);
   } catch (error) {
     return NextResponse.json({ error: 'Failed to fetch mail' }, { status: 500 });
+  }
+}
+
+/**
+ * POST /api/agents/[id]/mail — Send mail to this agent from another.
+ *
+ * Body: {
+ *   from_agent_id: string,
+ *   subject?: string,
+ *   body: string,
+ *   convoy_id?: string,    // optional scope
+ *   task_id?: string,      // optional scope
+ *   push?: boolean         // if true, also deliver via chat.send immediately
+ * }
+ *
+ * Counterpart to /api/convoy/[convoyId]/mail — this one handles mail that
+ * lives outside a convoy (roll-call, help-requests to the master
+ * orchestrator, ad-hoc inter-agent messages). Agents reply to mail by
+ * POSTing back the other direction.
+ */
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { id: toAgentId } = await params;
+    const body = await request.json() as {
+      from_agent_id?: string;
+      subject?: string;
+      body?: string;
+      convoy_id?: string;
+      task_id?: string;
+      push?: boolean;
+    };
+
+    if (!body.from_agent_id || !body.body) {
+      return NextResponse.json(
+        { error: 'from_agent_id and body are required' },
+        { status: 400 }
+      );
+    }
+
+    // Sanity-check both agents exist so FK errors surface as clean 4xx.
+    const recipient = queryOne<Agent>('SELECT id FROM agents WHERE id = ?', [toAgentId]);
+    if (!recipient) {
+      return NextResponse.json({ error: `Recipient agent ${toAgentId} not found` }, { status: 404 });
+    }
+    const sender = queryOne<Agent>('SELECT id FROM agents WHERE id = ?', [body.from_agent_id]);
+    if (!sender) {
+      return NextResponse.json({ error: `Sender agent ${body.from_agent_id} not found` }, { status: 400 });
+    }
+
+    const result = await sendMail({
+      convoyId: body.convoy_id || null,
+      taskId: body.task_id || null,
+      fromAgentId: body.from_agent_id,
+      toAgentId,
+      subject: body.subject,
+      body: body.body,
+      push: Boolean(body.push),
+    });
+
+    // If this mail looks like a reply to an open roll-call, record it
+    // against the matching rollcall_entries row so the UI's live status
+    // view flips from "waiting" to "responded" for this agent. No-op if
+    // there's no match — stray replies are just regular mail.
+    const rollcallMatch = recordRollCallReplyIfMatch({
+      mailId: result.message.id,
+      fromAgentId: body.from_agent_id,
+      toAgentId,
+      subject: body.subject,
+      body: body.body,
+    });
+
+    return NextResponse.json(
+      { ...result, rollcall_matched: rollcallMatch.matched, rollcall_id: rollcallMatch.rollcallId },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error('[POST /api/agents/[id]/mail] failed:', error);
+    return NextResponse.json(
+      { error: `Failed to send mail: ${(error as Error).message}` },
+      { status: 500 }
+    );
   }
 }
 

--- a/src/app/api/agents/[id]/openclaw/route.ts
+++ b/src/app/api/agents/[id]/openclaw/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { v4 as uuidv4 } from 'uuid';
 import { queryOne, run } from '@/lib/db';
 import { getOpenClawClient } from '@/lib/openclaw/client';
+import { logDebugEvent } from '@/lib/debug-log';
 import type { Agent, OpenClawSession } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -109,6 +110,18 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       [sessionId]
     );
 
+    logDebugEvent({
+      type: 'session.create',
+      direction: 'internal',
+      agentId: id,
+      sessionKey: openclawSessionId,
+      metadata: {
+        agent_name: agent.name,
+        channel: 'mission-control',
+        reason: 'manual_link',
+      },
+    });
+
     return NextResponse.json({ linked: true, session }, { status: 201 });
   } catch (error) {
     console.error('Failed to link agent to OpenClaw:', error);
@@ -147,6 +160,17 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
       'UPDATE openclaw_sessions SET status = ?, updated_at = ? WHERE id = ?',
       ['inactive', now, existingSession.id]
     );
+
+    logDebugEvent({
+      type: 'session.end',
+      direction: 'internal',
+      agentId: id,
+      sessionKey: existingSession.openclaw_session_id,
+      metadata: {
+        agent_name: agent.name,
+        reason: 'manual_unlink',
+      },
+    });
 
     // Log event
     run(

--- a/src/app/api/agents/[id]/route.ts
+++ b/src/app/api/agents/[id]/route.ts
@@ -94,6 +94,14 @@ export async function PATCH(
       const trimmed = body.session_key_prefix?.trim();
       values.push(!trimmed ? null : trimmed.endsWith(':') ? trimmed : trimmed + ':');
     }
+    if ((body as { is_active?: unknown }).is_active !== undefined) {
+      // Operator-set flag that excludes this agent from routing / convoy /
+      // roll-call consideration regardless of real-time status. Nothing in
+      // the DB row is destructive — flipping is_active back to 1 restores
+      // candidacy immediately.
+      updates.push('is_active = ?');
+      values.push((body as { is_active?: boolean }).is_active ? 1 : 0);
+    }
 
     if (updates.length === 0) {
       return NextResponse.json({ error: 'No updates provided' }, { status: 400 });

--- a/src/app/api/agents/local/route.ts
+++ b/src/app/api/agents/local/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from 'next/server';
+import { queryAll, run, transaction } from '@/lib/db';
+import { broadcast } from '@/lib/events';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * DELETE /api/agents/local — wipe every agent that was NOT synced from the
+ * OpenClaw Gateway (i.e. gateway_agent_id IS NULL). Used as a reset step
+ * when the local catalog drifts or accumulates manual test agents. Only
+ * affects rows in the Mission Control DB — the Gateway itself is untouched.
+ *
+ * Cleans up FK-referencing rows in the same transaction so the FK pragma
+ * doesn't block the delete.
+ */
+export async function DELETE() {
+  try {
+    const targets = queryAll<{ id: string; name: string }>(
+      `SELECT id, name FROM agents WHERE gateway_agent_id IS NULL`
+    );
+
+    if (targets.length === 0) {
+      return NextResponse.json({ deleted: 0, agents: [] });
+    }
+
+    const ids = targets.map((t) => t.id);
+    const placeholders = ids.map(() => '?').join(',');
+
+    transaction(() => {
+      // Required (NOT NULL) FK refs — delete dependent rows outright.
+      run(`DELETE FROM task_roles WHERE agent_id IN (${placeholders})`, ids);
+      run(`DELETE FROM work_checkpoints WHERE agent_id IN (${placeholders})`, ids);
+      run(
+        `DELETE FROM convoy_messages WHERE from_agent_id IN (${placeholders}) OR to_agent_id IN (${placeholders})`,
+        [...ids, ...ids]
+      );
+
+      // Nullable FK refs — set to NULL so history is retained but no longer
+      // points at a ghost agent.
+      run(`UPDATE tasks SET assigned_agent_id = NULL WHERE assigned_agent_id IN (${placeholders})`, ids);
+      run(`UPDATE tasks SET created_by_agent_id = NULL WHERE created_by_agent_id IN (${placeholders})`, ids);
+      run(`UPDATE events SET agent_id = NULL WHERE agent_id IN (${placeholders})`, ids);
+      run(`UPDATE openclaw_sessions SET agent_id = NULL WHERE agent_id IN (${placeholders})`, ids);
+      run(`UPDATE task_activities SET agent_id = NULL WHERE agent_id IN (${placeholders})`, ids);
+      run(`UPDATE knowledge_entries SET created_by_agent_id = NULL WHERE created_by_agent_id IN (${placeholders})`, ids);
+      run(`UPDATE cost_events SET agent_id = NULL WHERE agent_id IN (${placeholders})`, ids);
+      run(`UPDATE conversation_messages SET sender_agent_id = NULL WHERE sender_agent_id IN (${placeholders})`, ids);
+
+      // Some columns are declared in the schema but may not exist in every
+      // running DB (migrations are additive). Guard with try/catch so a
+      // missing table doesn't abort the whole clear.
+      try { run(`UPDATE content_pieces SET agent_id = NULL WHERE agent_id IN (${placeholders})`, ids); } catch {}
+      try { run(`UPDATE audit_log SET agent_id = NULL WHERE agent_id IN (${placeholders})`, ids); } catch {}
+      try { run(`UPDATE product_skills SET created_by_agent_id = NULL WHERE created_by_agent_id IN (${placeholders})`, ids); } catch {}
+
+      // agent_health has ON DELETE CASCADE — handled automatically below.
+      run(`DELETE FROM agents WHERE id IN (${placeholders})`, ids);
+    });
+
+    broadcast({
+      type: 'agents_cleared',
+      payload: { count: targets.length, scope: 'local' },
+    });
+
+    return NextResponse.json({ deleted: targets.length, agents: targets });
+  } catch (error) {
+    console.error('[DELETE /api/agents/local] failed:', error);
+    return NextResponse.json(
+      { error: `Failed to clear local agents: ${(error as Error).message}` },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/agents/rollcall/[id]/route.ts
+++ b/src/app/api/agents/rollcall/[id]/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getRollCallStatus } from '@/lib/rollcall';
+
+export const dynamic = 'force-dynamic';
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * GET /api/agents/rollcall/[id]
+ *
+ * Return the current state of a roll-call — per-target delivery status,
+ * whether each agent has replied, and the reply body if so. The UI polls
+ * this (or subscribes to SSE `rollcall_entry_updated` events) to update
+ * the live results panel.
+ */
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const status = getRollCallStatus(id);
+    if (!status) {
+      return NextResponse.json({ error: 'Roll-call not found' }, { status: 404 });
+    }
+
+    const now = Date.now();
+    const expiresMs = new Date(status.rollcall.expires_at).getTime();
+    const expired = now > expiresMs;
+
+    // Aggregate summary for quick glance.
+    const summary = {
+      total: status.entries.length,
+      delivered: status.entries.filter(e => e.delivery_status === 'sent').length,
+      delivery_failed: status.entries.filter(e => e.delivery_status === 'failed' || e.delivery_status === 'skipped').length,
+      replied: status.entries.filter(e => e.replied_at).length,
+      pending_reply: status.entries.filter(
+        e => e.delivery_status === 'sent' && !e.replied_at
+      ).length,
+      expired,
+      seconds_remaining: Math.max(0, Math.floor((expiresMs - now) / 1000)),
+    };
+
+    return NextResponse.json({
+      rollcall: status.rollcall,
+      entries: status.entries,
+      summary,
+    });
+  } catch (error) {
+    console.error('[GET /api/agents/rollcall/[id]] failed:', error);
+    return NextResponse.json(
+      { error: `Failed to fetch roll-call status: ${(error as Error).message}` },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/agents/rollcall/route.ts
+++ b/src/app/api/agents/rollcall/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { initiateRollCall } from '@/lib/rollcall';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/agents/rollcall
+ *
+ * Kick off a roll-call across all active agents in a workspace.
+ *
+ * Body: {
+ *   workspace_id?: string,                  // defaults to 'default'
+ *   mode?: 'direct' | 'coordinator',        // defaults to 'direct'
+ *   timeout_seconds?: number                // defaults to 30
+ * }
+ *
+ * Returns 200 with the created rollcall + per-target entries (with
+ * delivery status) on success. Returns 409 if no master orchestrator
+ * exists or more than one does — operator must resolve that first via
+ * `PATCH /api/agents/[id]` setting `is_master`. Returns 400 if there
+ * are no active non-master agents to call.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json().catch(() => ({})) as {
+      workspace_id?: string;
+      mode?: 'direct' | 'coordinator';
+      timeout_seconds?: number;
+    };
+
+    const workspaceId = body.workspace_id || 'default';
+    const mode = body.mode === 'coordinator' ? 'coordinator' : 'direct';
+    const timeoutSeconds = Math.max(5, Math.min(body.timeout_seconds ?? 30, 300));
+
+    const result = await initiateRollCall({ workspaceId, mode, timeoutSeconds });
+
+    if (!result.ok) {
+      // no_master / multiple_masters → 409 Conflict (operator must fix),
+      // no_active_agents → 400 Bad Request (no one to call).
+      const status =
+        result.reason === 'no_active_agents'
+          ? 400
+          : 409;
+      return NextResponse.json(
+        {
+          error: result.detail,
+          reason: result.reason,
+          candidates: result.candidates?.map(a => ({ id: a.id, name: a.name, role: a.role })),
+        },
+        { status }
+      );
+    }
+
+    return NextResponse.json({
+      ok: true,
+      rollcall_id: result.rollcall.id,
+      rollcall: result.rollcall,
+      entries: result.entries,
+    });
+  } catch (error) {
+    console.error('[POST /api/agents/rollcall] failed:', error);
+    return NextResponse.json(
+      { error: `Failed to initiate roll-call: ${(error as Error).message}` },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/convoy/[convoyId]/mail/route.ts
+++ b/src/app/api/convoy/[convoyId]/mail/route.ts
@@ -26,7 +26,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       );
     }
 
-    const message = sendMail({
+    const result = await sendMail({
       convoyId,
       fromAgentId: from_agent_id,
       toAgentId: to_agent_id,
@@ -34,7 +34,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       body: messageBody,
     });
 
-    return NextResponse.json(message, { status: 201 });
+    return NextResponse.json(result.message, { status: 201 });
   } catch (error) {
     const msg = error instanceof Error ? error.message : 'Failed to send mail';
     return NextResponse.json({ error: msg }, { status: 400 });

--- a/src/app/api/debug/diagnostic/route.ts
+++ b/src/app/api/debug/diagnostic/route.ts
@@ -1,0 +1,231 @@
+import { NextResponse } from 'next/server';
+import { v4 as uuidv4 } from 'uuid';
+import { queryOne, run } from '@/lib/db';
+import { broadcast } from '@/lib/events';
+import {
+  isDebugCollectionEnabled,
+  setDebugCollectionEnabled,
+  logDebugEvent,
+} from '@/lib/debug-log';
+import { syncGatewayAgentsToCatalog } from '@/lib/agent-catalog-sync';
+import { getMissionControlUrl } from '@/lib/config';
+import type { Agent, Task } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+interface DiagnosticStep {
+  name: string;
+  ok: boolean;
+  detail?: string;
+  duration_ms?: number;
+  data?: Record<string, unknown>;
+}
+
+/**
+ * POST /api/debug/diagnostic
+ *
+ * Preset end-to-end test to surface where the MC ↔ agent pipeline is
+ * failing. Runs the real dispatch flow against the gateway-synced
+ * "coordinator" agent so every instrumented surface (gateway.list_agents,
+ * session.create, chat.send) fires — the resulting events appear on
+ * `/debug` for inspection. Also emits `diagnostic.step` events so the
+ * progress of the test itself is visible alongside the traffic it triggers.
+ *
+ * Each step is attempted even if the previous one returned a soft warning;
+ * the endpoint only short-circuits on hard blockers (e.g. no coordinator
+ * found, task create failed).
+ */
+export async function POST() {
+  const runId = uuidv4();
+  const steps: DiagnosticStep[] = [];
+
+  const record = (step: DiagnosticStep) => {
+    steps.push(step);
+    logDebugEvent({
+      type: 'diagnostic.step',
+      direction: 'internal',
+      metadata: {
+        run_id: runId,
+        step: step.name,
+        ok: step.ok,
+        detail: step.detail,
+        ...step.data,
+      },
+      durationMs: step.duration_ms,
+      error: step.ok ? null : step.detail ?? null,
+    });
+  };
+
+  try {
+    // Step 1: Ensure debug collection is enabled. Everything downstream
+    // depends on this — without it, logDebugEvent() becomes a no-op and
+    // the operator sees an empty /debug feed.
+    const wasEnabled = isDebugCollectionEnabled();
+    if (!wasEnabled) {
+      setDebugCollectionEnabled(true);
+      broadcast({
+        type: 'debug_collection_toggled',
+        payload: { collection_enabled: true },
+      });
+    }
+    record({
+      name: 'enable_collection',
+      ok: true,
+      detail: wasEnabled ? 'already_enabled' : 'enabled_now',
+    });
+
+    // Step 2: Force-sync the gateway catalog. This also exercises the
+    // gateway WebSocket and logs `gateway.list_agents` — a common failure
+    // point (gateway down, auth misconfigured).
+    const syncStart = Date.now();
+    try {
+      const changed = await syncGatewayAgentsToCatalog({
+        force: true,
+        reason: 'diagnostic',
+      });
+      record({
+        name: 'gateway_sync',
+        ok: true,
+        duration_ms: Date.now() - syncStart,
+        detail: `synced ${changed} agent(s)`,
+        data: { changed },
+      });
+    } catch (err) {
+      record({
+        name: 'gateway_sync',
+        ok: false,
+        duration_ms: Date.now() - syncStart,
+        detail: (err as Error).message,
+      });
+      return NextResponse.json(
+        {
+          run_id: runId,
+          ok: false,
+          steps,
+          error: 'Gateway sync failed — OpenClaw unreachable or auth misconfigured',
+        },
+        { status: 502 }
+      );
+    }
+
+    // Step 3: Locate the coordinator agent. Prefer a gateway-synced one so
+    // we're actually talking to OpenClaw, not a local stub.
+    const coordinator = queryOne<Agent>(
+      `SELECT * FROM agents
+       WHERE role = 'coordinator'
+       ORDER BY (gateway_agent_id IS NOT NULL) DESC, updated_at DESC
+       LIMIT 1`
+    );
+    if (!coordinator) {
+      record({
+        name: 'find_coordinator',
+        ok: false,
+        detail: 'No agent with role=coordinator found',
+      });
+      return NextResponse.json(
+        {
+          run_id: runId,
+          ok: false,
+          steps,
+          error: 'No coordinator agent available. Import one from the Gateway first.',
+        },
+        { status: 404 }
+      );
+    }
+    record({
+      name: 'find_coordinator',
+      ok: true,
+      detail: coordinator.name,
+      data: {
+        agent_id: coordinator.id,
+        source: (coordinator as Agent & { source?: string }).source ?? null,
+        gateway_agent_id: (coordinator as Agent & { gateway_agent_id?: string }).gateway_agent_id ?? null,
+      },
+    });
+
+    // Step 4: Create a trivial test task assigned to coordinator. Keep the
+    // title stable-but-unique so the dispatch workspace dir doesn't collide
+    // across runs, and the task is easy to spot in the queue.
+    const taskId = uuidv4();
+    const now = new Date().toISOString();
+    const shortRun = runId.slice(0, 8);
+    const title = `Diagnostic ping ${shortRun}`;
+    const description =
+      'End-to-end debug test. Please reply with a single line: "pong from <your-name>". No files, no git, just a chat reply.';
+
+    run(
+      `INSERT INTO tasks (id, title, description, status, priority, assigned_agent_id, workspace_id, business_id, created_at, updated_at)
+       VALUES (?, ?, ?, 'assigned', 'normal', ?, 'default', 'default', ?, ?)`,
+      [taskId, title, description, coordinator.id, now, now]
+    );
+    record({
+      name: 'create_task',
+      ok: true,
+      detail: title,
+      data: { task_id: taskId },
+    });
+
+    const createdTask = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
+    if (createdTask) {
+      broadcast({ type: 'task_created', payload: createdTask });
+    }
+
+    // Step 5: Dispatch via HTTP so the task goes through the real pipeline
+    // (workspace isolation, catalog sync, chat.send logging). The dispatch
+    // route emits its own debug events — we just report the HTTP result.
+    const dispatchStart = Date.now();
+    const dispatchUrl = `${getMissionControlUrl()}/api/tasks/${taskId}/dispatch`;
+    let dispatchOk = false;
+    let dispatchDetail = '';
+    let dispatchData: Record<string, unknown> = {};
+    try {
+      // Same-origin server-side fetch has no Origin/Referer, so the
+      // middleware rejects it when MC_API_TOKEN is set. Pass the token
+      // explicitly; in dev (no token) this header is ignored.
+      const headers: Record<string, string> = {};
+      if (process.env.MC_API_TOKEN) {
+        headers['Authorization'] = `Bearer ${process.env.MC_API_TOKEN}`;
+      }
+      const res = await fetch(dispatchUrl, { method: 'POST', headers });
+      const body = await res.json().catch(() => ({}));
+      dispatchOk = res.ok;
+      dispatchDetail = res.ok
+        ? 'Task delivered to coordinator — watch the event stream for chat.send and the agent response'
+        : body?.error || `HTTP ${res.status}`;
+      dispatchData = { http_status: res.status, response: body };
+    } catch (err) {
+      dispatchDetail = (err as Error).message;
+      dispatchData = { fetch_error: dispatchDetail };
+    }
+    record({
+      name: 'dispatch',
+      ok: dispatchOk,
+      duration_ms: Date.now() - dispatchStart,
+      detail: dispatchDetail,
+      data: dispatchData,
+    });
+
+    return NextResponse.json({
+      run_id: runId,
+      ok: dispatchOk,
+      task_id: taskId,
+      agent_id: coordinator.id,
+      agent_name: coordinator.name,
+      steps,
+      hint: dispatchOk
+        ? 'Test task dispatched. If no chat.response appears within ~30s, the agent is reachable but not replying — check session logs.'
+        : 'Dispatch failed. See the step above for details.',
+    });
+  } catch (error) {
+    record({
+      name: 'unhandled',
+      ok: false,
+      detail: (error as Error).message,
+    });
+    console.error('[POST /api/debug/diagnostic] failed:', error);
+    return NextResponse.json(
+      { run_id: runId, ok: false, steps, error: (error as Error).message },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/debug/events/route.ts
+++ b/src/app/api/debug/events/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { broadcast } from '@/lib/events';
+import {
+  getDebugEvents,
+  getDebugEventCount,
+  clearDebugEvents,
+  type DebugEventFilter,
+  type DebugEventType,
+  type DebugEventDirection,
+} from '@/lib/debug-log';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/debug/events
+ *
+ * Query params (all optional):
+ *   task_id, agent_id, event_type, direction, after_id, limit
+ *
+ * Returns `{ events, total }`. `total` is the unfiltered count so the UI
+ * can show "N / M" even when the current filter is narrow.
+ */
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+
+  const filter: DebugEventFilter = {
+    taskId: searchParams.get('task_id') || undefined,
+    agentId: searchParams.get('agent_id') || undefined,
+    eventType: (searchParams.get('event_type') as DebugEventType | null) || undefined,
+    direction: (searchParams.get('direction') as DebugEventDirection | null) || undefined,
+    afterId: searchParams.get('after_id') || undefined,
+    limit: searchParams.get('limit') ? Number(searchParams.get('limit')) : undefined,
+  };
+
+  const events = getDebugEvents(filter);
+  const total = getDebugEventCount();
+
+  return NextResponse.json({ events, total });
+}
+
+/**
+ * DELETE /api/debug/events — wipe all captured rows. Operator-invoked from
+ * the /debug UI. Intentionally not soft-delete; debug data has no
+ * auditing value after the operator says "clear".
+ */
+export async function DELETE() {
+  const cleared = clearDebugEvents();
+  broadcast({ type: 'debug_events_cleared', payload: { cleared } });
+  return NextResponse.json({ cleared });
+}

--- a/src/app/api/debug/settings/route.ts
+++ b/src/app/api/debug/settings/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { broadcast } from '@/lib/events';
+import { isDebugCollectionEnabled, setDebugCollectionEnabled } from '@/lib/debug-log';
+
+export const dynamic = 'force-dynamic';
+
+/** GET /api/debug/settings — returns { collection_enabled } */
+export async function GET() {
+  return NextResponse.json({ collection_enabled: isDebugCollectionEnabled() });
+}
+
+/**
+ * POST /api/debug/settings — body: { collection_enabled: boolean }
+ *
+ * Toggles capture. When turning OFF, existing rows are preserved so the
+ * operator can still inspect them; use DELETE /api/debug/events to wipe.
+ */
+export async function POST(request: NextRequest) {
+  const body = await request.json().catch(() => ({}));
+  if (typeof body.collection_enabled !== 'boolean') {
+    return NextResponse.json(
+      { error: 'collection_enabled must be a boolean' },
+      { status: 400 }
+    );
+  }
+
+  setDebugCollectionEnabled(body.collection_enabled);
+  broadcast({
+    type: 'debug_collection_toggled',
+    payload: { collection_enabled: body.collection_enabled },
+  });
+  return NextResponse.json({ collection_enabled: body.collection_enabled });
+}

--- a/src/app/api/deliverables/[id]/download/route.ts
+++ b/src/app/api/deliverables/[id]/download/route.ts
@@ -1,0 +1,68 @@
+/**
+ * Download a single task deliverable as a file.
+ *
+ * Only works for file-type deliverables. URL and artifact types are not
+ * downloadable. Legacy 'host' rows are served too, provided MC can read the
+ * path (i.e. same-host or shared mount) — otherwise 404.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createReadStream } from 'fs';
+import { Readable } from 'stream';
+import path from 'path';
+import { getDb } from '@/lib/db';
+import {
+  resolveDeliverableReadPath,
+  mimeTypeForPath,
+  fileSizeBytes,
+  DeliverableReadError,
+} from '@/lib/deliverables/storage';
+import type { TaskDeliverable } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const db = getDb();
+  const deliverable = db.prepare(`SELECT * FROM task_deliverables WHERE id = ?`).get(params.id) as
+    | TaskDeliverable
+    | undefined;
+
+  if (!deliverable) {
+    return NextResponse.json({ error: 'Deliverable not found' }, { status: 404 });
+  }
+  if (deliverable.deliverable_type !== 'file') {
+    return NextResponse.json(
+      { error: 'Only file deliverables can be downloaded' },
+      { status: 400 }
+    );
+  }
+
+  let absPath: string;
+  try {
+    absPath = resolveDeliverableReadPath(deliverable);
+  } catch (e) {
+    if (e instanceof DeliverableReadError) {
+      return NextResponse.json({ error: e.message }, { status: e.status });
+    }
+    throw e;
+  }
+
+  const size = fileSizeBytes(absPath);
+  const contentType = mimeTypeForPath(absPath);
+  const downloadName = path.basename(absPath);
+
+  const nodeStream = createReadStream(absPath);
+  // Next.js accepts a Web ReadableStream for the body; convert Node → Web.
+  const webStream = Readable.toWeb(nodeStream) as unknown as ReadableStream;
+
+  const headers: Record<string, string> = {
+    'Content-Type': contentType,
+    'Content-Disposition': `attachment; filename="${encodeURIComponent(downloadName)}"`,
+  };
+  if (size !== undefined) headers['Content-Length'] = String(size);
+
+  return new NextResponse(webStream, { status: 200, headers });
+}

--- a/src/app/api/deliverables/tasks-with-deliverables/route.ts
+++ b/src/app/api/deliverables/tasks-with-deliverables/route.ts
@@ -1,0 +1,52 @@
+/**
+ * Summary list of every task that has at least one deliverable, used by the
+ * right-rail "Ready deliverables" panel.
+ *
+ * Returns a row per task with total count, mc-managed count (i.e. how many are
+ * downloadable), status, archived flag, and last_added_at for sorting.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/db';
+
+export const dynamic = 'force-dynamic';
+
+interface Row {
+  task_id: string;
+  task_title: string;
+  status: string;
+  is_archived: number;
+  file_count: number;
+  mc_count: number;
+  last_added_at: string;
+}
+
+export async function GET(request: NextRequest) {
+  const db = getDb();
+  const workspaceId = request.nextUrl.searchParams.get('workspace_id');
+
+  const params: string[] = [];
+  let where = 'WHERE td.deliverable_type = \'file\'';
+  if (workspaceId) {
+    where += ' AND t.workspace_id = ?';
+    params.push(workspaceId);
+  }
+
+  const rows = db.prepare(`
+    SELECT
+      t.id AS task_id,
+      t.title AS task_title,
+      t.status AS status,
+      COALESCE(t.is_archived, 0) AS is_archived,
+      COUNT(td.id) AS file_count,
+      SUM(CASE WHEN COALESCE(td.storage_scheme, 'host') = 'mc' THEN 1 ELSE 0 END) AS mc_count,
+      MAX(td.created_at) AS last_added_at
+    FROM task_deliverables td
+    JOIN tasks t ON t.id = td.task_id
+    ${where}
+    GROUP BY t.id
+    ORDER BY MAX(td.created_at) DESC
+  `).all(...params) as Row[];
+
+  return NextResponse.json(rows);
+}

--- a/src/app/api/openclaw/sessions/[id]/route.ts
+++ b/src/app/api/openclaw/sessions/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getOpenClawClient } from '@/lib/openclaw/client';
 import { getDb } from '@/lib/db';
 import { broadcast } from '@/lib/events';
+import { logDebugEvent } from '@/lib/debug-log';
 
 export const dynamic = 'force-dynamic';
 interface RouteParams {
@@ -183,6 +184,15 @@ export async function DELETE(request: Request, { params }: RouteParams) {
 
     // Delete the session
     db.prepare('DELETE FROM openclaw_sessions WHERE id = ?').run(session.id);
+
+    logDebugEvent({
+      type: 'session.end',
+      direction: 'internal',
+      agentId: agentId,
+      taskId: taskId,
+      sessionKey: session.openclaw_session_id,
+      metadata: { reason: 'session_delete_endpoint' },
+    });
 
     // If there's an associated agent that was auto-created (role = 'Sub-Agent'), delete it too
     if (agentId) {

--- a/src/app/api/openclaw/sessions/route.ts
+++ b/src/app/api/openclaw/sessions/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getOpenClawClient } from '@/lib/openclaw/client';
-import { queryAll } from '@/lib/db';
-import type { OpenClawSession } from '@/lib/types';
+import { queryAll, queryOne, run, transaction } from '@/lib/db';
+import { broadcast } from '@/lib/events';
+import { logDebugEvent } from '@/lib/debug-log';
+import { resolveAgentSessionKeyPrefix } from '@/lib/openclaw/session-key';
+import type { Agent, OpenClawSession } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
 // GET /api/openclaw/sessions - List OpenClaw sessions
@@ -89,6 +92,133 @@ export async function POST(request: Request) {
     console.error('Failed to create OpenClaw session:', error);
     return NextResponse.json(
       { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}
+
+// DELETE /api/openclaw/sessions - Reset all sessions, both MC-side and gateway-side.
+// Used by the sidebar's "Reset all sessions" action so the operator can
+// clear stale/zombie sessions in one click — typically after persona-file
+// edits (SOUL.md / AGENTS.md / MESSAGING-PROTOCOL.md) that need agents to
+// reload, or when sessionKey routing has drifted.
+//
+// Two phases:
+//   1. Wipe MC's `openclaw_sessions` table + clean up legacy Sub-Agent rows.
+//   2. Send `/reset` via chat.send to each gateway-synced agent's main
+//      session, which forces the gateway to re-init that session — the
+//      agent's next message reloads SOUL.md/AGENTS.md/etc. `/reset` and
+//      `/new` are OpenClaw's built-in session-init commands.
+//
+// Either phase can fail independently; the response reports both so the
+// operator can see what landed. `agents_reset` entries with `ok: false`
+// usually mean the gateway didn't route the command (agent offline,
+// allow-list restriction, etc.) — operator can fall back to `/reset` in
+// that agent's chat manually.
+export async function DELETE() {
+  try {
+    const sessions = queryAll<OpenClawSession>('SELECT * FROM openclaw_sessions');
+    const count = sessions.length;
+
+    transaction(() => {
+      // Same cleanup as the per-session DELETE in [id]/route.ts: remove
+      // any auto-created Sub-Agent rows whose session is being dropped.
+      // With ALLOW_DYNAMIC_AGENTS=false this is a no-op, but we keep the
+      // cleanup so resets stay safe in legacy workspaces where ghost
+      // Sub-Agent rows may still exist.
+      for (const s of sessions) {
+        if (s.agent_id) {
+          const agent = queryOne<{ id: string; role: string }>(
+            'SELECT id, role FROM agents WHERE id = ?',
+            [s.agent_id]
+          );
+          if (agent?.role === 'Sub-Agent') {
+            run('DELETE FROM agents WHERE id = ?', [agent.id]);
+          } else if (agent) {
+            run('UPDATE agents SET status = ? WHERE id = ?', ['standby', agent.id]);
+          }
+        }
+      }
+      run('DELETE FROM openclaw_sessions');
+    });
+
+    for (const s of sessions) {
+      logDebugEvent({
+        type: 'session.end',
+        direction: 'internal',
+        agentId: s.agent_id,
+        taskId: s.task_id,
+        sessionKey: s.openclaw_session_id,
+        metadata: { reason: 'bulk_reset' },
+      });
+    }
+
+    // Phase 2: tell each gateway-synced agent to re-init its session so
+    // SOUL.md / AGENTS.md / MESSAGING-PROTOCOL.md get re-injected on the
+    // next turn. Done sequentially because the OpenClawClient serializes
+    // on a single WebSocket — parallel would interleave but gain little
+    // at the typical roster size.
+    const gatewayAgents = queryAll<Agent>(
+      `SELECT * FROM agents
+         WHERE gateway_agent_id IS NOT NULL
+           AND COALESCE(is_active, 1) = 1
+           AND COALESCE(status, 'standby') != 'offline'`
+    );
+
+    const agentsReset: Array<{ agent_id: string; name: string; sessionKey: string; ok: boolean; error?: string }> = [];
+
+    if (gatewayAgents.length > 0) {
+      const client = getOpenClawClient();
+      try {
+        if (!client.isConnected()) await client.connect();
+      } catch (err) {
+        // If we can't even connect, return what we have and let the
+        // operator fall back to `/reset` in the chat. MC-side phase 1
+        // already succeeded.
+        return NextResponse.json({
+          success: true,
+          deleted: count,
+          agents_reset: [],
+          gateway_error: (err as Error).message,
+        });
+      }
+
+      for (const agent of gatewayAgents) {
+        const prefix = resolveAgentSessionKeyPrefix(agent);
+        const sessionKey = `${prefix}main`;
+        try {
+          await client.call('chat.send', {
+            sessionKey,
+            message: '/reset',
+            idempotencyKey: `reset-${agent.id}-${Date.now()}`,
+          });
+          agentsReset.push({ agent_id: agent.id, name: agent.name, sessionKey, ok: true });
+        } catch (err) {
+          agentsReset.push({
+            agent_id: agent.id,
+            name: agent.name,
+            sessionKey,
+            ok: false,
+            error: (err as Error).message,
+          });
+        }
+      }
+    }
+
+    broadcast({
+      type: 'agent_completed',
+      payload: { reset: true, count, agents_reset: agentsReset.length, deleted: true },
+    });
+
+    return NextResponse.json({
+      success: true,
+      deleted: count,
+      agents_reset: agentsReset,
+    });
+  } catch (error) {
+    console.error('Failed to reset OpenClaw sessions:', error);
+    return NextResponse.json(
+      { error: `Failed to reset sessions: ${(error as Error).message}` },
       { status: 500 }
     );
   }

--- a/src/app/api/tasks/[id]/activities/route.ts
+++ b/src/app/api/tasks/[id]/activities/route.ts
@@ -7,6 +7,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/db';
 import { broadcast } from '@/lib/events';
 import { CreateActivitySchema } from '@/lib/validation';
+import { logDebugEvent } from '@/lib/debug-log';
 import type { TaskActivity } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -148,6 +149,15 @@ export async function POST(
     broadcast({
       type: 'activity_logged',
       payload: result,
+    });
+
+    logDebugEvent({
+      type: 'agent.activity_post',
+      direction: 'inbound',
+      taskId,
+      agentId: agent_id ?? null,
+      requestBody: body,
+      metadata: { activity_type },
     });
 
     return NextResponse.json(result, { status: 201 });

--- a/src/app/api/tasks/[id]/admin/release-stall/route.ts
+++ b/src/app/api/tasks/[id]/admin/release-stall/route.ts
@@ -1,0 +1,165 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { v4 as uuidv4 } from 'uuid';
+import { queryOne, queryAll, run, transaction } from '@/lib/db';
+import { broadcast } from '@/lib/events';
+import { ReleaseStallSchema } from '@/lib/validation';
+import type { Task } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/tasks/[id]/admin/release-stall
+ *
+ * Admin escape hatch for stalled tasks that cannot clear the evidence gate.
+ * Terminates the task (default: cancelled), ends all OpenClaw sessions for
+ * the task and — if this is a convoy parent — for every convoy sub-task too,
+ * unassigns the agent, and writes audit trail to both task_activities and
+ * events.
+ *
+ * Auth: relies on the middleware bearer-token check (same as other admin
+ * endpoints — see src/middleware.ts). No additional role logic.
+ *
+ * Body:
+ *   reason:           required, 1..500 chars
+ *   terminal_state:   'cancelled' (default) | 'done'
+ *   released_by:      optional audit string (operator name, token hint, etc)
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: taskId } = await params;
+
+  try {
+    const body = await request.json().catch(() => ({}));
+    const validation = ReleaseStallSchema.safeParse(body);
+    if (!validation.success) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: validation.error.issues },
+        { status: 400 }
+      );
+    }
+
+    const { reason, terminal_state = 'cancelled', released_by } = validation.data;
+
+    const existing = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
+    if (!existing) {
+      return NextResponse.json({ error: 'Task not found' }, { status: 404 });
+    }
+
+    const now = new Date().toISOString();
+    const statusReason = `released_by_admin: ${reason}`;
+
+    // If this task is a convoy parent, collect sub-task ids so we can end
+    // sessions for every convoy member, not just the primary assignee.
+    const convoy = queryOne<{ id: string }>(
+      'SELECT id FROM convoys WHERE parent_task_id = ?',
+      [taskId]
+    );
+    const convoySubtaskIds = convoy
+      ? queryAll<{ task_id: string }>(
+          'SELECT task_id FROM convoy_subtasks WHERE convoy_id = ?',
+          [convoy.id]
+        ).map(r => r.task_id)
+      : [];
+    const sessionTaskIds = [taskId, ...convoySubtaskIds];
+
+    transaction(() => {
+      // 1. End all active OpenClaw sessions bound to this task or any
+      //    convoy sub-task. Matches the session-end shape used by
+      //    nudgeAgent() in src/lib/agent-health.ts.
+      const placeholders = sessionTaskIds.map(() => '?').join(',');
+      run(
+        `UPDATE openclaw_sessions
+         SET status = 'ended', ended_at = ?, updated_at = ?
+         WHERE task_id IN (${placeholders}) AND status = 'active'`,
+        [now, now, ...sessionTaskIds]
+      );
+
+      // 2. Flip the parent task to the terminal state. Clear the assignee
+      //    so the ex-agent can pick up other work via the standby sweep.
+      run(
+        `UPDATE tasks
+         SET status = ?, status_reason = ?, assigned_agent_id = NULL,
+             planning_dispatch_error = NULL, updated_at = ?
+         WHERE id = ?`,
+        [terminal_state, statusReason, now, taskId]
+      );
+
+      // 3. Audit row inside the task so it shows up in the Activity tab.
+      run(
+        `INSERT INTO task_activities (id, task_id, agent_id, activity_type, message, created_at)
+         VALUES (?, ?, ?, 'admin_release', ?, ?)`,
+        [
+          uuidv4(),
+          taskId,
+          existing.assigned_agent_id || null,
+          `Admin release-stall → ${terminal_state}: ${reason}${released_by ? ` (by ${released_by})` : ''}`,
+          now,
+        ]
+      );
+
+      // 4. System-level audit event. Mirrors the shape used by
+      //    auditBoardOverride() in src/lib/task-governance.ts.
+      run(
+        `INSERT INTO events (id, type, task_id, message, metadata, created_at)
+         VALUES (?, 'system', ?, ?, ?, ?)`,
+        [
+          uuidv4(),
+          taskId,
+          `Admin release-stall: ${existing.status} → ${terminal_state}`,
+          JSON.stringify({ adminRelease: true, reason, released_by: released_by || null, convoy_dissolved: Boolean(convoy) }),
+          now,
+        ]
+      );
+
+      // 5. If this was a convoy parent, mark the convoy as failed so the
+      //    coordinator UI reflects the dissolution. We don't touch the
+      //    sub-tasks — they'll be DELETEd / released individually if needed.
+      if (convoy) {
+        run(
+          `UPDATE convoys SET status = 'failed', updated_at = ? WHERE id = ?`,
+          [now, convoy.id]
+        );
+      }
+
+      // 6. Return the previously-assigned agent to standby if they have no
+      //    other active work. Same shape as in DELETE + PATCH handlers.
+      if (existing.assigned_agent_id) {
+        const otherActive = queryOne<{ count: number }>(
+          `SELECT COUNT(*) as count FROM tasks
+           WHERE assigned_agent_id = ?
+             AND status IN ('assigned', 'in_progress', 'testing', 'verification')
+             AND id != ?`,
+          [existing.assigned_agent_id, taskId]
+        );
+        if (!otherActive || otherActive.count === 0) {
+          run(
+            `UPDATE agents SET status = 'standby', updated_at = ?
+             WHERE id = ? AND status = 'working'`,
+            [now, existing.assigned_agent_id]
+          );
+        }
+      }
+    });
+
+    const updated = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
+    if (updated) {
+      broadcast({ type: 'task_updated', payload: updated });
+    }
+
+    return NextResponse.json({
+      success: true,
+      task: updated,
+      previous_status: existing.status,
+      sessions_ended: sessionTaskIds.length,
+      convoy_dissolved: Boolean(convoy),
+    });
+  } catch (error) {
+    console.error('Failed to release-stall task:', error);
+    return NextResponse.json(
+      { error: `Failed to release-stall task: ${(error as Error).message}` },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/tasks/[id]/archive/route.ts
+++ b/src/app/api/tasks/[id]/archive/route.ts
@@ -1,0 +1,64 @@
+/**
+ * Archive / unarchive a task.
+ *
+ * Archive is orthogonal to status: any task can be archived and its status is
+ * untouched. The board hides is_archived=1 by default. Deliverables stay put,
+ * so an archived task can still be revisited and re-downloaded.
+ *
+ * POST body: { archived: true | false } (defaults to true)
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/db';
+import { broadcast } from '@/lib/events';
+import type { Task } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const db = getDb();
+  const existing = db.prepare(`SELECT id FROM tasks WHERE id = ?`).get(params.id) as
+    | { id: string }
+    | undefined;
+  if (!existing) {
+    return NextResponse.json({ error: 'Task not found' }, { status: 404 });
+  }
+
+  let archived = true;
+  try {
+    const body = await request.json().catch(() => ({}));
+    if (body && typeof body.archived === 'boolean') archived = body.archived;
+  } catch {
+    // empty/invalid body is fine — default to archiving
+  }
+
+  if (archived) {
+    db.prepare(`
+      UPDATE tasks
+         SET is_archived = 1,
+             archived_at = datetime('now'),
+             updated_at = datetime('now')
+       WHERE id = ?
+    `).run(params.id);
+  } else {
+    db.prepare(`
+      UPDATE tasks
+         SET is_archived = 0,
+             archived_at = NULL,
+             updated_at = datetime('now')
+       WHERE id = ?
+    `).run(params.id);
+  }
+
+  const task = db.prepare(`SELECT * FROM tasks WHERE id = ?`).get(params.id) as Task;
+
+  broadcast({
+    type: archived ? 'task_archived' : 'task_unarchived',
+    payload: task,
+  });
+
+  return NextResponse.json(task);
+}

--- a/src/app/api/tasks/[id]/convoy/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/convoy/dispatch/route.ts
@@ -58,10 +58,16 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       const task = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [subtask.task_id]);
       if (!task) continue;
 
-      // Auto-assign agent if not assigned
+      // Auto-assign agent if not assigned. Use the decomposition's role hint
+      // so researcher/writer/reviewer sub-tasks reach their own agent;
+      // `pickDynamicAgent` falls back to any non-offline agent if no match
+      // for the role exists (see src/lib/task-governance.ts). Prior to this,
+      // every sub-task passed 'builder' here — which is why every sub-task
+      // in a convoy landed on the single builder agent.
       let agentId = task.assigned_agent_id;
       if (!agentId) {
-        const picked = pickDynamicAgent(subtask.task_id, 'builder');
+        const roleHint = subtask.suggested_role || 'builder';
+        const picked = pickDynamicAgent(subtask.task_id, roleHint);
         if (picked) {
           agentId = picked.id;
           run('UPDATE tasks SET assigned_agent_id = ?, updated_at = datetime(\'now\') WHERE id = ?', [agentId, subtask.task_id]);

--- a/src/app/api/tasks/[id]/convoy/route.ts
+++ b/src/app/api/tasks/[id]/convoy/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createConvoy, getConvoy, updateConvoyStatus, deleteConvoy } from '@/lib/convoy';
 import { queryOne, queryAll } from '@/lib/db';
 import { getOpenClawClient } from '@/lib/openclaw/client';
+import { resolveAgentSessionKeyPrefix } from '@/lib/openclaw/session-key';
 import { extractJSON, getMessagesFromOpenClaw } from '@/lib/planning-utils';
 import {
   getAgentRoster,
@@ -172,8 +173,10 @@ async function runAIDecomposition(task: Task): Promise<{
     await client.connect();
   }
 
-  // Create a unique session key for this decomposition
-  const prefix = masterAgent.session_key_prefix || 'agent:main:';
+  // Create a unique session key for this decomposition. Uses the agent's
+  // own namespace (gateway_agent_id or name) rather than the old `agent:main:`
+  // default that misrouted messages to the gateway's main agent.
+  const prefix = resolveAgentSessionKeyPrefix(masterAgent);
   const sessionKey = `${prefix}decompose:${task.id}`;
 
   const prompt = buildDecompositionPrompt(task, roster);

--- a/src/app/api/tasks/[id]/convoy/route.ts
+++ b/src/app/api/tasks/[id]/convoy/route.ts
@@ -63,7 +63,7 @@ Respond with ONLY valid JSON in this exact format:
  * Run AI decomposition via OpenClaw: send prompt, poll for response, parse sub-tasks.
  */
 async function runAIDecomposition(task: Task): Promise<{
-  subtasks: Array<{ title: string; description?: string; depends_on?: string[] }>;
+  subtasks: Array<{ title: string; description?: string; depends_on?: string[]; suggested_role?: string }>;
   reasoning: string;
 }> {
   // Find master agent for this workspace
@@ -125,6 +125,12 @@ async function runAIDecomposition(task: Task): Promise<{
             title: st.title,
             description: st.description,
             depends_on: st.depends_on,
+            // Preserve the AI's per-sub-task role hint so convoy dispatch can
+            // route researcher/writer/reviewer work to the right agent. Before
+            // this, the role was dropped here and dispatch fell back to the
+            // hardcoded 'builder' in convoy/dispatch/route.ts — every sub-task
+            // landed on whichever agent had role='builder'.
+            suggested_role: st.suggested_role,
           })),
           reasoning: parsed.reasoning || 'AI decomposition',
         };
@@ -143,7 +149,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     const { strategy = 'manual', name, subtasks, decomposition_spec } = body as {
       strategy?: DecompositionStrategy;
       name?: string;
-      subtasks?: Array<{ title: string; description?: string; agent_id?: string; depends_on?: string[] }>;
+      subtasks?: Array<{ title: string; description?: string; agent_id?: string; depends_on?: string[]; suggested_role?: string }>;
       decomposition_spec?: string;
     };
 

--- a/src/app/api/tasks/[id]/convoy/route.ts
+++ b/src/app/api/tasks/[id]/convoy/route.ts
@@ -3,6 +3,15 @@ import { createConvoy, getConvoy, updateConvoyStatus, deleteConvoy } from '@/lib
 import { queryOne, queryAll } from '@/lib/db';
 import { getOpenClawClient } from '@/lib/openclaw/client';
 import { extractJSON, getMessagesFromOpenClaw } from '@/lib/planning-utils';
+import {
+  getAgentRoster,
+  formatRosterForPrompt,
+  verifyAgentInWorkspace,
+  MAX_CONVOY_SUBTASKS,
+  MAX_TASKS_PER_AGENT,
+  MIN_NEW_AGENT_RATIONALE_LENGTH,
+  type RosterAgent,
+} from '@/lib/agent-resolver';
 import type { Task, Agent, ConvoyStatus, DecompositionStrategy } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -14,11 +23,27 @@ interface RouteParams {
   params: Promise<{ id: string }>;
 }
 
+interface ParsedSubtask {
+  title: string;
+  description?: string;
+  suggested_role?: string;
+  agent_id?: string | null;
+  agent_name?: string;
+  rationale?: string;
+  depends_on?: string[];
+}
+
 /**
- * Build the AI decomposition prompt from the task's spec and description.
+ * Build the AI decomposition prompt from the task's spec and description,
+ * injecting the current agent roster so the LLM can assign sub-tasks to
+ * existing agents by id instead of silently producing ghosts.
  */
-function buildDecompositionPrompt(task: Task): string {
+function buildDecompositionPrompt(task: Task, roster: RosterAgent[]): string {
   const specSection = task.description || 'No description provided.';
+  const rosterBlock = formatRosterForPrompt(roster);
+  const createPolicy = roster.length === 0
+    ? 'No existing agents. Set agent_id to null for every sub-task.'
+    : 'Prefer assigning sub-tasks to agents in the roster above. Only set agent_id to null when no listed agent is a reasonable fit; in that case you MUST provide a specific rationale naming the capability or capacity gap.';
 
   return `TASK DECOMPOSITION REQUEST
 
@@ -28,43 +53,107 @@ You are decomposing a task into parallel sub-tasks for a convoy (multi-agent par
 **Description/Spec:**
 ${specSection}
 
-Analyze this task and break it into independent sub-tasks that can be worked on in parallel by different agents. Each sub-task should be a self-contained unit of work.
+AVAILABLE AGENTS (workspace roster):
+${rosterBlock}
+
+${createPolicy}
 
 Rules:
-- Create 2-6 sub-tasks (prefer fewer, larger sub-tasks over many tiny ones)
-- Each sub-task must have a clear, actionable title and description
-- Identify dependencies: if sub-task C requires output from A and B, declare it
-- Dependencies reference other sub-tasks by their zero-based index (e.g. "subtask-0", "subtask-1")
-- Sub-tasks WITHOUT dependencies will run in parallel immediately
-- Sub-tasks WITH dependencies wait until all dependencies complete
-- Suggest a role for each sub-task (e.g. "developer", "designer", "writer")
+- Plan no more than ${MAX_CONVOY_SUBTASKS} sub-tasks. If the task is too big for that, plan the first ${MAX_CONVOY_SUBTASKS} and describe what was left out in "deferred".
+- Each sub-task must have a clear, actionable title and description.
+- Identify dependencies: if sub-task C requires output from A and B, declare it.
+- Dependencies reference other sub-tasks by their zero-based index (e.g. "subtask-0", "subtask-1").
+- Sub-tasks WITHOUT dependencies run in parallel immediately.
+- Do not assign more than ${MAX_TASKS_PER_AGENT} sub-tasks to the same agent_id; if more work exists for a role, prefer creating a new agent over overloading.
+- Prefer agents with status "standby" over "working".
+- For each sub-task include "agent_id" (from the roster above) OR null, plus "suggested_role" (human-readable), and a "rationale" explaining the choice.
+- If agent_id is null, "rationale" must name the specific capability gap — "no suitable agent" is not acceptable.
 
-Respond with ONLY valid JSON in this exact format:
+Respond with ONLY valid JSON — no markdown fences, no commentary — in this exact shape:
 {
   "reasoning": "Brief explanation of how you decomposed this task",
+  "deferred": "optional — what was left out when capped at ${MAX_CONVOY_SUBTASKS} sub-tasks",
   "subtasks": [
     {
       "title": "Sub-task title",
       "description": "Detailed description of what this sub-task should accomplish",
-      "suggested_role": "developer",
+      "suggested_role": "researcher",
+      "agent_id": "<existing agent id from roster, or null>",
+      "agent_name": "<name for new agent, only when agent_id is null>",
+      "rationale": "Why this agent was chosen, or why a new agent is required",
       "depends_on": []
-    },
-    {
-      "title": "Another sub-task",
-      "description": "Description...",
-      "suggested_role": "developer",
-      "depends_on": ["subtask-0"]
     }
   ]
 }`;
 }
 
 /**
+ * Validate the LLM's plan against the guardrails (subtask cap, per-agent load
+ * limit, hallucinated agent ids, required rationale for new agents). Mutates
+ * each subtask's agent_id to null when validation fails for that subtask, so
+ * the caller falls back to creating a new agent rather than assigning to a
+ * non-existent one. Returns any validation problems for logging.
+ */
+function validateConvoyPlan(
+  subtasks: ParsedSubtask[],
+  workspaceId: string,
+): { errors: string[]; warnings: string[] } {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  if (subtasks.length > MAX_CONVOY_SUBTASKS) {
+    errors.push(`Plan has ${subtasks.length} sub-tasks, exceeds cap of ${MAX_CONVOY_SUBTASKS}`);
+  }
+
+  const assignmentCounts = new Map<string, number>();
+
+  for (const subtask of subtasks) {
+    if (subtask.agent_id) {
+      const agent = verifyAgentInWorkspace(workspaceId, subtask.agent_id);
+      if (!agent) {
+        warnings.push(
+          `LLM returned unknown agent_id ${subtask.agent_id} for sub-task "${subtask.title}" — will fall back to role-based pick`,
+        );
+        subtask.agent_id = null;
+      } else {
+        const next = (assignmentCounts.get(subtask.agent_id) ?? 0) + 1;
+        assignmentCounts.set(subtask.agent_id, next);
+        if (next > MAX_TASKS_PER_AGENT) {
+          warnings.push(
+            `Agent ${agent.name} (${subtask.agent_id}) assigned ${next} sub-tasks, exceeds per-agent load limit of ${MAX_TASKS_PER_AGENT} — dropping this assignment`,
+          );
+          subtask.agent_id = null;
+        }
+      }
+    }
+
+    if (subtask.agent_id == null) {
+      const rationale = (subtask.rationale ?? '').trim();
+      if (rationale.length < MIN_NEW_AGENT_RATIONALE_LENGTH) {
+        warnings.push(
+          `Sub-task "${subtask.title}" requests a new agent without a specific rationale (got "${rationale}") — dispatch will fall back to the role-based pick instead of auto-creating`,
+        );
+      }
+    }
+  }
+
+  return { errors, warnings };
+}
+
+/**
  * Run AI decomposition via OpenClaw: send prompt, poll for response, parse sub-tasks.
  */
 async function runAIDecomposition(task: Task): Promise<{
-  subtasks: Array<{ title: string; description?: string; depends_on?: string[]; suggested_role?: string }>;
+  subtasks: Array<{
+    title: string;
+    description?: string;
+    depends_on?: string[];
+    suggested_role?: string;
+    agent_id?: string | null;
+  }>;
   reasoning: string;
+  deferred?: string;
+  warnings: string[];
 }> {
   // Find master agent for this workspace
   const masterAgent = queryOne<Agent>(
@@ -76,6 +165,8 @@ async function runAIDecomposition(task: Task): Promise<{
     throw new Error('No master agent available for AI decomposition');
   }
 
+  const roster = getAgentRoster(task.workspace_id);
+
   const client = getOpenClawClient();
   if (!client.isConnected()) {
     await client.connect();
@@ -85,7 +176,7 @@ async function runAIDecomposition(task: Task): Promise<{
   const prefix = masterAgent.session_key_prefix || 'agent:main:';
   const sessionKey = `${prefix}decompose:${task.id}`;
 
-  const prompt = buildDecompositionPrompt(task);
+  const prompt = buildDecompositionPrompt(task, roster);
 
   // Send the decomposition prompt
   await client.call('chat.send', {
@@ -109,30 +200,32 @@ async function runAIDecomposition(task: Task): Promise<{
 
       const parsed = extractJSON(msg.content) as {
         reasoning?: string;
-        subtasks?: Array<{
-          title: string;
-          description?: string;
-          suggested_role?: string;
-          depends_on?: string[];
-        }>;
+        deferred?: string;
+        subtasks?: ParsedSubtask[];
       } | null;
 
       if (parsed?.subtasks && Array.isArray(parsed.subtasks) && parsed.subtasks.length > 0) {
-        // Convert subtask index references (e.g. "subtask-0") to task IDs later
-        // For now, keep them as-is — they'll be resolved during convoy creation
+        const subtasks = parsed.subtasks.slice(0, MAX_CONVOY_SUBTASKS);
+        const { errors, warnings } = validateConvoyPlan(subtasks, task.workspace_id);
+        if (errors.length > 0) {
+          throw new Error(`Convoy plan rejected: ${errors.join('; ')}`);
+        }
+        for (const w of warnings) console.warn(`[Convoy Decomposition] ${w}`);
+
         return {
-          subtasks: parsed.subtasks.map(st => ({
+          subtasks: subtasks.map(st => ({
             title: st.title,
             description: st.description,
             depends_on: st.depends_on,
-            // Preserve the AI's per-sub-task role hint so convoy dispatch can
-            // route researcher/writer/reviewer work to the right agent. Before
-            // this, the role was dropped here and dispatch fell back to the
-            // hardcoded 'builder' in convoy/dispatch/route.ts — every sub-task
-            // landed on whichever agent had role='builder'.
             suggested_role: st.suggested_role,
+            // Pass the LLM's validated agent choice through to createConvoy so
+            // the sub-task row is pre-assigned. Null means "let dispatch pick
+            // by role" — which is the non-breaking fallback for empty rosters.
+            agent_id: st.agent_id ?? null,
           })),
           reasoning: parsed.reasoning || 'AI decomposition',
+          deferred: parsed.deferred,
+          warnings,
         };
       }
     }
@@ -167,11 +260,18 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           parentTaskId: id,
           name: name || task.title,
           strategy: 'ai',
-          decompositionSpec: JSON.stringify({ reasoning: result.reasoning }),
+          decompositionSpec: JSON.stringify({
+            reasoning: result.reasoning,
+            deferred: result.deferred,
+            warnings: result.warnings,
+          }),
           subtasks: result.subtasks,
         });
 
-        return NextResponse.json({ ...convoy, ai_reasoning: result.reasoning }, { status: 201 });
+        return NextResponse.json(
+          { ...convoy, ai_reasoning: result.reasoning, ai_deferred: result.deferred, warnings: result.warnings },
+          { status: 201 },
+        );
       } catch (err) {
         const message = err instanceof Error ? err.message : 'AI decomposition failed';
         return NextResponse.json({ error: message }, { status: 500 });

--- a/src/app/api/tasks/[id]/deliverables/download/route.ts
+++ b/src/app/api/tasks/[id]/deliverables/download/route.ts
@@ -1,0 +1,92 @@
+/**
+ * Download all file deliverables for a task as a zip.
+ *
+ * Skips URL/artifact types. Skips file deliverables that can't be read (404
+ * from the storage helper) — the rest still go into the archive.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { PassThrough } from 'stream';
+import { Readable } from 'stream';
+import path from 'path';
+import archiver from 'archiver';
+import { getDb } from '@/lib/db';
+import {
+  resolveDeliverableReadPath,
+  DeliverableReadError,
+} from '@/lib/deliverables/storage';
+import type { Task, TaskDeliverable } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const db = getDb();
+  const task = db.prepare(`SELECT id, title FROM tasks WHERE id = ?`).get(params.id) as
+    | Pick<Task, 'id' | 'title'>
+    | undefined;
+
+  if (!task) {
+    return NextResponse.json({ error: 'Task not found' }, { status: 404 });
+  }
+
+  const deliverables = db.prepare(`
+    SELECT * FROM task_deliverables
+    WHERE task_id = ? AND deliverable_type = 'file'
+    ORDER BY created_at ASC
+  `).all(params.id) as TaskDeliverable[];
+
+  const entries: { absPath: string; name: string }[] = [];
+  for (const d of deliverables) {
+    try {
+      const absPath = resolveDeliverableReadPath(d);
+      // Entry name is suffixed with the deliverable id to keep archive entries
+      // unique even when two deliverables share a filename.
+      const ext = path.extname(absPath);
+      const base = path.basename(absPath, ext);
+      entries.push({ absPath, name: `${base}-${d.id}${ext}` });
+    } catch (e) {
+      if (e instanceof DeliverableReadError) {
+        // Silently skip unreadable rows — don't fail the whole zip.
+        console.warn(`[deliverables zip] Skipping ${d.id}: ${e.message}`);
+        continue;
+      }
+      throw e;
+    }
+  }
+
+  if (entries.length === 0) {
+    return NextResponse.json(
+      { error: 'No downloadable deliverables for this task' },
+      { status: 404 }
+    );
+  }
+
+  const archive = archiver('zip', { zlib: { level: 6 } });
+  const pass = new PassThrough();
+  archive.pipe(pass);
+
+  for (const entry of entries) {
+    archive.file(entry.absPath, { name: entry.name });
+  }
+  archive.finalize();
+
+  archive.on('error', (err) => {
+    console.error('[deliverables zip] archive error', err);
+    pass.destroy(err);
+  });
+
+  const slug = (task.title || 'task').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'task';
+  const zipName = `${slug}-deliverables.zip`;
+
+  const webStream = Readable.toWeb(pass) as unknown as ReadableStream;
+  return new NextResponse(webStream, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/zip',
+      'Content-Disposition': `attachment; filename="${encodeURIComponent(zipName)}"`,
+    },
+  });
+}

--- a/src/app/api/tasks/[id]/deliverables/route.ts
+++ b/src/app/api/tasks/[id]/deliverables/route.ts
@@ -9,8 +9,13 @@ import { broadcast } from '@/lib/events';
 import { CreateDeliverableSchema } from '@/lib/validation';
 import { logDebugEvent } from '@/lib/debug-log';
 import { existsSync } from 'fs';
+import {
+  isUnderDeliverablesHostRoot,
+  hostPathToContainerPath,
+  fileSizeBytes,
+} from '@/lib/deliverables/storage';
 
-import type { TaskDeliverable } from '@/lib/types';
+import type { TaskDeliverable, DeliverableStorageScheme } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
 /**
@@ -65,13 +70,35 @@ export async function POST(
 
     const { deliverable_type, title, path, description } = validation.data;
 
-    // Validate file existence for file deliverables
+    // Reject the reserved ssh:// prefix — the column is widened for future
+    // remote storage, but nothing reads it yet. Failing here avoids half-wired
+    // deliverables accumulating.
+    if (path && path.startsWith('ssh://')) {
+      return NextResponse.json(
+        { error: 'Remote (ssh://) deliverable storage is not yet supported' },
+        { status: 501 }
+      );
+    }
+
+    // Decide storage_scheme + capture file metadata.
+    let storageScheme: DeliverableStorageScheme = 'host';
+    let sizeBytes: number | undefined;
     let fileExists = true;
     let normalizedPath = path;
+
     if (deliverable_type === 'file' && path) {
-      // Expand tilde
       normalizedPath = path.replace(/^~/, process.env.HOME || '');
-      fileExists = existsSync(normalizedPath);
+      if (isUnderDeliverablesHostRoot(path)) {
+        storageScheme = 'mc';
+        // Existence + size measured against the container-perspective path
+        // (MC reads from there; the path the agent wrote is host-perspective).
+        const containerPath = hostPathToContainerPath(path);
+        fileExists = existsSync(containerPath);
+        if (fileExists) sizeBytes = fileSizeBytes(containerPath);
+      } else {
+        // Legacy host-path: just use as-given (tilde-expanded).
+        fileExists = existsSync(normalizedPath);
+      }
       if (!fileExists) {
         console.warn(`[DELIVERABLE] Warning: File does not exist: ${normalizedPath}`);
       }
@@ -82,15 +109,17 @@ export async function POST(
 
     // Insert deliverable
     db.prepare(`
-      INSERT INTO task_deliverables (id, task_id, deliverable_type, title, path, description)
-      VALUES (?, ?, ?, ?, ?, ?)
+      INSERT INTO task_deliverables (id, task_id, deliverable_type, title, path, description, storage_scheme, size_bytes)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       id,
       taskId,
       deliverable_type,
       title,
       path || null,
-      description || null
+      description || null,
+      storageScheme,
+      sizeBytes ?? null
     );
 
     // Get the created deliverable

--- a/src/app/api/tasks/[id]/deliverables/route.ts
+++ b/src/app/api/tasks/[id]/deliverables/route.ts
@@ -7,6 +7,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/db';
 import { broadcast } from '@/lib/events';
 import { CreateDeliverableSchema } from '@/lib/validation';
+import { logDebugEvent } from '@/lib/debug-log';
 import { existsSync } from 'fs';
 
 import type { TaskDeliverable } from '@/lib/types';
@@ -103,6 +104,14 @@ export async function POST(
     broadcast({
       type: 'deliverable_added',
       payload: deliverable,
+    });
+
+    logDebugEvent({
+      type: 'agent.deliverable_post',
+      direction: 'inbound',
+      taskId,
+      requestBody: body,
+      metadata: { deliverable_type, title, file_exists: fileExists },
     });
 
     // Return with warning if file doesn't exist

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -10,6 +10,7 @@ import { syncGatewayAgentsToCatalog } from '@/lib/agent-catalog-sync';
 import { pickDynamicAgent } from '@/lib/task-governance';
 import { buildCheckpointContext, saveCheckpoint, getLatestCheckpoint } from '@/lib/checkpoint';
 import { clearStallFlag } from '@/lib/stall-detection';
+import { logDebugEvent } from '@/lib/debug-log';
 import { formatMailForDispatch } from '@/lib/mailbox';
 import { getPendingNotesForDispatch } from '@/lib/task-notes';
 import { createTaskWorkspace, determineIsolationStrategy } from '@/lib/workspace-isolation';
@@ -440,11 +441,42 @@ If you need help or clarification, ask the orchestrator.`;
       // Format: {prefix}{openclaw_session_id} where prefix defaults to 'agent:main:'
       const prefix = agent.session_key_prefix || 'agent:main:';
       const sessionKey = `${prefix}${session.openclaw_session_id}`;
-      await client.call('chat.send', {
-        sessionKey,
-        message: finalMessage,
-        idempotencyKey: `dispatch-${task.id}-${Date.now()}`
-      });
+      const idempotencyKey = `dispatch-${task.id}-${Date.now()}`;
+      const chatSendStart = Date.now();
+      let chatSendResponse: unknown;
+      let chatSendError: string | null = null;
+      try {
+        chatSendResponse = await client.call('chat.send', {
+          sessionKey,
+          message: finalMessage,
+          idempotencyKey,
+        });
+      } catch (err) {
+        chatSendError = (err as Error).message;
+        throw err; // preserve existing error-path behavior below
+      } finally {
+        // Debug console capture. No-op unless collection is enabled. Stores
+        // the full dispatch payload so operators can see exactly what the
+        // agent was asked to do — including injected knowledge, checkpoint
+        // context, and planning spec.
+        logDebugEvent({
+          type: 'chat.send',
+          direction: 'outbound',
+          taskId: task.id,
+          agentId: agent.id,
+          sessionKey,
+          durationMs: Date.now() - chatSendStart,
+          requestBody: { sessionKey, message: finalMessage, idempotencyKey },
+          responseBody: chatSendResponse,
+          error: chatSendError,
+          metadata: {
+            agent_name: agent.name,
+            agent_role: (agent as { role?: string }).role ?? null,
+            message_length: finalMessage.length,
+            task_status: task.status,
+          },
+        });
+      }
 
       // Only move to in_progress for builder dispatch (task is in 'assigned' status)
       // For tester/reviewer/verifier, the task status is already correct

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -340,6 +340,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           WHERE gateway_agent_id IS NOT NULL
             AND id != ?
             AND COALESCE(status, 'standby') != 'offline'
+            AND COALESCE(is_active, 1) = 1
           ORDER BY role ASC, name ASC`,
         [agent.id]
       );
@@ -515,9 +516,15 @@ If you need help or clarification, ask the orchestrator.`;
 
     // Send message to agent's session using chat.send
     try {
-      // Use sessionKey for routing to the agent's session
-      // Format: {prefix}{openclaw_session_id} where prefix defaults to 'agent:main:'
-      const prefix = agent.session_key_prefix || 'agent:main:';
+      // Use sessionKey for routing to the agent's session.
+      // Prefix defaults (via resolveAgentSessionKeyPrefix) are:
+      //   1. Explicit `agent.session_key_prefix` if set
+      //   2. `agent:<gateway_agent_id>:` for gateway-synced agents
+      //   3. `agent:<name-slug>:` as last resort
+      // The old hard-coded `agent:main:` catchall silently misrouted
+      // every MC→agent chat.send to the gateway's "main" agent.
+      const { resolveAgentSessionKeyPrefix } = await import('@/lib/openclaw/session-key');
+      const prefix = resolveAgentSessionKeyPrefix(agent);
       const sessionKey = `${prefix}${session.openclaw_session_id}`;
       const idempotencyKey = `dispatch-${task.id}-${Date.now()}`;
       const chatSendStart = Date.now();

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -8,7 +8,8 @@ import { getRelevantKnowledge, formatKnowledgeForDispatch } from '@/lib/learner'
 import { getTaskWorkflow } from '@/lib/workflow-engine';
 import { syncGatewayAgentsToCatalog } from '@/lib/agent-catalog-sync';
 import { pickDynamicAgent } from '@/lib/task-governance';
-import { buildCheckpointContext } from '@/lib/checkpoint';
+import { buildCheckpointContext, saveCheckpoint, getLatestCheckpoint } from '@/lib/checkpoint';
+import { clearStallFlag } from '@/lib/stall-detection';
 import { formatMailForDispatch } from '@/lib/mailbox';
 import { getPendingNotesForDispatch } from '@/lib/task-notes';
 import { createTaskWorkspace, determineIsolationStrategy } from '@/lib/workspace-isolation';
@@ -484,6 +485,37 @@ If you need help or clarification, ask the orchestrator.`;
          VALUES (?, ?, ?, ?, ?, ?)`,
         [activityId, task.id, agent.id, 'status_changed', `Task dispatched to ${agent.name} - Agent is now working on this task`, now]
       );
+
+      // A successful dispatch is the canonical "coordinator (or operator)
+      // has acted" signal. Clear any stalled_* status_reason so the
+      // scanner doesn't re-flag the task on its next pass.
+      clearStallFlag(task.id);
+
+      // Auto-checkpoint on dispatch. Throttled to 60s so rapid re-dispatch
+      // during nudge/recovery doesn't write duplicate rows. Gives
+      // checkpoint/restore a viable starting point even before the agent
+      // writes any of its own checkpoints — previously the restore route
+      // returned 404 for long-running tasks because nothing ever called
+      // saveCheckpoint().
+      try {
+        const latestCheckpoint = getLatestCheckpoint(task.id);
+        const recent = latestCheckpoint
+          && (Date.now() - new Date(latestCheckpoint.created_at).getTime()) / 1000 < 60;
+        if (!recent) {
+          saveCheckpoint({
+            taskId: task.id,
+            agentId: agent.id,
+            checkpointType: 'auto',
+            stateSummary: `Dispatched to ${agent.name} (status=${task.status}, role=${currentStage?.role || 'unknown'})`,
+            contextData: {
+              stage: currentStage?.label,
+              dispatch_message_length: finalMessage.length,
+            },
+          });
+        }
+      } catch (err) {
+        console.warn('[Dispatch] saveCheckpoint failed:', err);
+      }
 
       return NextResponse.json({
         success: true,

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -359,6 +359,17 @@ their persona, memory, and channel bindings.
       }
     }
 
+    // Every /api/tasks/* and /api/agents/* callback requires the MC bearer
+    // token when MC_API_TOKEN is set — which is always in practice, since
+    // unauthenticated dev mode is only for local experiments. Every
+    // completion-instruction branch embeds this header line so agents
+    // paste a ready-to-use curl rather than being told to POST to a URL
+    // and silently 401-ing.
+    const mcAuthToken = process.env.MC_API_TOKEN || '';
+    const authHeaderLine = mcAuthToken
+      ? `  -H "Authorization: Bearer ${mcAuthToken}" \\\n`
+      : '';
+
     let completionInstructions: string;
     if (isCoordinator) {
       completionInstructions = `**YOUR ROLE: COORDINATOR** — Break this task down and delegate to the persistent agents above. Track their progress and roll the results up to Mission Control.
@@ -369,25 +380,53 @@ their persona, memory, and channel bindings.
   - \`message\`: include the task id (\`${task.id}\`), the specific slice of work you want them to do, and any context they need. Prefix each message with \"You are the <role> for this task\" so they receive the role framing they would get from Mission Control directly.
   - \`timeoutSeconds\`: use \`0\` (fire-and-forget) for parallel work; use a positive value only when you need a synchronous reply.
 - **DO NOT use \`sessions_spawn\`** for this workflow. Spawned subagents inherit a stripped context (no SOUL.md/IDENTITY.md) and won't know the role they're meant to play. We want the pinned persona of the persistent agents.
-- If \`sessions_send\` is rejected with a permissions/allow-list error, surface that by calling \`${failEndpoint}\` with the error details — it means the OpenClaw allow-list needs to be updated for this coordinator.
+- If \`sessions_send\` is rejected with a permissions/allow-list error (e.g. *"Session send visibility is restricted"*), the OpenClaw allow-list on this coordinator needs \`tools.sessions.visibility: "all"\` — or an explicit list of peer agent ids. Surface the blocker via:
+  \`\`\`bash
+  curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/fail" \\
+    -H "Content-Type: application/json" \\
+${authHeaderLine}    -d '{"reason":"sessions_send blocked by allow-list: <error text>"}'
+  \`\`\`
 
-**TRACKING & REPORTING:**
-1. Log activity whenever you delegate or receive results: POST ${missionControlUrl}/api/tasks/${task.id}/activities
-   Body: {"activity_type": "updated", "message": "Delegated <slice> to <agent name>"}
-2. Register any deliverables the agents produce: POST ${missionControlUrl}/api/tasks/${task.id}/deliverables
-3. When the whole task is complete, update status: PATCH ${missionControlUrl}/api/tasks/${task.id}
-   Body: {"status": "${nextStatus}"}
+**TRACKING & REPORTING** (all calls require the Authorization header):
+
+\`\`\`bash
+# Log each delegation / receipt
+curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/activities" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"activity_type":"updated","message":"Delegated <slice> to <agent name>"}'
+
+# Register aggregated deliverable (after all peers report in)
+curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/deliverables" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"deliverable_type":"file","title":"<title>","path":"${taskProjectDir}/<filename>"}'
+
+# Close the task
+curl -sS -X PATCH "${missionControlUrl}/api/tasks/${task.id}" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"status":"${nextStatus}"}'
+\`\`\`
 
 When complete, reply with:
 \`TASK_COMPLETE: [summary of what was delegated, to whom, and the aggregate outcome]\``;
     } else if (isBuilder) {
-      completionInstructions = `**IMPORTANT:** After completing work, you MUST call these APIs:
-1. Log activity: POST ${missionControlUrl}/api/tasks/${task.id}/activities
-   Body: {"activity_type": "completed", "message": "Description of what was done"}
-2. Register deliverable: POST ${missionControlUrl}/api/tasks/${task.id}/deliverables
-   Body: {"deliverable_type": "file", "title": "File name", "path": "${taskProjectDir}/filename.html"}
-3. Update status: PATCH ${missionControlUrl}/api/tasks/${task.id}
-   Body: {"status": "${nextStatus}"}
+      completionInstructions = `**IMPORTANT:** After completing work, you MUST make these three calls in order — all require the Authorization header:
+
+\`\`\`bash
+# 1. Register deliverable
+curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/deliverables" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"deliverable_type":"file","title":"<file name>","path":"${taskProjectDir}/<filename>"}'
+
+# 2. Log activity (must have both a deliverable AND an activity before step 3 will pass the evidence gate)
+curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/activities" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"activity_type":"completed","message":"<what you built in one line>"}'
+
+# 3. Transition status
+curl -sS -X PATCH "${missionControlUrl}/api/tasks/${task.id}" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"status":"${nextStatus}"}'
+\`\`\`
 
 When complete, reply with:
 \`TASK_COMPLETE: [brief summary of what you did]\``;
@@ -396,15 +435,25 @@ When complete, reply with:
 
 Review the output directory for deliverables and run any applicable tests.
 
-**If tests PASS:**
-1. Log activity: POST ${missionControlUrl}/api/tasks/${task.id}/activities
-   Body: {"activity_type": "completed", "message": "Tests passed: [summary]"}
-2. Update status: PATCH ${missionControlUrl}/api/tasks/${task.id}
-   Body: {"status": "${nextStatus}"}
+**If tests PASS** — all calls require the Authorization header:
+
+\`\`\`bash
+curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/activities" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"activity_type":"completed","message":"Tests passed: <summary>"}'
+
+curl -sS -X PATCH "${missionControlUrl}/api/tasks/${task.id}" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"status":"${nextStatus}"}'
+\`\`\`
 
 **If tests FAIL:**
-1. ${failEndpoint}
-   Body: {"reason": "Detailed description of what failed and what needs fixing"}
+
+\`\`\`bash
+curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/fail" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"reason":"<detailed description of what failed and what needs fixing>"}'
+\`\`\`
 
 Reply with: \`TEST_PASS: [summary]\` or \`TEST_FAIL: [what failed]\``;
     } else if (isVerifier) {
@@ -412,22 +461,36 @@ Reply with: \`TEST_PASS: [summary]\` or \`TEST_FAIL: [what failed]\``;
 
 Review deliverables, test results, and task requirements.
 
-**If verification PASSES:**
-1. Log activity: POST ${missionControlUrl}/api/tasks/${task.id}/activities
-   Body: {"activity_type": "completed", "message": "Verification passed: [summary]"}
-2. Update status: PATCH ${missionControlUrl}/api/tasks/${task.id}
-   Body: {"status": "${nextStatus}"}
+**If verification PASSES** — all calls require the Authorization header:
+
+\`\`\`bash
+curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/activities" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"activity_type":"completed","message":"Verification passed: <summary>"}'
+
+curl -sS -X PATCH "${missionControlUrl}/api/tasks/${task.id}" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"status":"${nextStatus}"}'
+\`\`\`
 
 **If verification FAILS:**
-1. ${failEndpoint}
-   Body: {"reason": "Detailed description of what failed and what needs fixing"}
+
+\`\`\`bash
+curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/fail" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"reason":"<detailed description of what failed and what needs fixing>"}'
+\`\`\`
 
 Reply with: \`VERIFY_PASS: [summary]\` or \`VERIFY_FAIL: [what failed]\``;
     } else {
       // Fallback for unknown roles
-      completionInstructions = `**IMPORTANT:** After completing work:
-1. Update status: PATCH ${missionControlUrl}/api/tasks/${task.id}
-   Body: {"status": "${nextStatus}"}`;
+      completionInstructions = `**IMPORTANT:** After completing work, update status — the call requires the Authorization header:
+
+\`\`\`bash
+curl -sS -X PATCH "${missionControlUrl}/api/tasks/${task.id}" \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{"status":"${nextStatus}"}'
+\`\`\``;
     }
 
     // Build image references section

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -136,7 +136,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       // Create session record
       const sessionId = uuidv4();
       const openclawSessionId = `mission-control-${agent.name.toLowerCase().replace(/\s+/g, '-')}-${id}`;
-      
+
       run(
         `INSERT INTO openclaw_sessions (id, agent_id, openclaw_session_id, task_id, channel, status, created_at, updated_at)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -154,6 +154,18 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
          VALUES (?, ?, ?, ?, ?)`,
         [uuidv4(), 'agent_status_changed', agent.id, `${agent.name} session created`, now]
       );
+
+      logDebugEvent({
+        type: 'session.create',
+        direction: 'internal',
+        taskId: id,
+        agentId: agent.id,
+        sessionKey: openclawSessionId,
+        metadata: {
+          agent_name: agent.name,
+          reason: 'no_active_session_found',
+        },
+      });
     }
 
     if (!session) {
@@ -300,14 +312,74 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       }
     }
 
-    const isBuilder = !currentStage || currentStage.role === 'builder' || task.status === 'assigned';
-    const isTester = currentStage?.role === 'tester';
-    const isVerifier = currentStage?.role === 'verifier' || currentStage?.role === 'reviewer';
+    // Role detection. Coordinator/orchestrator must be checked *before*
+    // the builder fallback — `isBuilder` is true whenever `currentStage` is
+    // unresolved, which was bucketing coordinator dispatches as "go build
+    // something" and triggering the legacy sessions_spawn path.
+    const isCoordinator =
+      (agent as Agent & { role?: string }).role === 'coordinator' ||
+      (agent as Agent & { role?: string }).role === 'orchestrator' ||
+      Boolean(agent.is_master);
+    const isBuilder = !isCoordinator && (!currentStage || currentStage.role === 'builder' || task.status === 'assigned');
+    const isTester = !isCoordinator && currentStage?.role === 'tester';
+    const isVerifier = !isCoordinator && (currentStage?.role === 'verifier' || currentStage?.role === 'reviewer');
     const nextStatus = nextStage?.status || 'review';
     const failEndpoint = `POST ${missionControlUrl}/api/tasks/${task.id}/fail`;
 
+    // For coordinator dispatches, enumerate the persistent gateway-synced
+    // agents so the coordinator can delegate via `sessions_send` rather than
+    // spawning ephemeral subagents (which inherit a stripped context — no
+    // SOUL.md / IDENTITY.md — and are therefore "confused" about their
+    // role). We only list agents with a gateway_agent_id so local/test
+    // agents don't leak into the coordinator's dispatch surface.
+    let delegationRosterSection = '';
+    if (isCoordinator) {
+      const siblings = queryAll<{ id: string; name: string; role: string; gateway_agent_id: string }>(
+        `SELECT id, name, role, gateway_agent_id
+           FROM agents
+          WHERE gateway_agent_id IS NOT NULL
+            AND id != ?
+            AND COALESCE(status, 'standby') != 'offline'
+          ORDER BY role ASC, name ASC`,
+        [agent.id]
+      );
+      if (siblings.length > 0) {
+        const rosterLines = siblings
+          .map(s => `- **${s.name}** (role: \`${s.role}\`, gateway id: \`${s.gateway_agent_id}\`)`)
+          .join('\n');
+        delegationRosterSection = `\n---
+**👥 AVAILABLE PERSISTENT AGENTS — delegate here, do NOT spawn new ones:**
+${rosterLines}
+
+Each of these is a long-lived agent with its own pinned identity
+(\`SOUL.md\`, \`AGENTS.md\`, \`USER.md\`). Route work to them so they keep
+their persona, memory, and channel bindings.
+`;
+      }
+    }
+
     let completionInstructions: string;
-    if (isBuilder) {
+    if (isCoordinator) {
+      completionInstructions = `**YOUR ROLE: COORDINATOR** — Break this task down and delegate to the persistent agents above. Track their progress and roll the results up to Mission Control.
+
+**CRITICAL — HOW TO DELEGATE:**
+- Use the \`sessions_send\` tool (a.k.a. \`agent.send\`) to dispatch work to each persistent agent.
+  - \`sessionKey\`: call \`sessions_list\` first to discover the target agent's active session, or target its main session. The gateway ids above identify each agent.
+  - \`message\`: include the task id (\`${task.id}\`), the specific slice of work you want them to do, and any context they need. Prefix each message with \"You are the <role> for this task\" so they receive the role framing they would get from Mission Control directly.
+  - \`timeoutSeconds\`: use \`0\` (fire-and-forget) for parallel work; use a positive value only when you need a synchronous reply.
+- **DO NOT use \`sessions_spawn\`** for this workflow. Spawned subagents inherit a stripped context (no SOUL.md/IDENTITY.md) and won't know the role they're meant to play. We want the pinned persona of the persistent agents.
+- If \`sessions_send\` is rejected with a permissions/allow-list error, surface that by calling \`${failEndpoint}\` with the error details — it means the OpenClaw allow-list needs to be updated for this coordinator.
+
+**TRACKING & REPORTING:**
+1. Log activity whenever you delegate or receive results: POST ${missionControlUrl}/api/tasks/${task.id}/activities
+   Body: {"activity_type": "updated", "message": "Delegated <slice> to <agent name>"}
+2. Register any deliverables the agents produce: POST ${missionControlUrl}/api/tasks/${task.id}/deliverables
+3. When the whole task is complete, update status: PATCH ${missionControlUrl}/api/tasks/${task.id}
+   Body: {"status": "${nextStatus}"}
+
+When complete, reply with:
+\`TASK_COMPLETE: [summary of what was delegated, to whom, and the aggregate outcome]\``;
+    } else if (isBuilder) {
       completionInstructions = `**IMPORTANT:** After completing work, you MUST call these APIs:
 1. Log activity: POST ${missionControlUrl}/api/tasks/${task.id}/activities
    Body: {"activity_type": "completed", "message": "Description of what was done"}
@@ -415,18 +487,24 @@ Reply with: \`VERIFY_PASS: [summary]\` or \`VERIFY_FAIL: [what failed]\``;
     }
 
     const roleLabel = currentStage?.label || 'Task';
-    const taskMessage = `${priorityEmoji} **${isBuilder ? 'NEW TASK ASSIGNED' : `${roleLabel.toUpperCase()} STAGE — ${task.title}`}**
+    const headline = isCoordinator
+      ? `COORDINATOR DISPATCH — ${task.title}`
+      : isBuilder
+        ? 'NEW TASK ASSIGNED'
+        : `${roleLabel.toUpperCase()} STAGE — ${task.title}`;
+
+    const taskMessage = `${priorityEmoji} **${headline}**
 
 **Title:** ${task.title}
 ${task.description ? `**Description:** ${task.description}\n` : ''}
 **Priority:** ${task.priority.toUpperCase()}
 ${task.due_date ? `**Due:** ${task.due_date}\n` : ''}
 **Task ID:** ${task.id}
-${planningSpecSection}${agentInstructionsSection}${skillsSection}${knowledgeSection}${imagesSection}${buildCheckpointContext(task.id) || ''}${formatMailForDispatch(agent.id) || ''}${repoSection}
+${planningSpecSection}${agentInstructionsSection}${skillsSection}${knowledgeSection}${imagesSection}${buildCheckpointContext(task.id) || ''}${formatMailForDispatch(agent.id) || ''}${repoSection}${delegationRosterSection}
 ${isBuilder ? (workspaceIsolated
   ? `**\u{1F512} ISOLATED WORKSPACE:** ${taskProjectDir}\n- **Port:** ${workspacePort || 'default'} (use this for dev server, NOT the default)\n${workspaceBranchName ? `- **Branch:** ${workspaceBranchName}\n` : ''}- **IMPORTANT:** Do NOT modify files outside this workspace directory. Other agents may be working on the same project in parallel. All your work must stay within: ${taskProjectDir}\nCreate this directory if needed and save all deliverables there.\n`
   : `**OUTPUT DIRECTORY:** ${taskProjectDir}\nCreate this directory and save all deliverables there.\n`)
-: `**OUTPUT DIRECTORY:** ${taskProjectDir}\n`}
+: isCoordinator ? '' : `**OUTPUT DIRECTORY:** ${taskProjectDir}\n`}
 ${completionInstructions}
 
 If you need help or clarification, ask the orchestrator.`;

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -4,6 +4,7 @@ import { queryOne, queryAll, run } from '@/lib/db';
 import { getOpenClawClient } from '@/lib/openclaw/client';
 import { broadcast } from '@/lib/events';
 import { getProjectsPath, getMissionControlUrl } from '@/lib/config';
+import { getTaskDeliverableDir } from '@/lib/deliverables/storage';
 import { getRelevantKnowledge, formatKnowledgeForDispatch } from '@/lib/learner';
 import { getTaskWorkflow } from '@/lib/workflow-engine';
 import { syncGatewayAgentsToCatalog } from '@/lib/agent-catalog-sync';
@@ -203,11 +204,16 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       urgent: '🔴'
     }[task.priority] || '⚪';
 
-    // Get project path for deliverables — with workspace isolation if needed
+    // Get project path for working files — with workspace isolation if needed
     const projectsPath = getProjectsPath();
     const projectDir = task.title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
     let taskProjectDir = `${projectsPath}/${projectDir}`;
     const missionControlUrl = getMissionControlUrl();
+
+    // Deliverables directory: MC-managed location the agent writes FINAL
+    // deliverables into so they become web-downloadable. Separate from
+    // taskProjectDir, which may be an isolated worktree the agent codes in.
+    const deliverablesDir = getTaskDeliverableDir(task.id, 'host');
 
     // Create isolated workspace if parallel builds are possible
     // Only for builder dispatches (assigned/in_progress), not tester/reviewer
@@ -396,9 +402,10 @@ curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/activities" \\
 ${authHeaderLine}  -d '{"activity_type":"updated","message":"Delegated <slice> to <agent name>"}'
 
 # Register aggregated deliverable (after all peers report in)
+# Save the file to the **DELIVERABLES DIR** below so it becomes web-downloadable.
 curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/deliverables" \\
   -H "Content-Type: application/json" \\
-${authHeaderLine}  -d '{"deliverable_type":"file","title":"<title>","path":"${taskProjectDir}/<filename>"}'
+${authHeaderLine}  -d '{"deliverable_type":"file","title":"<title>","path":"${deliverablesDir}/<filename>"}'
 
 # Close the task
 curl -sS -X PATCH "${missionControlUrl}/api/tasks/${task.id}" \\
@@ -413,9 +420,10 @@ When complete, reply with:
 
 \`\`\`bash
 # 1. Register deliverable
+# Save the file to the **DELIVERABLES DIR** below so it becomes web-downloadable.
 curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/deliverables" \\
   -H "Content-Type: application/json" \\
-${authHeaderLine}  -d '{"deliverable_type":"file","title":"<file name>","path":"${taskProjectDir}/<filename>"}'
+${authHeaderLine}  -d '{"deliverable_type":"file","title":"<file name>","path":"${deliverablesDir}/<filename>"}'
 
 # 2. Log activity (must have both a deliverable AND an activity before step 3 will pass the evidence gate)
 curl -sS -X POST "${missionControlUrl}/api/tasks/${task.id}/activities" \\
@@ -566,9 +574,9 @@ ${task.due_date ? `**Due:** ${task.due_date}\n` : ''}
 **Task ID:** ${task.id}
 ${planningSpecSection}${agentInstructionsSection}${skillsSection}${knowledgeSection}${imagesSection}${buildCheckpointContext(task.id) || ''}${formatMailForDispatch(agent.id) || ''}${repoSection}${delegationRosterSection}
 ${isBuilder ? (workspaceIsolated
-  ? `**\u{1F512} ISOLATED WORKSPACE:** ${taskProjectDir}\n- **Port:** ${workspacePort || 'default'} (use this for dev server, NOT the default)\n${workspaceBranchName ? `- **Branch:** ${workspaceBranchName}\n` : ''}- **IMPORTANT:** Do NOT modify files outside this workspace directory. Other agents may be working on the same project in parallel. All your work must stay within: ${taskProjectDir}\nCreate this directory if needed and save all deliverables there.\n`
-  : `**OUTPUT DIRECTORY:** ${taskProjectDir}\nCreate this directory and save all deliverables there.\n`)
-: isCoordinator ? '' : `**OUTPUT DIRECTORY:** ${taskProjectDir}\n`}
+  ? `**\u{1F512} ISOLATED WORKSPACE:** ${taskProjectDir}\n- **Port:** ${workspacePort || 'default'} (use this for dev server, NOT the default)\n${workspaceBranchName ? `- **Branch:** ${workspaceBranchName}\n` : ''}- **IMPORTANT:** Do NOT modify files outside this workspace directory. Other agents may be working on the same project in parallel. All your work must stay within: ${taskProjectDir}\n**DELIVERABLES DIR (separate):** ${deliverablesDir}\nCreate ${deliverablesDir} and save final deliverables there so they become web-downloadable from Mission Control.\n`
+  : `**OUTPUT DIRECTORY:** ${taskProjectDir}\n**DELIVERABLES DIR:** ${deliverablesDir}\nCreate ${deliverablesDir} and save final deliverables there so they become web-downloadable from Mission Control.\n`)
+: isCoordinator ? `**DELIVERABLES DIR:** ${deliverablesDir}\nAggregated deliverables registered via the deliverables endpoint should be written to this directory so they become web-downloadable.\n` : `**OUTPUT DIRECTORY:** ${taskProjectDir}\n**DELIVERABLES DIR:** ${deliverablesDir}\nFinal deliverables should be saved to ${deliverablesDir} so they become web-downloadable.\n`}
 ${completionInstructions}
 
 If you need help or clarification, ask the orchestrator.`;

--- a/src/app/api/tasks/[id]/fail/route.ts
+++ b/src/app/api/tasks/[id]/fail/route.ts
@@ -50,8 +50,26 @@ export async function POST(
       failReason: reason,
     }).catch(err => console.error('[Learner] notification failed:', err));
 
-    // Trigger the fail-loopback via the workflow engine
-    const result = await handleStageFailure(taskId, task.status, reason);
+    // Trigger the fail-loopback via the workflow engine. Wrap in try/catch so
+    // an internal throw (e.g. DB error, dispatch timeout) returns a clean 400
+    // instead of the bare 500 "Internal server error" that masked the real
+    // problem before. Operators hitting this endpoint for stalled tasks got
+    // the opaque 500 and had no path forward — the admin release-stall
+    // endpoint now covers the "can't recover" case.
+    let result: Awaited<ReturnType<typeof handleStageFailure>>;
+    try {
+      result = await handleStageFailure(taskId, task.status, reason);
+    } catch (err) {
+      const message = (err as Error).message || 'handleStageFailure threw';
+      console.error('[Fail] handleStageFailure threw:', err);
+      return NextResponse.json(
+        {
+          success: false,
+          error: `Stage failure could not be processed: ${message}. If the task is stuck, use POST /api/tasks/${taskId}/admin/release-stall.`,
+        },
+        { status: 400 }
+      );
+    }
 
     if (result.success) {
       // Fail-loopback freed a slot (testing/verification) — drain the queue
@@ -64,14 +82,28 @@ export async function POST(
         message: `Task returned to ${result.newAgentName ? result.newAgentName : 'previous stage'} for rework`,
         newAgent: result.newAgentName,
       });
-    } else {
-      return NextResponse.json({
+    }
+
+    // result.success === false with a structured error — return 400, not 500.
+    // A 500 implies the server is broken; the server is fine, the transition
+    // is just rejected. This was the original bug: callers saw 500 and
+    // assumed the server had crashed when the real issue was a missing
+    // workflow template or fail_target.
+    return NextResponse.json(
+      {
         success: false,
         error: result.error || 'Failed to process stage failure',
-      }, { status: 500 });
-    }
+        hint: result.error?.includes('No workflow template') || result.error?.includes('No fail target')
+          ? `Task has no recovery path. Use POST /api/tasks/${taskId}/admin/release-stall to cancel it.`
+          : undefined,
+      },
+      { status: 400 }
+    );
   } catch (error) {
     console.error('Failed to process stage failure:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return NextResponse.json(
+      { error: `Failed to process stage failure: ${(error as Error).message}` },
+      { status: 500 }
+    );
   }
 }

--- a/src/app/api/tasks/[id]/fail/route.ts
+++ b/src/app/api/tasks/[id]/fail/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { queryOne } from '@/lib/db';
 import { handleStageFailure, drainQueue } from '@/lib/workflow-engine';
 import { notifyLearner } from '@/lib/learner';
+import { logDebugEvent } from '@/lib/debug-log';
 import type { Task } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -32,6 +33,14 @@ export async function POST(
     if (!task) {
       return NextResponse.json({ error: 'Task not found' }, { status: 404 });
     }
+
+    logDebugEvent({
+      type: 'agent.fail_post',
+      direction: 'inbound',
+      taskId,
+      requestBody: body,
+      metadata: { from_status: task.status },
+    });
 
     // Only allow failure from testing, review, or verification stages
     const failableStatuses = ['testing', 'review', 'verification'];

--- a/src/app/api/tasks/[id]/planning/force-complete/route.ts
+++ b/src/app/api/tasks/[id]/planning/force-complete/route.ts
@@ -82,11 +82,15 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     let firstAgentId: string | null = null;
 
     if (allowDynamicAgents && completionParsed.agents?.length > 0) {
+      // Mirrors the planning poll path: null-preferred default. New agents
+      // inherit the master's explicit prefix only if one is set; otherwise
+      // leave it null so the runtime resolver picks the agent's own
+      // namespace instead of the `agent:main:` catchall.
       const masterAgent = queryOne<{ session_key_prefix?: string }>(
         `SELECT session_key_prefix FROM agents WHERE is_master = 1 AND workspace_id = ? ORDER BY created_at ASC LIMIT 1`,
         [task.workspace_id]
       );
-      const sessionKeyPrefix = masterAgent?.session_key_prefix || 'agent:main:';
+      const sessionKeyPrefix = masterAgent?.session_key_prefix || null;
 
       for (const agent of completionParsed.agents) {
         const agentId = crypto.randomUUID();

--- a/src/app/api/tasks/[id]/planning/poll/route.ts
+++ b/src/app/api/tasks/[id]/planning/poll/route.ts
@@ -39,7 +39,13 @@ async function handlePlanningCompletion(taskId: string, parsed: any, messages: a
         `SELECT session_key_prefix FROM agents WHERE is_master = 1 AND workspace_id = ? ORDER BY created_at ASC LIMIT 1`
       ).get(task.workspace_id) as { session_key_prefix?: string } | undefined : undefined;
 
-      const sessionKeyPrefix = masterAgent?.session_key_prefix || 'agent:main:';
+      // Only inherit an explicit prefix if the master has one set. When it's
+      // null we leave the new agent's prefix null too — the runtime
+      // resolver (resolveAgentSessionKeyPrefix) will default to the new
+      // agent's own namespace at send time instead of baking in the
+      // `agent:main:` catchall that misrouted everything to the gateway's
+      // main agent.
+      const sessionKeyPrefix = masterAgent?.session_key_prefix || null;
 
       const insertAgent = db.prepare(`
         INSERT INTO agents (id, workspace_id, name, role, description, avatar_emoji, status, soul_md, session_key_prefix, created_at, updated_at)

--- a/src/app/api/tasks/[id]/planning/poll/route.ts
+++ b/src/app/api/tasks/[id]/planning/poll/route.ts
@@ -4,6 +4,7 @@ import { getOpenClawClient } from '@/lib/openclaw/client';
 import { broadcast } from '@/lib/events';
 import { getMissionControlUrl } from '@/lib/config';
 import { extractJSON, getMessagesFromOpenClaw } from '@/lib/planning-utils';
+import { findAgentForRole, verifyAgentInWorkspace } from '@/lib/agent-resolver';
 import { Task } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -37,7 +38,7 @@ async function handlePlanningCompletion(taskId: string, parsed: any, messages: a
       const masterAgent = task ? db.prepare(
         `SELECT session_key_prefix FROM agents WHERE is_master = 1 AND workspace_id = ? ORDER BY created_at ASC LIMIT 1`
       ).get(task.workspace_id) as { session_key_prefix?: string } | undefined : undefined;
-      
+
       const sessionKeyPrefix = masterAgent?.session_key_prefix || 'agent:main:';
 
       const insertAgent = db.prepare(`
@@ -45,20 +46,49 @@ async function handlePlanningCompletion(taskId: string, parsed: any, messages: a
         VALUES (?, (SELECT workspace_id FROM tasks WHERE id = ?), ?, ?, ?, ?, 'standby', ?, ?, datetime('now'), datetime('now'))
       `);
 
-      for (const agent of parsed.agents) {
-        const agentId = crypto.randomUUID();
-        if (!firstAgentId) firstAgentId = agentId;
+      const workspaceId = task?.workspace_id;
 
-        insertAgent.run(
-          agentId,
-          taskId,
-          agent.name,
-          agent.role,
-          agent.instructions || '',
-          agent.avatar_emoji || '🤖',
-          agent.soul_md || '',
-          sessionKeyPrefix
-        );
+      // For each agent the planner wants to spin up, first check whether the
+      // workspace already has a gateway-linked (or session-routed) agent that
+      // fills this role. If so, reuse it — this is the core fix for the ghost
+      // agent duplication bug. Only when no existing agent matches (or the
+      // planner gave an explicit agent_id that we've verified) do we create a
+      // new row.
+      for (const agent of parsed.agents) {
+        let resolvedId: string | null = null;
+
+        if (workspaceId && agent.agent_id) {
+          const verified = verifyAgentInWorkspace(workspaceId, agent.agent_id);
+          if (verified) {
+            resolvedId = verified.id;
+          } else {
+            console.warn(`[Planning Poll] Planner returned unknown agent_id ${agent.agent_id} for role "${agent.role}" — falling back to role match`);
+          }
+        }
+
+        if (!resolvedId && workspaceId && agent.role) {
+          const existing = findAgentForRole(workspaceId, agent.role);
+          if (existing) {
+            resolvedId = existing.id;
+            console.log(`[Planning Poll] Reusing existing agent ${existing.name} (${existing.id}) for role "${agent.role}" — skipping insert`);
+          }
+        }
+
+        if (!resolvedId) {
+          resolvedId = crypto.randomUUID();
+          insertAgent.run(
+            resolvedId,
+            taskId,
+            agent.name,
+            agent.role,
+            agent.instructions || '',
+            agent.avatar_emoji || '🤖',
+            agent.soul_md || '',
+            sessionKeyPrefix
+          );
+        }
+
+        if (!firstAgentId) firstAgentId = resolvedId;
       }
     } else if (!allowDynamicAgents && parsed.agents && parsed.agents.length > 0) {
       console.log(`[Planning Poll] Dynamic agent generation disabled (ALLOW_DYNAMIC_AGENTS=false), skipping creation of ${parsed.agents.length} agent(s)`);
@@ -257,6 +287,10 @@ export async function GET(
               avatar_emoji?: string;
               soul_md?: string;
               instructions?: string;
+              /** Optional: planner may reuse an existing workspace agent by id. */
+              agent_id?: string | null;
+              /** Optional: why a new agent is needed vs. reusing one from the roster. */
+              rationale?: string;
             }>;
             execution_plan?: object;
           } | null;

--- a/src/app/api/tasks/[id]/planning/route.ts
+++ b/src/app/api/tasks/[id]/planning/route.ts
@@ -8,9 +8,12 @@ import { getAgentRoster, formatRosterForPrompt } from '@/lib/agent-resolver';
 
 export const dynamic = 'force-dynamic';
 
-// Default planning session prefix for OpenClaw
-// Can be overridden per-agent via the session_key_prefix column on agents table
-const DEFAULT_SESSION_KEY_PREFIX = 'agent:main:';
+// Last-resort fallback when no agent context is available. Normally the
+// per-agent prefix resolver (resolveAgentSessionKeyPrefix) picks the
+// gateway-id or name-slug based prefix for the specific target agent.
+// The old `agent:main:` default silently routed every planning session
+// to the gateway's "main" agent regardless of which agent was planning.
+const FALLBACK_SESSION_KEY_PREFIX = 'agent:main:';
 
 // GET /api/tasks/[id]/planning - Get planning state
 export async function GET(
@@ -99,20 +102,22 @@ export async function POST(
       return NextResponse.json({ error: 'Planning already started', sessionKey: task.planning_session_key }, { status: 400 });
     }
 
-    // Check if there are other orchestrators available before starting planning with the default master agent
-    // Get the default master agent for this workspace
-    const defaultMaster = queryOne<{ id: string; session_key_prefix?: string }>(
-      `SELECT id, session_key_prefix FROM agents WHERE is_master = 1 AND workspace_id = ? ORDER BY created_at ASC LIMIT 1`,
+    // Check if there are other orchestrators available before starting planning with the default master agent.
+    // Fetch the full master agent so we can feed it to resolveAgentSessionKeyPrefix
+    // instead of reading session_key_prefix directly — the resolver falls
+    // back to the agent's own gateway namespace when no explicit prefix is set.
+    const defaultMaster = queryOne<import('@/lib/types').Agent>(
+      `SELECT * FROM agents WHERE is_master = 1 AND workspace_id = ? ORDER BY created_at ASC LIMIT 1`,
       [task.workspace_id]
     );
 
-    // Get assigned agent if any (for session_key_prefix)
+    // Get assigned agent (for session_key_prefix via the resolver).
     const taskWithAgent = getDb().prepare(`
-      SELECT a.session_key_prefix 
-      FROM tasks t 
-      LEFT JOIN agents a ON t.assigned_agent_id = a.id 
+      SELECT a.session_key_prefix, a.gateway_agent_id, a.name
+      FROM tasks t
+      LEFT JOIN agents a ON t.assigned_agent_id = a.id
       WHERE t.id = ?
-    `).get(taskId) as { session_key_prefix?: string } | undefined;
+    `).get(taskId) as { session_key_prefix?: string; gateway_agent_id?: string; name?: string } | undefined;
 
     const otherOrchestrators = queryAll<{
       id: string;
@@ -136,9 +141,26 @@ export async function POST(
       }, { status: 409 }); // 409 Conflict
     }
 
-    // Create session key for this planning task
-    // Priority: custom prefix > assigned agent's prefix > master agent's prefix > default prefix
-    const basePrefix = customSessionKeyPrefix || taskWithAgent?.session_key_prefix || defaultMaster?.session_key_prefix || DEFAULT_SESSION_KEY_PREFIX;
+    // Create session key for this planning task.
+    // Priority: custom prefix > assigned agent (via resolver) > master agent
+    // (via resolver) > fallback. The resolver picks `agent:<gateway_id>:`
+    // or `agent:<name>:` when the column is null, keeping messages in the
+    // specific agent's namespace.
+    const { resolveAgentSessionKeyPrefix } = await import('@/lib/openclaw/session-key');
+    let basePrefix: string;
+    if (customSessionKeyPrefix) {
+      basePrefix = customSessionKeyPrefix.endsWith(':') ? customSessionKeyPrefix : customSessionKeyPrefix + ':';
+    } else if (taskWithAgent?.name) {
+      basePrefix = resolveAgentSessionKeyPrefix({
+        session_key_prefix: taskWithAgent.session_key_prefix,
+        gateway_agent_id: taskWithAgent.gateway_agent_id,
+        name: taskWithAgent.name,
+      } as import('@/lib/types').Agent);
+    } else if (defaultMaster) {
+      basePrefix = resolveAgentSessionKeyPrefix(defaultMaster);
+    } else {
+      basePrefix = FALLBACK_SESSION_KEY_PREFIX;
+    }
     const planningPrefix = basePrefix + 'planning:';
     const sessionKey = `${planningPrefix}${taskId}`;
 

--- a/src/app/api/tasks/[id]/planning/route.ts
+++ b/src/app/api/tasks/[id]/planning/route.ts
@@ -3,6 +3,7 @@ import { getDb, queryAll, queryOne, run } from '@/lib/db';
 import { getOpenClawClient } from '@/lib/openclaw/client';
 import { broadcast } from '@/lib/events';
 import { extractJSON } from '@/lib/planning-utils';
+import { getAgentRoster, formatRosterForPrompt } from '@/lib/agent-resolver';
 // File system imports removed - using OpenClaw API instead
 
 export const dynamic = 'force-dynamic';
@@ -141,11 +142,26 @@ export async function POST(
     const planningPrefix = basePrefix + 'planning:';
     const sessionKey = `${planningPrefix}${taskId}`;
 
+    // Fetch the gateway-linked agent roster and surface it to the planner.
+    // Without this context the planner invents new agents every run, which is
+    // the root of the ghost-agent duplication bug: the real gateway agents
+    // sit idle while newly-created rows with no session_key_prefix receive
+    // the dispatch. When the planner emits its final `agents` list at status
+    // "complete", it may now return `agent_id` per agent to reuse one of these
+    // existing rows — see the polling handler for reuse/verify logic.
+    const roster = getAgentRoster(task.workspace_id);
+    const rosterBlock = formatRosterForPrompt(roster);
+
     // Build the initial planning prompt
     const planningPrompt = `PLANNING REQUEST
 
 Task Title: ${task.title}
 Task Description: ${task.description || 'No description provided'}
+
+AVAILABLE AGENTS (workspace roster):
+${rosterBlock}
+
+When you later emit the final plan (status: "complete") with an "agents" array, prefer assigning roles to the agents listed above by including their "agent_id" in each entry. Only propose a new agent (agent_id: null) when no listed agent is a suitable fit — and include a "rationale" explaining the specific capability gap.
 
 You are starting a planning session for this task. Read PLANNING.md for your protocol.
 

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -9,6 +9,7 @@ import { updateConvoyProgress, checkConvoyCompletion } from '@/lib/convoy';
 import { syncGatewayAgentsToCatalog } from '@/lib/agent-catalog-sync';
 import { triggerWorkspaceMerge } from '@/lib/workspace-isolation';
 import { UpdateTaskSchema } from '@/lib/validation';
+import { logDebugEvent } from '@/lib/debug-log';
 import type { Task, UpdateTaskRequest, Agent, TaskDeliverable } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -66,6 +67,21 @@ export async function PATCH(
     if (!existing) {
       return NextResponse.json({ error: 'Task not found' }, { status: 404 });
     }
+
+    // Log the PATCH attempt up front so failed transitions (evidence-gate
+    // rejections, forbidden moves, etc.) still appear in the debug feed —
+    // those are the cases operators most need to see.
+    logDebugEvent({
+      type: 'agent.status_patch',
+      direction: 'inbound',
+      taskId: id,
+      agentId: validatedData.updated_by_agent_id ?? null,
+      requestBody: validatedData,
+      metadata: {
+        from_status: existing.status,
+        requested_status: validatedData.status ?? null,
+      },
+    });
 
     // Keep OpenClaw agent catalog synced opportunistically on task updates
     await syncGatewayAgentsToCatalog({ reason: 'task_patch' }).catch(err => {

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -4,7 +4,7 @@ import { queryOne, queryAll, run } from '@/lib/db';
 import { broadcast } from '@/lib/events';
 import { getMissionControlUrl } from '@/lib/config';
 import { handleStageTransition, handleStageFailure, getTaskWorkflow, drainQueue, populateTaskRolesFromAgents } from '@/lib/workflow-engine';
-import { hasStageEvidence, canUseBoardOverride, auditBoardOverride, taskCanBeDone, recordLearnerOnTransition } from '@/lib/task-governance';
+import { hasStageEvidence, canUseBoardOverride, auditBoardOverride, taskCanBeDone, recordLearnerOnTransition, isTerminalStatus } from '@/lib/task-governance';
 import { updateConvoyProgress, checkConvoyCompletion } from '@/lib/convoy';
 import { syncGatewayAgentsToCatalog } from '@/lib/agent-catalog-sync';
 import { triggerWorkspaceMerge } from '@/lib/workspace-isolation';
@@ -174,6 +174,16 @@ export async function PATCH(
     if (nextStatus !== undefined && nextStatus !== existing.status) {
       const boardOverrideRequested = Boolean(body.board_override);
       const boardOverrideAllowed = boardOverrideRequested && canUseBoardOverride(request);
+
+      // Cancelled is terminal: PATCH cannot move a cancelled task back into an
+      // active state. Use /admin/release-stall to un-cancel via a deliberate
+      // administrative action (which re-dispatches separately).
+      if (isTerminalStatus(existing.status) && existing.status === 'cancelled' && !boardOverrideAllowed) {
+        return NextResponse.json(
+          { error: `Cannot transition cancelled task to ${nextStatus}. Create a new task or use board_override.` },
+          { status: 400 }
+        );
+      }
 
       // Hard evidence gate for forward-stage transitions and completion
       const enteringQualityStage = ['testing', 'review', 'verification', 'done'].includes(nextStatus);
@@ -520,14 +530,31 @@ export async function DELETE(
       run('DELETE FROM convoys WHERE id = ?', [convoy.id]);
     }
 
-    // Delete or nullify related records first (foreign key constraints)
-    // Note: task_activities and task_deliverables have ON DELETE CASCADE
+    // Delete or nullify related records first (foreign key constraints).
+    // Tables with ON DELETE CASCADE: task_activities, task_deliverables,
+    // task_roles, task_notes, planning_questions, planning_specs,
+    // user_task_reads — these handle themselves.
+    //
+    // Tables with a plain REFERENCES (no cascade) to tasks(id) will block
+    // the delete with an FK error unless we handle them here. These were
+    // the silent "Failed to delete task" cause for stalled tasks that had
+    // agent_health / workspace_ports rows.
     run('DELETE FROM work_checkpoints WHERE task_id = ?', [id]);
     run('DELETE FROM openclaw_sessions WHERE task_id = ?', [id]);
     run('DELETE FROM events WHERE task_id = ?', [id]);
-    // Conversations and Knowledge reference tasks - nullify or delete
+    run('DELETE FROM agent_health WHERE task_id = ?', [id]);
+    run('DELETE FROM workspace_ports WHERE task_id = ?', [id]);
+    run('DELETE FROM workspace_merges WHERE task_id = ?', [id]);
+    // Product-autopilot tables: null out rather than cascade-delete so the
+    // parent product/idea/skill history is preserved across task deletion.
     run('UPDATE conversations SET task_id = NULL WHERE task_id = ?', [id]);
     run('UPDATE knowledge_entries SET task_id = NULL WHERE task_id = ?', [id]);
+    run('UPDATE ideas SET task_id = NULL WHERE task_id = ?', [id]);
+    run('UPDATE content_inventory SET task_id = NULL WHERE task_id = ?', [id]);
+    run('UPDATE cost_events SET task_id = NULL WHERE task_id = ?', [id]);
+    run('UPDATE product_skills SET created_by_task_id = NULL WHERE created_by_task_id = ?', [id]);
+    // skill_reports.task_id is NOT NULL — drop the rows rather than null them.
+    run('DELETE FROM skill_reports WHERE task_id = ?', [id]);
 
     // Now delete the task (cascades to task_activities and task_deliverables)
     run('DELETE FROM tasks WHERE id = ?', [id]);

--- a/src/app/api/tasks/clear/route.ts
+++ b/src/app/api/tasks/clear/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from 'next/server';
+import { queryOne, run, transaction } from '@/lib/db';
+import { broadcast } from '@/lib/events';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * DELETE /api/tasks/clear — wipe every task from the Mission Control DB.
+ * Does NOT touch OpenClaw Gateway state, workspace directories, or agents.
+ *
+ * Many child tables reference tasks(id) with ON DELETE CASCADE, but several
+ * (events, conversations, openclaw_sessions, knowledge_entries, cost_events,
+ * agent_health, ideas, content_pieces, skill_reports, product_skills) do
+ * not — with FK=ON, a bare DELETE FROM tasks would fail. Clear the
+ * non-cascading refs first (nullify where nullable, delete where task-scoped).
+ */
+export async function DELETE() {
+  try {
+    const before = queryOne<{ cnt: number }>('SELECT COUNT(*) as cnt FROM tasks')?.cnt ?? 0;
+    if (before === 0) {
+      return NextResponse.json({ deleted: 0 });
+    }
+
+    transaction(() => {
+      // Task-scoped rows without ON DELETE CASCADE — wipe fully.
+      run('DELETE FROM workspace_ports');
+      run('DELETE FROM workspace_merges');
+      run('DELETE FROM events WHERE task_id IS NOT NULL');
+      run('DELETE FROM openclaw_sessions WHERE task_id IS NOT NULL');
+      try { run('DELETE FROM skill_reports'); } catch {}
+      try { run('DELETE FROM debug_events'); } catch {}
+
+      // Rows that may outlive a task — just null out the FK.
+      run('UPDATE conversations SET task_id = NULL WHERE task_id IS NOT NULL');
+      run('UPDATE knowledge_entries SET task_id = NULL WHERE task_id IS NOT NULL');
+      run('UPDATE agent_health SET task_id = NULL WHERE task_id IS NOT NULL');
+      run('UPDATE cost_events SET task_id = NULL WHERE task_id IS NOT NULL');
+      try { run('UPDATE ideas SET task_id = NULL WHERE task_id IS NOT NULL'); } catch {}
+      try { run('UPDATE content_pieces SET task_id = NULL WHERE task_id IS NOT NULL'); } catch {}
+      try { run('UPDATE product_skills SET created_by_task_id = NULL WHERE created_by_task_id IS NOT NULL'); } catch {}
+
+      // Tables with ON DELETE CASCADE (task_roles, task_activities,
+      // task_deliverables, planning_questions, planning_specs, task_notes,
+      // user_task_reads, checkpoints, task_dependencies, convoys,
+      // convoy_subtasks, stall_flags, work_checkpoints) handle themselves.
+      run('DELETE FROM tasks');
+    });
+
+    broadcast({
+      type: 'tasks_cleared',
+      payload: { count: before },
+    });
+
+    return NextResponse.json({ deleted: before });
+  } catch (error) {
+    console.error('[DELETE /api/tasks/clear] failed:', error);
+    return NextResponse.json(
+      { error: `Failed to clear tasks: ${(error as Error).message}` },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -22,6 +22,8 @@ export async function GET(request: NextRequest) {
         t.*,
         aa.name as assigned_agent_name,
         aa.avatar_emoji as assigned_agent_emoji,
+        aa.status as assigned_agent_status,
+        aa.role as assigned_agent_role,
         ca.name as created_by_agent_name
       FROM tasks t
       LEFT JOIN agents aa ON t.assigned_agent_id = aa.id
@@ -56,9 +58,17 @@ export async function GET(request: NextRequest) {
 
     sql += ' ORDER BY t.created_at DESC';
 
-    const tasks = queryAll<Task & { assigned_agent_name?: string; assigned_agent_emoji?: string; created_by_agent_name?: string }>(sql, params);
+    const tasks = queryAll<Task & {
+      assigned_agent_name?: string;
+      assigned_agent_emoji?: string;
+      assigned_agent_status?: string;
+      assigned_agent_role?: string;
+      created_by_agent_name?: string;
+    }>(sql, params);
 
-    // Transform to include nested agent info
+    // Transform to include nested agent info. `status` and `role` are needed
+    // client-side so the Blocked badge can distinguish "agent went offline
+    // mid-task" from other block conditions — see src/lib/blocked-state.ts.
     const transformedTasks = tasks.map((task) => ({
       ...task,
       assigned_agent: task.assigned_agent_id
@@ -66,6 +76,8 @@ export async function GET(request: NextRequest) {
             id: task.assigned_agent_id,
             name: task.assigned_agent_name,
             avatar_emoji: task.assigned_agent_emoji,
+            status: task.assigned_agent_status,
+            role: task.assigned_agent_role,
           }
         : undefined,
     }));

--- a/src/app/api/tasks/scan-stalls/route.ts
+++ b/src/app/api/tasks/scan-stalls/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { scanStalledTasks } from '@/lib/stall-detection';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/tasks/scan-stalls
+ *
+ * Manual trigger for the stall scanner. The scanner also runs automatically
+ * every 2 minutes as part of runHealthCheckCycle (invoked from the SSE
+ * stream while at least one client is connected). Use this endpoint when
+ * you want an immediate pass — e.g. from an external cron, or when
+ * debugging a stuck task.
+ *
+ * Response:
+ *   {
+ *     scanned: number,
+ *     flagged: Array<{ task_id, title, status, minutes_idle, mode, notified }>
+ *   }
+ */
+export async function POST(_request: NextRequest) {
+  try {
+    const report = await scanStalledTasks();
+    return NextResponse.json(report);
+  } catch (error) {
+    console.error('[ScanStalls] failed:', error);
+    return NextResponse.json(
+      { error: `Stall scan failed: ${(error as Error).message}` },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/workspaces/route.ts
+++ b/src/app/api/workspaces/route.ts
@@ -44,6 +44,7 @@ export async function GET(request: NextRequest) {
           review: 0,
           verification: 0,
           done: 0,
+          cancelled: 0,
           total: 0
         };
         

--- a/src/app/debug/page.tsx
+++ b/src/app/debug/page.tsx
@@ -2,16 +2,35 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
-import { ArrowLeft, Trash2, Play, Pause, ChevronDown, ChevronRight } from 'lucide-react';
+import { ArrowLeft, Trash2, Play, Pause, ChevronDown, ChevronRight, Users, ListX, Activity } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import type { DebugEvent, DebugEventType, DebugEventDirection } from '@/lib/debug-log';
 
 const EVENT_TYPE_OPTIONS: Array<{ value: '' | DebugEventType; label: string }> = [
   { value: '', label: 'All event types' },
-  { value: 'chat.send', label: 'chat.send (outbound)' },
-  { value: 'chat.response', label: 'chat.response' },
-  { value: 'session.create', label: 'session.create' },
-  { value: 'session.end', label: 'session.end' },
+  // Outbound
+  { value: 'chat.send', label: '↑ chat.send' },
+  { value: 'gateway.rpc', label: '↑ gateway.rpc (all RPCs)' },
+  { value: 'gateway.list_agents', label: '↑ gateway.list_agents' },
+  // Inbound
+  { value: 'chat.response', label: '↓ chat.response' },
+  { value: 'agent.event', label: '↓ agent.event (stream)' },
+  { value: 'agent.activity_post', label: '↓ agent.activity_post' },
+  { value: 'agent.deliverable_post', label: '↓ agent.deliverable_post' },
+  { value: 'agent.status_patch', label: '↓ agent.status_patch' },
+  { value: 'agent.fail_post', label: '↓ agent.fail_post' },
+  // Lifecycle
+  { value: 'session.create', label: '• session.create' },
+  { value: 'session.end', label: '• session.end' },
+  { value: 'ws.connect', label: '• ws.connect' },
+  { value: 'ws.authenticated', label: '• ws.authenticated' },
+  { value: 'ws.disconnect', label: '• ws.disconnect' },
+  { value: 'ws.error', label: '• ws.error' },
+  { value: 'ws.reconnect', label: '• ws.reconnect' },
+  // Scheduler / diagnostic
+  { value: 'stall.flagged', label: '• stall.flagged' },
+  { value: 'stall.cleared', label: '• stall.cleared' },
+  { value: 'diagnostic.step', label: '• diagnostic.step' },
 ];
 
 const DIRECTION_OPTIONS: Array<{ value: '' | DebugEventDirection; label: string }> = [
@@ -33,6 +52,13 @@ export default function DebugConsolePage() {
     direction: '' as '' | DebugEventDirection,
   });
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+  const [diagnosticBusy, setDiagnosticBusy] = useState(false);
+  const [diagnosticResult, setDiagnosticResult] = useState<null | {
+    ok: boolean;
+    message: string;
+    task_id?: string;
+    steps?: Array<{ name: string; ok: boolean; detail?: string; duration_ms?: number }>;
+  }>(null);
 
   // Keep the latest filter in a ref so the SSE handler (which is stable
   // across renders) reads the current value without having to re-register.
@@ -110,6 +136,61 @@ export default function DebugConsolePage() {
     setExpandedIds(new Set());
   };
 
+  const clearLocalAgents = async () => {
+    if (!confirm('Delete all non-gateway (local) agents from Mission Control? Gateway-synced agents will be kept.')) return;
+    try {
+      const res = await fetch('/api/agents/local', { method: 'DELETE' });
+      const data = await res.json();
+      if (!res.ok) {
+        alert(data.error || 'Failed to clear local agents');
+        return;
+      }
+      alert(`Cleared ${data.deleted} local agent(s).`);
+    } catch (err) {
+      alert(`Failed to clear local agents: ${(err as Error).message}`);
+    }
+  };
+
+  const clearAllTasks = async () => {
+    if (!confirm('Delete ALL tasks from the Mission Control DB? This cannot be undone. (OpenClaw and workspace directories are not affected.)')) return;
+    try {
+      const res = await fetch('/api/tasks/clear', { method: 'DELETE' });
+      const data = await res.json();
+      if (!res.ok) {
+        alert(data.error || 'Failed to clear tasks');
+        return;
+      }
+      alert(`Cleared ${data.deleted} task(s).`);
+    } catch (err) {
+      alert(`Failed to clear tasks: ${(err as Error).message}`);
+    }
+  };
+
+  const runDiagnostic = async () => {
+    setDiagnosticBusy(true);
+    setDiagnosticResult(null);
+    try {
+      const res = await fetch('/api/debug/diagnostic', { method: 'POST' });
+      const data = await res.json();
+      setDiagnosticResult({
+        ok: Boolean(data.ok),
+        message: data.hint || data.error || (data.ok ? 'Diagnostic complete' : 'Diagnostic failed'),
+        task_id: data.task_id,
+        steps: data.steps,
+      });
+      // Auto-filter the event stream to this run so the operator can see
+      // exactly the traffic this test triggered, without the rest of the
+      // noise on the page.
+      if (data.task_id) {
+        setFilter(f => ({ ...f, taskId: data.task_id }));
+      }
+    } catch (err) {
+      setDiagnosticResult({ ok: false, message: (err as Error).message });
+    } finally {
+      setDiagnosticBusy(false);
+    }
+  };
+
   const toggleExpanded = (id: string) => {
     setExpandedIds(prev => {
       const next = new Set(prev);
@@ -171,6 +252,72 @@ export default function DebugConsolePage() {
             : enabled
             ? `Collection is ON — capturing every outbound chat.send. ${total} event(s) stored.`
             : `Collection is OFF. ${total} event(s) stored from previous sessions. Click "Start collection" to capture new traffic.`}
+        </div>
+
+        {/* Diagnostic tools */}
+        <div className="mb-4 px-4 py-3 rounded-lg border border-mc-border bg-mc-bg-secondary">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="text-sm">
+              <div className="font-medium">Diagnostic tools</div>
+              <div className="text-xs text-mc-text-secondary">
+                Reset local state and run an end-to-end ping against the coordinator.
+              </div>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                onClick={runDiagnostic}
+                disabled={diagnosticBusy}
+                className="min-h-11 px-4 rounded-lg border border-blue-500/40 bg-blue-500/15 text-blue-300 hover:bg-blue-500/25 flex items-center gap-2 text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <Activity className="w-4 h-4" />
+                {diagnosticBusy ? 'Running...' : 'Run diagnostic'}
+              </button>
+              <button
+                onClick={clearLocalAgents}
+                className="min-h-11 px-4 rounded-lg border border-mc-border bg-mc-bg text-mc-text-secondary hover:text-mc-text hover:bg-mc-bg-tertiary flex items-center gap-2 text-sm"
+                title="Delete every agent that was not synced from the OpenClaw Gateway"
+              >
+                <Users className="w-4 h-4" />
+                Clear local agents
+              </button>
+              <button
+                onClick={clearAllTasks}
+                className="min-h-11 px-4 rounded-lg border border-mc-border bg-mc-bg text-mc-text-secondary hover:text-mc-text hover:bg-mc-bg-tertiary flex items-center gap-2 text-sm"
+                title="Delete all tasks from the Mission Control DB (OpenClaw untouched)"
+              >
+                <ListX className="w-4 h-4" />
+                Clear all tasks
+              </button>
+            </div>
+          </div>
+
+          {diagnosticResult && (
+            <div className={`mt-3 px-3 py-2 rounded border text-xs ${
+              diagnosticResult.ok
+                ? 'border-green-500/30 bg-green-500/10 text-green-300'
+                : 'border-red-500/40 bg-red-500/10 text-red-300'
+            }`}>
+              <div className="font-medium mb-1">
+                {diagnosticResult.ok ? '✅' : '❌'} {diagnosticResult.message}
+              </div>
+              {diagnosticResult.task_id && (
+                <div className="text-mc-text-secondary font-mono">
+                  task_id={diagnosticResult.task_id} (filter applied below)
+                </div>
+              )}
+              {diagnosticResult.steps && diagnosticResult.steps.length > 0 && (
+                <ul className="mt-2 space-y-0.5 font-mono">
+                  {diagnosticResult.steps.map((s, i) => (
+                    <li key={i}>
+                      {s.ok ? '✓' : '✗'} {s.name}
+                      {s.duration_ms != null && ` (${s.duration_ms}ms)`}
+                      {s.detail && ` — ${s.detail}`}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
         </div>
 
         {/* Filters */}

--- a/src/app/debug/page.tsx
+++ b/src/app/debug/page.tsx
@@ -1,0 +1,329 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
+import { ArrowLeft, Trash2, Play, Pause, ChevronDown, ChevronRight } from 'lucide-react';
+import { formatDistanceToNow } from 'date-fns';
+import type { DebugEvent, DebugEventType, DebugEventDirection } from '@/lib/debug-log';
+
+const EVENT_TYPE_OPTIONS: Array<{ value: '' | DebugEventType; label: string }> = [
+  { value: '', label: 'All event types' },
+  { value: 'chat.send', label: 'chat.send (outbound)' },
+  { value: 'chat.response', label: 'chat.response' },
+  { value: 'session.create', label: 'session.create' },
+  { value: 'session.end', label: 'session.end' },
+];
+
+const DIRECTION_OPTIONS: Array<{ value: '' | DebugEventDirection; label: string }> = [
+  { value: '', label: 'All directions' },
+  { value: 'outbound', label: 'Outbound (MC → agent)' },
+  { value: 'inbound', label: 'Inbound (agent → MC)' },
+  { value: 'internal', label: 'Internal' },
+];
+
+export default function DebugConsolePage() {
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+  const [events, setEvents] = useState<DebugEvent[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState({
+    taskId: '',
+    agentId: '',
+    eventType: '' as '' | DebugEventType,
+    direction: '' as '' | DebugEventDirection,
+  });
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+
+  // Keep the latest filter in a ref so the SSE handler (which is stable
+  // across renders) reads the current value without having to re-register.
+  const filterRef = useRef(filter);
+  filterRef.current = filter;
+
+  const refetch = async () => {
+    const qs = new URLSearchParams();
+    if (filter.taskId) qs.set('task_id', filter.taskId);
+    if (filter.agentId) qs.set('agent_id', filter.agentId);
+    if (filter.eventType) qs.set('event_type', filter.eventType);
+    if (filter.direction) qs.set('direction', filter.direction);
+    qs.set('limit', '200');
+    const res = await fetch(`/api/debug/events?${qs.toString()}`);
+    const data = await res.json();
+    setEvents(data.events || []);
+    setTotal(data.total || 0);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    fetch('/api/debug/settings').then(r => r.json()).then(d => setEnabled(Boolean(d.collection_enabled)));
+  }, []);
+
+  useEffect(() => {
+    setLoading(true);
+    refetch();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filter.taskId, filter.agentId, filter.eventType, filter.direction]);
+
+  // Live tail — subscribe to SSE, react only to debug-specific events.
+  useEffect(() => {
+    const es = new EventSource('/api/events/stream');
+    es.onmessage = (event) => {
+      if (event.data.startsWith(':')) return;
+      try {
+        const parsed = JSON.parse(event.data) as { type: string; payload: unknown };
+        if (parsed.type === 'debug_event_logged') {
+          const incoming = parsed.payload as DebugEvent;
+          // Respect active filters — if the incoming row doesn't match, skip.
+          const f = filterRef.current;
+          if (f.taskId && incoming.task_id !== f.taskId) return;
+          if (f.agentId && incoming.agent_id !== f.agentId) return;
+          if (f.eventType && incoming.event_type !== f.eventType) return;
+          if (f.direction && incoming.direction !== f.direction) return;
+          setEvents(prev => [incoming, ...prev].slice(0, 200));
+          setTotal(prev => prev + 1);
+        } else if (parsed.type === 'debug_events_cleared') {
+          setEvents([]);
+          setTotal(0);
+        } else if (parsed.type === 'debug_collection_toggled') {
+          const p = parsed.payload as { collection_enabled: boolean };
+          setEnabled(p.collection_enabled);
+        }
+      } catch { /* ignore malformed */ }
+    };
+    return () => es.close();
+  }, []);
+
+  const toggleCollection = async () => {
+    const next = !enabled;
+    setEnabled(next);
+    await fetch('/api/debug/settings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ collection_enabled: next }),
+    });
+  };
+
+  const clearAll = async () => {
+    if (!confirm(`Delete all ${total} debug event(s)?`)) return;
+    await fetch('/api/debug/events', { method: 'DELETE' });
+    setEvents([]);
+    setTotal(0);
+    setExpandedIds(new Set());
+  };
+
+  const toggleExpanded = (id: string) => {
+    setExpandedIds(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  };
+
+  return (
+    <div className="min-h-screen bg-mc-bg text-mc-text">
+      <header className="border-b border-mc-border bg-mc-bg-secondary">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 py-4 flex items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <Link href="/" className="text-mc-text-secondary hover:text-mc-text">
+              <ArrowLeft className="w-5 h-5" />
+            </Link>
+            <span className="text-2xl">🔬</span>
+            <div>
+              <h1 className="text-xl font-bold">Debug Console</h1>
+              <p className="text-xs text-mc-text-secondary">
+                Raw capture of Mission Control ↔ agent traffic
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={toggleCollection}
+              disabled={enabled === null}
+              className={`min-h-11 px-4 rounded-lg border flex items-center gap-2 text-sm font-medium transition-colors ${
+                enabled
+                  ? 'bg-red-500/15 border-red-500/40 text-red-300 hover:bg-red-500/25'
+                  : 'bg-green-500/15 border-green-500/40 text-green-300 hover:bg-green-500/25'
+              }`}
+            >
+              {enabled ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
+              {enabled === null ? '...' : enabled ? 'Stop collection' : 'Start collection'}
+            </button>
+            <button
+              onClick={clearAll}
+              disabled={total === 0}
+              className="min-h-11 px-4 rounded-lg border border-mc-border bg-mc-bg text-mc-text-secondary hover:text-mc-text hover:bg-mc-bg-tertiary flex items-center gap-2 text-sm disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              <Trash2 className="w-4 h-4" />
+              Clear ({total})
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 py-6">
+        {/* Status banner */}
+        <div className={`mb-4 px-4 py-3 rounded-lg border text-sm ${
+          enabled
+            ? 'bg-green-500/10 border-green-500/30 text-green-300'
+            : 'bg-mc-bg-tertiary border-mc-border text-mc-text-secondary'
+        }`}>
+          {enabled === null
+            ? 'Loading collection state...'
+            : enabled
+            ? `Collection is ON — capturing every outbound chat.send. ${total} event(s) stored.`
+            : `Collection is OFF. ${total} event(s) stored from previous sessions. Click "Start collection" to capture new traffic.`}
+        </div>
+
+        {/* Filters */}
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-3 mb-4">
+          <input
+            type="text"
+            placeholder="Filter by task_id"
+            value={filter.taskId}
+            onChange={e => setFilter(f => ({ ...f, taskId: e.target.value }))}
+            className="min-h-11 px-3 rounded-lg border border-mc-border bg-mc-bg-secondary text-sm"
+          />
+          <input
+            type="text"
+            placeholder="Filter by agent_id"
+            value={filter.agentId}
+            onChange={e => setFilter(f => ({ ...f, agentId: e.target.value }))}
+            className="min-h-11 px-3 rounded-lg border border-mc-border bg-mc-bg-secondary text-sm"
+          />
+          <select
+            value={filter.eventType}
+            onChange={e => setFilter(f => ({ ...f, eventType: e.target.value as '' | DebugEventType }))}
+            className="min-h-11 px-3 rounded-lg border border-mc-border bg-mc-bg-secondary text-sm"
+          >
+            {EVENT_TYPE_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+          </select>
+          <select
+            value={filter.direction}
+            onChange={e => setFilter(f => ({ ...f, direction: e.target.value as '' | DebugEventDirection }))}
+            className="min-h-11 px-3 rounded-lg border border-mc-border bg-mc-bg-secondary text-sm"
+          >
+            {DIRECTION_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+          </select>
+        </div>
+
+        {/* Event list */}
+        {loading ? (
+          <div className="text-center py-12 text-mc-text-secondary">Loading...</div>
+        ) : events.length === 0 ? (
+          <div className="text-center py-12 text-mc-text-secondary border border-mc-border rounded-lg bg-mc-bg-secondary">
+            No events match the current filter.
+            {!enabled && total === 0 && (
+              <div className="mt-2 text-xs">Turn collection ON and dispatch a task to see traffic here.</div>
+            )}
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {events.map(event => (
+              <DebugEventRow
+                key={event.id}
+                event={event}
+                expanded={expandedIds.has(event.id)}
+                onToggle={() => toggleExpanded(event.id)}
+              />
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}
+
+function DebugEventRow({
+  event,
+  expanded,
+  onToggle,
+}: {
+  event: DebugEvent;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const directionBadge = useMemo(() => {
+    const m = {
+      outbound: { label: 'OUT', cls: 'bg-blue-500/15 text-blue-300 border-blue-500/30' },
+      inbound: { label: 'IN', cls: 'bg-purple-500/15 text-purple-300 border-purple-500/30' },
+      internal: { label: 'INT', cls: 'bg-mc-text-secondary/10 text-mc-text-secondary border-mc-border' },
+    }[event.direction];
+    return m || { label: event.direction, cls: '' };
+  }, [event.direction]);
+
+  const hasError = Boolean(event.error);
+
+  return (
+    <div className={`rounded-lg border ${hasError ? 'border-red-500/40 bg-red-500/5' : 'border-mc-border bg-mc-bg-secondary'}`}>
+      <button
+        onClick={onToggle}
+        className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-mc-bg-tertiary/40 rounded-lg"
+      >
+        {expanded ? <ChevronDown className="w-4 h-4 flex-shrink-0" /> : <ChevronRight className="w-4 h-4 flex-shrink-0" />}
+        <span className={`text-[10px] font-mono px-1.5 py-0.5 rounded border ${directionBadge.cls} flex-shrink-0`}>
+          {directionBadge.label}
+        </span>
+        <span className="font-mono text-sm flex-shrink-0">{event.event_type}</span>
+        <span className="text-xs text-mc-text-secondary truncate flex-1">
+          {event.task_id && <span className="mr-3">task={event.task_id.slice(0, 8)}</span>}
+          {event.agent_id && <span className="mr-3">agent={event.agent_id.slice(0, 8)}</span>}
+          {event.duration_ms != null && <span className="mr-3">{event.duration_ms}ms</span>}
+          {hasError && <span className="text-red-300">error</span>}
+        </span>
+        <span className="text-[11px] text-mc-text-secondary/70 flex-shrink-0">
+          {formatDistanceToNow(new Date(event.created_at), { addSuffix: true })}
+        </span>
+      </button>
+
+      {expanded && (
+        <div className="border-t border-mc-border px-4 py-3 text-xs font-mono space-y-3">
+          <DebugField label="created_at" value={event.created_at} />
+          {event.session_key && <DebugField label="session_key" value={event.session_key} />}
+          {event.task_id && <DebugField label="task_id" value={event.task_id} />}
+          {event.agent_id && <DebugField label="agent_id" value={event.agent_id} />}
+          {event.duration_ms != null && <DebugField label="duration_ms" value={String(event.duration_ms)} />}
+          {event.error && <DebugField label="error" value={event.error} tone="error" />}
+          {event.metadata && <DebugField label="metadata" value={prettyJson(event.metadata)} block />}
+          {event.request_body && <DebugField label="request_body" value={prettyJson(event.request_body)} block />}
+          {event.response_body && <DebugField label="response_body" value={prettyJson(event.response_body)} block />}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DebugField({
+  label,
+  value,
+  block = false,
+  tone,
+}: {
+  label: string;
+  value: string;
+  block?: boolean;
+  tone?: 'error';
+}) {
+  const toneCls = tone === 'error' ? 'text-red-300' : 'text-mc-text';
+  if (block) {
+    return (
+      <div>
+        <div className="text-mc-text-secondary mb-1">{label}</div>
+        <pre className={`whitespace-pre-wrap break-all bg-mc-bg px-3 py-2 rounded border border-mc-border max-h-96 overflow-auto ${toneCls}`}>{value}</pre>
+      </div>
+    );
+  }
+  return (
+    <div className="flex gap-3">
+      <span className="text-mc-text-secondary w-28 flex-shrink-0">{label}</span>
+      <span className={`break-all ${toneCls}`}>{value}</span>
+    </div>
+  );
+}
+
+function prettyJson(value: string | null): string {
+  if (value == null) return '';
+  try {
+    return JSON.stringify(JSON.parse(value), null, 2);
+  } catch {
+    return value;
+  }
+}

--- a/src/app/workspace/[slug]/page.tsx
+++ b/src/app/workspace/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { Header } from '@/components/Header';
 import { AgentsSidebar } from '@/components/AgentsSidebar';
 import { MissionQueue } from '@/components/MissionQueue';
 import { LiveFeed } from '@/components/LiveFeed';
+import { ReadyDeliverablesPanel } from '@/components/ReadyDeliverablesPanel';
 import { SSEDebugPanel } from '@/components/SSEDebugPanel';
 import { useMissionControl } from '@/lib/store';
 import { useSSE } from '@/hooks/useSSE';
@@ -211,7 +212,7 @@ export default function WorkspacePage() {
       <div className="hidden lg:flex flex-1 overflow-hidden">
         <AgentsSidebar workspaceId={workspace.id} />
         <MissionQueue workspaceId={workspace.id} />
-        <LiveFeed />
+        <LiveFeed topSlot={<ReadyDeliverablesPanel workspaceId={workspace.id} />} />
       </div>
 
       <div

--- a/src/components/AgentModal.tsx
+++ b/src/components/AgentModal.tsx
@@ -305,10 +305,11 @@ export function AgentModal({ agent, onClose, workspaceId, onAgentCreated }: Agen
                   value={form.session_key_prefix}
                   onChange={(e) => setForm({ ...form, session_key_prefix: e.target.value })}
                   className="w-full min-h-11 bg-mc-bg border border-mc-border rounded px-3 py-2 text-sm focus:outline-none focus:border-mc-accent"
-                  placeholder="agent:main:"
+                  placeholder="agent:<name>:"
                 />
                 <p className="text-xs text-mc-text-secondary mt-1">
-                  OpenClaw session routing prefix. Defaults to &quot;agent:main:&quot; if not set.
+                  OpenClaw session routing prefix. Leave empty to default to
+                  &quot;agent:&lt;gateway_agent_id&gt;:&quot; (or &quot;agent:&lt;name&gt;:&quot; for local agents).
                 </p>
               </div>
             </div>

--- a/src/components/AgentsSidebar.tsx
+++ b/src/components/AgentsSidebar.tsx
@@ -1,12 +1,32 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { Plus, ChevronRight, ChevronLeft, Zap, ZapOff, Loader2, Search } from 'lucide-react';
+import { Plus, ChevronRight, ChevronLeft, Zap, ZapOff, Loader2, Search, Power, Megaphone, X, MoreVertical } from 'lucide-react';
 import { useMissionControl } from '@/lib/store';
 import type { Agent, AgentStatus, AgentHealthState, OpenClawSession } from '@/lib/types';
 import { AgentModal } from './AgentModal';
 import { DiscoverAgentsModal } from './DiscoverAgentsModal';
 import { HealthIndicator } from './HealthIndicator';
+
+interface RollCallEntryView {
+  id: string;
+  target_agent_id: string;
+  target_agent_name?: string;
+  target_agent_role?: string;
+  delivery_status: 'pending' | 'sent' | 'failed' | 'skipped';
+  delivery_error: string | null;
+  replied_at: string | null;
+  reply_body: string | null;
+}
+
+interface RollCallResultView {
+  rollcall_id: string;
+  mode: 'direct' | 'coordinator';
+  seconds_remaining: number;
+  entries: RollCallEntryView[];
+  error?: string;
+  reason?: 'no_master' | 'multiple_masters' | 'no_active_agents';
+}
 
 type FilterTab = 'all' | 'working' | 'standby';
 
@@ -17,7 +37,7 @@ interface AgentsSidebarProps {
 }
 
 export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = true }: AgentsSidebarProps) {
-  const { agents, selectedAgent, setSelectedAgent, agentOpenClawSessions, setAgentOpenClawSession } = useMissionControl();
+  const { agents, selectedAgent, setSelectedAgent, agentOpenClawSessions, setAgentOpenClawSession, updateAgent } = useMissionControl();
   const [filter, setFilter] = useState<FilterTab>('all');
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [editingAgent, setEditingAgent] = useState<Agent | null>(null);
@@ -26,6 +46,24 @@ export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = tr
   const [activeSubAgents, setActiveSubAgents] = useState(0);
   const [agentHealth, setAgentHealth] = useState<Record<string, AgentHealthState>>({});
   const [isMinimized, setIsMinimized] = useState(false);
+  const [togglingAgentId, setTogglingAgentId] = useState<string | null>(null);
+  const [rollCallBusy, setRollCallBusy] = useState(false);
+  const [rollCallResult, setRollCallResult] = useState<RollCallResultView | null>(null);
+  const [showActionMenu, setShowActionMenu] = useState(false);
+
+  // Close the action menu when clicking outside it. We watch document mousedown
+  // and check that the target isn't inside the menu or the trigger button.
+  useEffect(() => {
+    if (!showActionMenu) return;
+    const onMouseDown = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (!target.closest('[data-agents-action-menu]')) {
+        setShowActionMenu(false);
+      }
+    };
+    document.addEventListener('mousedown', onMouseDown);
+    return () => document.removeEventListener('mousedown', onMouseDown);
+  }, [showActionMenu]);
 
   const effectiveMinimized = mobileMode ? false : isMinimized;
   const toggleMinimize = () => setIsMinimized(!isMinimized);
@@ -91,6 +129,108 @@ export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = tr
     return () => clearInterval(interval);
   }, []);
 
+  // Toggle is_active for an agent. Optimistic update — on failure we roll
+  // back and surface the error.
+  const toggleAgentActive = async (agent: Agent, e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    const nextActive = !(Number(agent.is_active ?? 1) === 1);
+    setTogglingAgentId(agent.id);
+    const optimistic: Agent = { ...agent, is_active: nextActive ? 1 : 0 };
+    updateAgent(optimistic);
+    try {
+      const res = await fetch(`/api/agents/${agent.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ is_active: nextActive }),
+      });
+      if (!res.ok) {
+        updateAgent(agent); // rollback
+        const err = await res.json().catch(() => ({}));
+        alert(err.error || 'Failed to toggle agent');
+      } else {
+        const fresh = await res.json();
+        updateAgent(fresh as Agent);
+      }
+    } catch (err) {
+      updateAgent(agent); // rollback
+      alert(`Failed to toggle agent: ${(err as Error).message}`);
+    } finally {
+      setTogglingAgentId(null);
+    }
+  };
+
+  // Kick off a roll-call and open the results panel. Failures
+  // (no/multiple master orchestrators) are surfaced in the same panel so
+  // the operator can act on the alert without leaving the sidebar.
+  const runRollCall = async () => {
+    setRollCallBusy(true);
+    setRollCallResult(null);
+    try {
+      const res = await fetch('/api/agents/rollcall', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          workspace_id: workspaceId || 'default',
+          mode: 'direct',
+          timeout_seconds: 30,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setRollCallResult({
+          rollcall_id: '',
+          mode: 'direct',
+          seconds_remaining: 0,
+          entries: [],
+          error: data.error,
+          reason: data.reason,
+        });
+        return;
+      }
+      setRollCallResult({
+        rollcall_id: data.rollcall_id,
+        mode: data.rollcall.mode,
+        seconds_remaining: 30,
+        entries: data.entries,
+      });
+    } catch (err) {
+      setRollCallResult({
+        rollcall_id: '',
+        mode: 'direct',
+        seconds_remaining: 0,
+        entries: [],
+        error: (err as Error).message,
+      });
+    } finally {
+      setRollCallBusy(false);
+    }
+  };
+
+  // Poll roll-call status while panel is open and timer hasn't expired.
+  // SSE would be nicer; polling is simpler and fine for the small entry
+  // counts this feature fans out to.
+  useEffect(() => {
+    if (!rollCallResult?.rollcall_id) return;
+    const rid = rollCallResult.rollcall_id;
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const res = await fetch(`/api/agents/rollcall/${rid}`);
+        if (!res.ok) return;
+        const data = await res.json();
+        if (cancelled) return;
+        setRollCallResult(prev => prev && prev.rollcall_id === rid
+          ? { ...prev, entries: data.entries, seconds_remaining: data.summary.seconds_remaining }
+          : prev
+        );
+      } catch {}
+    };
+    tick();
+    const interval = setInterval(tick, 2000);
+    return () => { cancelled = true; clearInterval(interval); };
+  }, [rollCallResult?.rollcall_id]);
+
   const handleConnectToOpenClaw = async (agent: Agent, e: React.MouseEvent) => {
     e.stopPropagation();
     setConnectingAgentId(agent.id);
@@ -138,7 +278,7 @@ export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = tr
   return (
     <aside
       className={`bg-mc-bg-secondary ${mobileMode ? 'border border-mc-border rounded-lg h-full' : 'border-r border-mc-border'} flex flex-col transition-all duration-300 ease-in-out ${
-        effectiveMinimized ? 'w-12' : mobileMode ? 'w-full' : 'w-64'
+        effectiveMinimized ? 'w-12' : mobileMode ? 'w-full' : 'w-80'
       }`}
     >
       <div className="p-3 border-b border-mc-border">
@@ -156,6 +296,43 @@ export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = tr
             <>
               <span className="text-sm font-medium uppercase tracking-wider">Agents</span>
               <span className="bg-mc-bg-tertiary text-mc-text-secondary text-xs px-2 py-0.5 rounded ml-2">{agents.length}</span>
+              <div className="relative ml-auto" data-agents-action-menu>
+                <button
+                  onClick={() => setShowActionMenu(v => !v)}
+                  className="p-1.5 rounded hover:bg-mc-bg-tertiary text-mc-text-secondary hover:text-mc-text transition-colors"
+                  aria-label="Agent actions"
+                  title="Agent actions"
+                >
+                  <MoreVertical className="w-4 h-4" />
+                </button>
+                {showActionMenu && (
+                  <div className="absolute right-0 top-full mt-1 w-56 rounded-lg border border-mc-border bg-mc-bg shadow-lg z-30 py-1">
+                    <button
+                      onClick={() => { setShowActionMenu(false); runRollCall(); }}
+                      disabled={rollCallBusy}
+                      className="w-full flex items-center gap-2 px-3 py-2 text-sm text-purple-300 hover:bg-purple-500/10 disabled:opacity-50 disabled:cursor-not-allowed text-left"
+                    >
+                      {rollCallBusy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Megaphone className="w-4 h-4" />}
+                      {rollCallBusy ? 'Calling…' : 'Roll Call'}
+                    </button>
+                    <div className="h-px bg-mc-border my-1" />
+                    <button
+                      onClick={() => { setShowActionMenu(false); setShowCreateModal(true); }}
+                      className="w-full flex items-center gap-2 px-3 py-2 text-sm text-mc-text hover:bg-mc-bg-tertiary text-left"
+                    >
+                      <Plus className="w-4 h-4" />
+                      Add Agent
+                    </button>
+                    <button
+                      onClick={() => { setShowActionMenu(false); setShowDiscoverModal(true); }}
+                      className="w-full flex items-center gap-2 px-3 py-2 text-sm text-blue-300 hover:bg-blue-500/10 text-left"
+                    >
+                      <Search className="w-4 h-4" />
+                      Import from Gateway
+                    </button>
+                  </div>
+                )}
+              </div>
             </>
           )}
         </div>
@@ -221,8 +398,10 @@ export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = tr
           }
 
           const isConnecting = connectingAgentId === agent.id;
+          const isActive = Number(agent.is_active ?? 1) === 1;
+          const isToggling = togglingAgentId === agent.id;
           return (
-            <div key={agent.id} className={`w-full rounded hover:bg-mc-bg-tertiary transition-colors ${selectedAgent?.id === agent.id ? 'bg-mc-bg-tertiary' : ''}`}>
+            <div key={agent.id} className={`w-full rounded hover:bg-mc-bg-tertiary transition-colors ${selectedAgent?.id === agent.id ? 'bg-mc-bg-tertiary' : ''} ${!isActive ? 'opacity-50' : ''}`}>
               <button
                 onClick={() => {
                   setSelectedAgent(agent);
@@ -239,6 +418,11 @@ export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = tr
                   <div className="flex items-center gap-2">
                     <span className="font-medium text-sm truncate">{agent.name}</span>
                     {!!agent.is_master && <span className="text-xs text-mc-accent-yellow">★</span>}
+                    {!isActive && (
+                      <span className="text-[9px] px-1 py-0 bg-amber-500/20 text-amber-400 rounded uppercase tracking-wider" title="Excluded from routing + roll-call">
+                        paused
+                      </span>
+                    )}
                   </div>
                   <div className="text-xs text-mc-text-secondary truncate flex items-center gap-1">
                     {agent.role}
@@ -251,6 +435,22 @@ export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = tr
                 </div>
 
                 <div className="flex items-center gap-1.5">
+                  <span
+                    role="button"
+                    tabIndex={0}
+                    onClick={(e) => toggleAgentActive(agent, e)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleAgentActive(agent, e as unknown as React.MouseEvent); }
+                    }}
+                    title={isActive ? 'Active — click to pause (excludes from routing + roll-call)' : 'Paused — click to activate'}
+                    className={`p-1.5 rounded transition-colors cursor-pointer ${
+                      isActive
+                        ? 'text-mc-text-secondary hover:text-mc-text hover:bg-mc-bg-tertiary'
+                        : 'text-amber-400 hover:bg-amber-500/20'
+                    } ${isToggling ? 'opacity-50 pointer-events-none' : ''}`}
+                  >
+                    <Power className="w-3.5 h-3.5" />
+                  </span>
                   {agentHealth[agent.id] && agentHealth[agent.id] !== 'idle' && (
                     <HealthIndicator state={agentHealth[agent.id]} size="sm" />
                   )}
@@ -293,28 +493,104 @@ export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = tr
         })}
       </div>
 
-      {!effectiveMinimized && (
-        <div className="p-3 border-t border-mc-border space-y-2">
-          <button
-            onClick={() => setShowCreateModal(true)}
-            className="w-full min-h-11 flex items-center justify-center gap-2 px-3 bg-mc-bg-tertiary hover:bg-mc-border rounded text-sm text-mc-text-secondary hover:text-mc-text transition-colors"
-          >
-            <Plus className="w-4 h-4" />
-            Add Agent
-          </button>
-          <button
-            onClick={() => setShowDiscoverModal(true)}
-            className="w-full min-h-11 flex items-center justify-center gap-2 px-3 bg-blue-500/10 hover:bg-blue-500/20 border border-blue-500/20 rounded text-sm text-blue-400 hover:text-blue-300 transition-colors"
-          >
-            <Search className="w-4 h-4" />
-            Import from Gateway
-          </button>
+      {!effectiveMinimized && rollCallResult && (
+        <div className="border-t border-mc-border bg-mc-bg-secondary">
+          <RollCallResultsPanel
+            result={rollCallResult}
+            onClose={() => setRollCallResult(null)}
+          />
         </div>
       )}
+
 
       {showCreateModal && <AgentModal onClose={() => setShowCreateModal(false)} workspaceId={workspaceId} />}
       {editingAgent && <AgentModal agent={editingAgent} onClose={() => setEditingAgent(null)} workspaceId={workspaceId} />}
       {showDiscoverModal && <DiscoverAgentsModal onClose={() => setShowDiscoverModal(false)} workspaceId={workspaceId} />}
     </aside>
+  );
+}
+
+/**
+ * Inline panel that shows the live roll-call results. Renders above the
+ * action buttons so the operator can watch replies land without leaving
+ * the sidebar context. Also surfaces alert-level errors (no master
+ * orchestrator / multiple master orchestrators) in the same surface.
+ */
+function RollCallResultsPanel({
+  result,
+  onClose,
+}: {
+  result: RollCallResultView;
+  onClose: () => void;
+}) {
+  // Error state: no master, multiple masters, or other failure.
+  if (result.error) {
+    const alertTitle =
+      result.reason === 'no_master'
+        ? '⚠️ No Master Orchestrator'
+        : result.reason === 'multiple_masters'
+          ? '⚠️ Multiple Master Orchestrators'
+          : '⚠️ Roll-call Failed';
+    return (
+      <div className="p-3 border-l-4 border-amber-500 bg-amber-500/10">
+        <div className="flex items-start justify-between gap-2 mb-1">
+          <span className="text-sm font-semibold text-amber-300">{alertTitle}</span>
+          <button onClick={onClose} className="text-mc-text-secondary hover:text-mc-text p-0.5">
+            <X className="w-3.5 h-3.5" />
+          </button>
+        </div>
+        <p className="text-xs text-mc-text-secondary">{result.error}</p>
+      </div>
+    );
+  }
+
+  const delivered = result.entries.filter(e => e.delivery_status === 'sent').length;
+  const skipped = result.entries.filter(e => e.delivery_status === 'skipped').length;
+  const failed = result.entries.filter(e => e.delivery_status === 'failed').length;
+  const replied = result.entries.filter(e => e.replied_at).length;
+  const expired = result.seconds_remaining <= 0;
+
+  return (
+    <div className="p-3">
+      <div className="flex items-center justify-between mb-2">
+        <div className="text-xs">
+          <div className="font-semibold text-mc-text flex items-center gap-2">
+            📢 Roll Call ({expired ? 'complete' : `${result.seconds_remaining}s left`})
+          </div>
+          <div className="text-mc-text-secondary mt-0.5">
+            {replied}/{result.entries.length} replied · {delivered} delivered · {skipped + failed} undelivered
+          </div>
+        </div>
+        <button onClick={onClose} className="text-mc-text-secondary hover:text-mc-text p-0.5" title="Close">
+          <X className="w-3.5 h-3.5" />
+        </button>
+      </div>
+      <div className="space-y-1 max-h-40 overflow-auto">
+        {result.entries.map(e => {
+          const replyGlyph = e.replied_at ? '✓' : expired ? '✗' : '⏳';
+          const replyColor = e.replied_at
+            ? 'text-green-400'
+            : expired
+              ? 'text-red-400'
+              : 'text-mc-text-secondary';
+          const deliveryBadge = e.delivery_status === 'sent'
+            ? null
+            : e.delivery_status === 'skipped'
+              ? <span className="text-[9px] px-1 bg-mc-text-secondary/20 text-mc-text-secondary rounded" title={e.delivery_error || ''}>no session</span>
+              : e.delivery_status === 'failed'
+                ? <span className="text-[9px] px-1 bg-red-500/20 text-red-400 rounded" title={e.delivery_error || ''}>fail</span>
+                : null;
+          return (
+            <div key={e.id} className="flex items-center gap-2 text-xs">
+              <span className={`w-4 text-center ${replyColor}`}>{replyGlyph}</span>
+              <span className="flex-1 truncate">
+                {e.target_agent_name} <span className="text-mc-text-secondary">({e.target_agent_role})</span>
+              </span>
+              {deliveryBadge}
+            </div>
+          );
+        })}
+      </div>
+    </div>
   );
 }

--- a/src/components/AgentsSidebar.tsx
+++ b/src/components/AgentsSidebar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { Plus, ChevronRight, ChevronLeft, Zap, ZapOff, Loader2, Search, Power, Megaphone, X, MoreVertical } from 'lucide-react';
+import { Plus, ChevronRight, ChevronLeft, Zap, ZapOff, Loader2, Search, Power, Megaphone, X, MoreVertical, RotateCcw } from 'lucide-react';
 import { useMissionControl } from '@/lib/store';
 import type { Agent, AgentStatus, AgentHealthState, OpenClawSession } from '@/lib/types';
 import { AgentModal } from './AgentModal';
@@ -50,6 +50,7 @@ export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = tr
   const [rollCallBusy, setRollCallBusy] = useState(false);
   const [rollCallResult, setRollCallResult] = useState<RollCallResultView | null>(null);
   const [showActionMenu, setShowActionMenu] = useState(false);
+  const [resetSessionsBusy, setResetSessionsBusy] = useState(false);
 
   // Close the action menu when clicking outside it. We watch document mousedown
   // and check that the target isn't inside the menu or the trigger button.
@@ -207,6 +208,53 @@ export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = tr
     }
   };
 
+  // Reset all OpenClaw sessions — both MC-side (session rows) and
+  // gateway-side (via `/reset` sent to each active gateway-synced agent's
+  // main session, which forces the gateway to re-init and reload the
+  // agent's persona files on its next turn). One click, two phases.
+  const resetAllSessions = async () => {
+    if (!confirm(
+      'Reset ALL agent sessions?\n\n' +
+      'This does two things:\n' +
+      '  1. Wipes Mission Control\'s session tracking (the "OpenClaw Connected" badges).\n' +
+      '  2. Sends `/reset` to every active gateway-synced agent\'s main session, which forces OpenClaw to re-initialize the session and reload the agent\'s SOUL.md / AGENTS.md / MESSAGING-PROTOCOL.md on its next turn.\n\n' +
+      'Use this after editing agent persona files, or when sessionKey routing has drifted.'
+    )) return;
+    setResetSessionsBusy(true);
+    try {
+      const res = await fetch('/api/openclaw/sessions', { method: 'DELETE' });
+      const data = await res.json();
+      if (!res.ok) {
+        alert(data.error || 'Failed to reset sessions');
+        return;
+      }
+      // Drop in-memory OpenClaw session state so badges update immediately.
+      for (const agent of agents) {
+        setAgentOpenClawSession(agent.id, null);
+      }
+      // Summarise both phases. Gateway /reset can fail per-agent (allow-list,
+      // offline, etc.) — surface those in the alert so the operator knows
+      // which ones to hit manually in the chat.
+      const resets: Array<{ name: string; ok: boolean; error?: string }> = data.agents_reset || [];
+      const ok = resets.filter(r => r.ok).map(r => r.name);
+      const failed = resets.filter(r => !r.ok);
+      const lines: string[] = [
+        `Cleared ${data.deleted} MC session record(s).`,
+      ];
+      if (ok.length) lines.push(`Sent /reset to: ${ok.join(', ')}`);
+      if (failed.length) {
+        lines.push(`Failed to /reset: ${failed.map(f => `${f.name} (${f.error || 'unknown'})`).join('; ')}`);
+        lines.push('Fall back: run `/reset` in those agents\' OpenClaw chats directly.');
+      }
+      if (data.gateway_error) lines.push(`Gateway unreachable: ${data.gateway_error}`);
+      alert(lines.join('\n'));
+    } catch (err) {
+      alert(`Failed to reset sessions: ${(err as Error).message}`);
+    } finally {
+      setResetSessionsBusy(false);
+    }
+  };
+
   // Poll roll-call status while panel is open and timer hasn't expired.
   // SSE would be nicer; polling is simpler and fine for the small entry
   // counts this feature fans out to.
@@ -314,6 +362,15 @@ export function AgentsSidebar({ workspaceId, mobileMode = false, isPortrait = tr
                     >
                       {rollCallBusy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Megaphone className="w-4 h-4" />}
                       {rollCallBusy ? 'Calling…' : 'Roll Call'}
+                    </button>
+                    <button
+                      onClick={() => { setShowActionMenu(false); resetAllSessions(); }}
+                      disabled={resetSessionsBusy}
+                      className="w-full flex items-center gap-2 px-3 py-2 text-sm text-amber-300 hover:bg-amber-500/10 disabled:opacity-50 disabled:cursor-not-allowed text-left"
+                      title="Clear all OpenClaw session records so next dispatch starts fresh"
+                    >
+                      {resetSessionsBusy ? <Loader2 className="w-4 h-4 animate-spin" /> : <RotateCcw className="w-4 h-4" />}
+                      {resetSessionsBusy ? 'Resetting…' : 'Reset all sessions'}
                     </button>
                     <div className="h-px bg-mc-border my-1" />
                     <button

--- a/src/components/BlockedBadge.tsx
+++ b/src/components/BlockedBadge.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { getBlockedState, type BlockedState } from '@/lib/blocked-state';
+import type { Task } from '@/lib/types';
+
+interface BlockedBadgeProps {
+  task: Task;
+  portraitMode?: boolean;
+}
+
+/**
+ * Rich replacement for the scattered "Assigned, but blocked: {err}" /
+ * "In queue — waiting for verification" / "Needs agent" rows that
+ * previously lived inline in MissionQueue.tsx. Single source of truth
+ * for block detection is src/lib/blocked-state.ts.
+ */
+export function BlockedBadge({ task, portraitMode = true }: BlockedBadgeProps) {
+  const state = getBlockedState(task);
+  if (!state) return null;
+
+  return <BlockedBadgeInner state={state} portraitMode={portraitMode} />;
+}
+
+function BlockedBadgeInner({ state, portraitMode }: { state: BlockedState; portraitMode: boolean }) {
+  const toneClasses =
+    state.tone === 'error'
+      ? 'bg-red-500/10 border-red-500/30 text-red-300'
+      : state.tone === 'warn'
+      ? 'bg-amber-500/10 border-amber-500/30 text-amber-200'
+      : 'bg-cyan-500/10 border-cyan-500/30 text-cyan-200';
+
+  const dotColor =
+    state.tone === 'error' ? 'bg-red-400' : state.tone === 'warn' ? 'bg-amber-400' : 'bg-cyan-400';
+
+  return (
+    <div
+      className={`flex items-start gap-2 ${portraitMode ? 'mb-3 py-2 px-3' : 'mb-2 py-1.5 px-2.5'} rounded-md border ${toneClasses}`}
+      title={state.tooltip}
+    >
+      <div className={`w-2 h-2 rounded-full mt-1 flex-shrink-0 ${dotColor}`} />
+      <span className="text-xs leading-snug">{state.label}</span>
+    </div>
+  );
+}

--- a/src/components/DeliverablesList.tsx
+++ b/src/components/DeliverablesList.tsx
@@ -6,7 +6,7 @@
 'use client';
 
 import { useEffect, useState, useCallback } from 'react';
-import { FileText, Link as LinkIcon, Package, ExternalLink, Eye } from 'lucide-react';
+import { FileText, Link as LinkIcon, Package, ExternalLink, Eye, Download, Archive } from 'lucide-react';
 import { debug } from '@/lib/debug';
 import type { TaskDeliverable } from '@/lib/types';
 
@@ -101,6 +101,13 @@ export function DeliverablesList({ taskId }: DeliverablesListProps) {
     }
   };
 
+  const formatBytes = (bytes: number) => {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+    return `${(bytes / 1024 / 1024 / 1024).toFixed(1)} GB`;
+  };
+
   const formatTimestamp = (timestamp: string) => {
     const date = new Date(timestamp);
     return date.toLocaleDateString('en-US', {
@@ -128,8 +135,24 @@ export function DeliverablesList({ taskId }: DeliverablesListProps) {
     );
   }
 
+  const mcFileCount = deliverables.filter(
+    d => d.deliverable_type === 'file' && d.storage_scheme === 'mc'
+  ).length;
+
   return (
     <div className="space-y-3">
+      {mcFileCount > 0 && (
+        <div className="flex items-center justify-end">
+          <a
+            href={`/api/tasks/${taskId}/deliverables/download`}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded bg-mc-accent text-white hover:bg-mc-accent/90"
+            title={`Download ${mcFileCount} file${mcFileCount === 1 ? '' : 's'} as a zip`}
+          >
+            <Archive className="w-4 h-4" />
+            Download all ({mcFileCount})
+          </a>
+        </div>
+      )}
       {deliverables.map((deliverable) => (
         <div
           key={deliverable.id}
@@ -158,6 +181,16 @@ export function DeliverablesList({ taskId }: DeliverablesListProps) {
                 <h4 className="font-medium text-mc-text">{deliverable.title}</h4>
               )}
               <div className="flex items-center gap-1">
+                {/* Download button (MC-managed file deliverables only) */}
+                {deliverable.deliverable_type === 'file' && deliverable.storage_scheme === 'mc' && (
+                  <a
+                    href={`/api/deliverables/${deliverable.id}/download`}
+                    className="flex-shrink-0 p-1.5 hover:bg-mc-bg-tertiary rounded text-mc-accent"
+                    title="Download file"
+                  >
+                    <Download className="w-4 h-4" />
+                  </a>
+                )}
                 {/* Preview button for HTML files */}
                 {deliverable.deliverable_type === 'file' && deliverable.path?.endsWith('.html') && (
                   <button
@@ -207,10 +240,24 @@ export function DeliverablesList({ taskId }: DeliverablesListProps) {
             )}
 
             {/* Metadata */}
-            <div className="flex items-center gap-4 mt-2 text-xs text-mc-text-secondary">
+            <div className="flex items-center gap-2 mt-2 text-xs text-mc-text-secondary flex-wrap">
               <span className="capitalize">{deliverable.deliverable_type}</span>
               <span>•</span>
               <span>{formatTimestamp(deliverable.created_at)}</span>
+              {deliverable.size_bytes != null && (
+                <>
+                  <span>•</span>
+                  <span>{formatBytes(deliverable.size_bytes)}</span>
+                </>
+              )}
+              {deliverable.deliverable_type === 'file' && deliverable.storage_scheme !== 'mc' && (
+                <span
+                  className="px-1.5 py-0.5 rounded bg-mc-bg-tertiary text-mc-text-secondary"
+                  title="Stored on host filesystem; not downloadable from the web UI"
+                >
+                  host-only
+                </span>
+              )}
             </div>
           </div>
         </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,7 +6,69 @@ import Link from 'next/link';
 import { Zap, Settings, ChevronLeft, LayoutGrid, Rocket } from 'lucide-react';
 import { useMissionControl } from '@/lib/store';
 import { format } from 'date-fns';
-import type { Workspace } from '@/lib/types';
+import type { Workspace, Agent, Task, TaskStatus } from '@/lib/types';
+
+// Label + colour map for the "Tasks in Queue" stage breakdown. Kept in
+// Header so the tooltip can render a stable order regardless of hash-map
+// iteration; counts at zero are hidden.
+const STAGE_LABELS: Array<{ status: TaskStatus; label: string; color: string }> = [
+  { status: 'inbox', label: 'Inbox', color: 'text-mc-text-secondary' },
+  { status: 'pending_dispatch', label: 'Pending dispatch', color: 'text-mc-text-secondary' },
+  { status: 'planning', label: 'Planning', color: 'text-blue-400' },
+  { status: 'assigned', label: 'Assigned', color: 'text-cyan-400' },
+  { status: 'in_progress', label: 'In progress', color: 'text-cyan-400' },
+  { status: 'convoy_active', label: 'Convoy active', color: 'text-purple-400' },
+  { status: 'testing', label: 'Testing', color: 'text-amber-400' },
+  { status: 'verification', label: 'Verification', color: 'text-orange-400' },
+];
+
+function ActiveAgentsTooltip({ activeAgents, activeSubAgents }: { activeAgents: Agent[]; activeSubAgents: number }) {
+  if (activeAgents.length === 0 && activeSubAgents === 0) {
+    return <span className="text-mc-text-secondary">Nothing currently working.</span>;
+  }
+  return (
+    <div className="space-y-1">
+      {activeAgents.map(a => (
+        <div key={a.id} className="flex items-center gap-2 text-xs">
+          <span className="text-base">{a.avatar_emoji}</span>
+          <span className="flex-1 truncate">{a.name}</span>
+          <span className="text-mc-text-secondary">{a.role}</span>
+        </div>
+      ))}
+      {activeSubAgents > 0 && (
+        <div className="text-xs text-mc-text-secondary pt-1 border-t border-mc-border">
+          + {activeSubAgents} sub-agent{activeSubAgents === 1 ? '' : 's'}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function QueuedTasksTooltip({ tasks }: { tasks: Task[] }) {
+  const queued = tasks.filter(t => t.status !== 'done' && t.status !== 'review' && t.status !== 'cancelled');
+  if (queued.length === 0) {
+    return <span className="text-mc-text-secondary">No tasks in queue.</span>;
+  }
+  const counts: Record<string, number> = {};
+  for (const t of queued) counts[t.status] = (counts[t.status] || 0) + 1;
+  const rows = STAGE_LABELS
+    .map(s => ({ ...s, count: counts[s.status] || 0 }))
+    .filter(s => s.count > 0);
+  return (
+    <div className="space-y-1">
+      {rows.map(r => (
+        <div key={r.status} className="flex items-center justify-between gap-3 text-xs">
+          <span className={r.color}>{r.label}</span>
+          <span className="font-mono text-mc-text">{r.count}</span>
+        </div>
+      ))}
+      <div className="text-xs text-mc-text-secondary pt-1 border-t border-mc-border flex justify-between">
+        <span>Total</span>
+        <span className="font-mono">{queued.length}</span>
+      </div>
+    </div>
+  );
+}
 
 interface HeaderProps {
   workspace?: Workspace;
@@ -42,8 +104,14 @@ export function Header({ workspace, isPortrait = true }: HeaderProps) {
     return () => clearInterval(interval);
   }, []);
 
-  const workingAgents = agents.filter((a) => a.status === 'working').length;
-  const activeAgents = workingAgents + activeSubAgents;
+  // "Agents active" counts persistent agents currently assigned to a live
+  // task. Sub-agent sessions used to be summed in too, but with the new
+  // routing model (Coordinator → sessions_send → persistent agents) a
+  // sub-agent session is a child of an existing agent, not an additional
+  // worker — adding it double-counts. The sub-agent count is still
+  // surfaced separately in the sidebar when >0.
+  const workingAgentsList = agents.filter((a) => a.status === 'working');
+  const activeAgents = workingAgentsList.length;
   const tasksInQueue = tasks.filter((t) => t.status !== 'done' && t.status !== 'review').length;
 
   const portraitWorkspaceHeader = !!workspace && isPortrait;
@@ -89,13 +157,21 @@ export function Header({ workspace, isPortrait = true }: HeaderProps) {
             </div>
 
             <div className="flex-1 grid grid-cols-2 gap-2">
-              <div className="min-h-11 rounded border border-mc-border bg-mc-bg-tertiary px-2 flex items-center justify-center gap-1.5 text-xs">
+              <div className="relative group min-h-11 rounded border border-mc-border bg-mc-bg-tertiary px-2 flex items-center justify-center gap-1.5 text-xs cursor-help">
                 <span className="text-mc-accent-cyan font-semibold">{activeAgents}</span>
                 <span className="text-mc-text-secondary">active</span>
+                <div className="hidden group-hover:block absolute top-full mt-1 left-0 right-0 md:left-auto md:right-auto md:w-64 z-40 p-2 rounded-lg border border-mc-border bg-mc-bg shadow-lg">
+                  <div className="text-[11px] uppercase tracking-wider text-mc-text-secondary mb-1.5">Agents active</div>
+                  <ActiveAgentsTooltip activeAgents={workingAgentsList} activeSubAgents={activeSubAgents} />
+                </div>
               </div>
-              <div className="min-h-11 rounded border border-mc-border bg-mc-bg-tertiary px-2 flex items-center justify-center gap-1.5 text-xs">
+              <div className="relative group min-h-11 rounded border border-mc-border bg-mc-bg-tertiary px-2 flex items-center justify-center gap-1.5 text-xs cursor-help">
                 <span className="text-mc-accent-purple font-semibold">{tasksInQueue}</span>
                 <span className="text-mc-text-secondary">queued</span>
+                <div className="hidden group-hover:block absolute top-full mt-1 left-0 right-0 md:left-auto md:right-auto md:w-64 z-40 p-2 rounded-lg border border-mc-border bg-mc-bg shadow-lg">
+                  <div className="text-[11px] uppercase tracking-wider text-mc-text-secondary mb-1.5">Tasks in queue</div>
+                  <QueuedTasksTooltip tasks={tasks} />
+                </div>
               </div>
             </div>
           </div>
@@ -130,13 +206,21 @@ export function Header({ workspace, isPortrait = true }: HeaderProps) {
 
           {workspace && (
             <div className="hidden lg:flex items-center gap-8">
-              <div className="text-center">
+              <div className="relative group text-center cursor-help">
                 <div className="text-2xl font-bold text-mc-accent-cyan">{activeAgents}</div>
                 <div className="text-xs text-mc-text-secondary uppercase">Agents Active</div>
+                <div className="hidden group-hover:block absolute top-full mt-1 left-1/2 -translate-x-1/2 w-64 z-40 p-2 rounded-lg border border-mc-border bg-mc-bg shadow-lg text-left">
+                  <div className="text-[11px] uppercase tracking-wider text-mc-text-secondary mb-1.5">Agents active</div>
+                  <ActiveAgentsTooltip activeAgents={workingAgentsList} activeSubAgents={activeSubAgents} />
+                </div>
               </div>
-              <div className="text-center">
+              <div className="relative group text-center cursor-help">
                 <div className="text-2xl font-bold text-mc-accent-purple">{tasksInQueue}</div>
                 <div className="text-xs text-mc-text-secondary uppercase">Tasks in Queue</div>
+                <div className="hidden group-hover:block absolute top-full mt-1 left-1/2 -translate-x-1/2 w-64 z-40 p-2 rounded-lg border border-mc-border bg-mc-bg shadow-lg text-left">
+                  <div className="text-[11px] uppercase tracking-wider text-mc-text-secondary mb-1.5">Tasks in queue</div>
+                  <QueuedTasksTooltip tasks={tasks} />
+                </div>
               </div>
             </div>
           )}

--- a/src/components/LiveFeed.tsx
+++ b/src/components/LiveFeed.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { ChevronRight, ChevronLeft, Clock } from 'lucide-react';
+import { ChevronUp, ChevronDown, Clock, PanelRightClose, PanelRightOpen } from 'lucide-react';
 import { useMissionControl } from '@/lib/store';
 import type { Event } from '@/lib/types';
 import { formatDistanceToNow } from 'date-fns';
@@ -11,15 +11,21 @@ type FeedFilter = 'all' | 'tasks' | 'agents';
 interface LiveFeedProps {
   mobileMode?: boolean;
   isPortrait?: boolean;
+  // Optional content rendered at the top of the rail, above the filter tabs.
+  // Used by the desktop layout to stack the Ready Deliverables panel above
+  // the feed without creating a competing w-80 wrapper.
+  topSlot?: React.ReactNode;
 }
 
-export function LiveFeed({ mobileMode = false, isPortrait = true }: LiveFeedProps) {
+export function LiveFeed({ mobileMode = false, isPortrait = true, topSlot }: LiveFeedProps) {
   const { events } = useMissionControl();
   const [filter, setFilter] = useState<FeedFilter>('all');
-  const [isMinimized, setIsMinimized] = useState(false);
+  const [isMinimized, setIsMinimized] = useState(false); // whole-rail collapse
+  const [feedCollapsed, setFeedCollapsed] = useState(false); // only hide feed content
 
   const effectiveMinimized = mobileMode ? false : isMinimized;
   const toggleMinimize = () => setIsMinimized(!isMinimized);
+  const toggleFeed = () => setFeedCollapsed(v => !v);
 
   const filteredEvents = events.filter((event) => {
     if (filter === 'all') return true;
@@ -28,28 +34,58 @@ export function LiveFeed({ mobileMode = false, isPortrait = true }: LiveFeedProp
     return true;
   });
 
+  // Whole-rail collapsed view: a slim 12px-wide column with just the expand button.
+  if (effectiveMinimized) {
+    return (
+      <aside className="w-12 bg-mc-bg-secondary border-l border-mc-border flex flex-col items-center py-2 transition-all duration-300 ease-in-out">
+        <button
+          onClick={toggleMinimize}
+          className="p-1 rounded hover:bg-mc-bg-tertiary text-mc-text-secondary hover:text-mc-text transition-colors"
+          aria-label="Expand right panel"
+          title="Expand right panel"
+        >
+          <PanelRightOpen className="w-4 h-4" />
+        </button>
+      </aside>
+    );
+  }
+
   return (
     <aside
       className={`bg-mc-bg-secondary ${mobileMode ? 'border border-mc-border rounded-lg h-full' : 'border-l border-mc-border'} flex flex-col transition-all duration-300 ease-in-out ${
-        effectiveMinimized ? 'w-12' : mobileMode ? 'w-full' : 'w-80'
+        mobileMode ? 'w-full' : 'w-80'
       }`}
     >
-      <div className="p-3 border-b border-mc-border">
-        <div className="flex items-center">
-          {!mobileMode && (
-            <button
-              onClick={toggleMinimize}
-              className="p-1 rounded hover:bg-mc-bg-tertiary text-mc-text-secondary hover:text-mc-text transition-colors"
-              aria-label={effectiveMinimized ? 'Expand feed' : 'Minimize feed'}
-            >
-              {effectiveMinimized ? <ChevronLeft className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
-            </button>
-          )}
-          {!effectiveMinimized && <span className="text-sm font-medium uppercase tracking-wider">Live Feed</span>}
+      {/* Rail toolbar — whole-panel minimize lives here, independent of the
+          LIVE FEED section header so it's always reachable even when the feed
+          (or deliverables) is collapsed. */}
+      {!mobileMode && (
+        <div className="flex items-center justify-end px-2 py-1 border-b border-mc-border/60">
+          <button
+            onClick={toggleMinimize}
+            className="p-1 rounded hover:bg-mc-bg-tertiary text-mc-text-secondary hover:text-mc-text transition-colors"
+            aria-label="Minimize right panel"
+            title="Minimize right panel"
+          >
+            <PanelRightClose className="w-4 h-4" />
+          </button>
         </div>
+      )}
 
-        {!effectiveMinimized && (
-          <div className={`mt-3 ${mobileMode && isPortrait ? 'grid grid-cols-3 gap-2' : 'flex gap-1'}`}>
+      {topSlot && <div className="flex-shrink-0">{topSlot}</div>}
+
+      {/* LIVE FEED section — the header itself is a button that collapses the
+          section independently of the deliverables panel and the whole rail. */}
+      <div className={`border-b border-mc-border flex-shrink-0 ${feedCollapsed ? '' : ''}`}>
+        <button
+          onClick={toggleFeed}
+          className="w-full flex items-center justify-between px-3 py-2 hover:bg-mc-bg-tertiary"
+        >
+          <span className="text-sm font-medium uppercase tracking-wider">Live Feed</span>
+          {feedCollapsed ? <ChevronDown className="w-4 h-4 text-mc-text-secondary" /> : <ChevronUp className="w-4 h-4 text-mc-text-secondary" />}
+        </button>
+        {!feedCollapsed && (
+          <div className={`px-3 pb-3 ${mobileMode && isPortrait ? 'grid grid-cols-3 gap-2' : 'flex gap-1'}`}>
             {(['all', 'tasks', 'agents'] as FeedFilter[]).map((tab) => (
               <button
                 key={tab}
@@ -65,7 +101,7 @@ export function LiveFeed({ mobileMode = false, isPortrait = true }: LiveFeedProp
         )}
       </div>
 
-      {!effectiveMinimized && (
+      {!feedCollapsed && (
         <div className="flex-1 overflow-y-auto p-2 space-y-1 pb-[calc(0.5rem+env(safe-area-inset-bottom))]">
           {filteredEvents.length === 0 ? (
             <div className="text-center py-8 text-mc-text-secondary text-sm">No events yet</div>
@@ -103,6 +139,10 @@ function EventItem({ event }: { event: Event }) {
         return '🚚';
       case 'convoy_completed':
         return '🏁';
+      case 'task_archived':
+        return '📦';
+      case 'task_unarchived':
+        return '📤';
       default:
         return '📌';
     }

--- a/src/components/MissionQueue.tsx
+++ b/src/components/MissionQueue.tsx
@@ -8,6 +8,7 @@ import { getConfig } from '@/lib/config';
 import { useUnreadCounts } from '@/hooks/useUnreadCounts';
 import type { Task, TaskStatus } from '@/lib/types';
 import { TaskModal } from './TaskModal';
+import { BlockedBadge } from './BlockedBadge';
 import { formatDistanceToNow } from 'date-fns';
 
 interface MissionQueueProps {
@@ -462,36 +463,17 @@ function TaskCard({ task, onDragStart, onClick, onMoveStatus, isDragging, mobile
           </div>
         )}
 
-        {isAssigned && dispatchError && (
-          <div className={`flex items-start gap-2 ${portraitMode ? 'mb-3 py-2 px-3' : 'mb-2 py-1.5 px-2.5'} bg-red-500/10 rounded-md border border-red-500/30`}>
-            <div className="w-2 h-2 bg-red-400 rounded-full mt-1 flex-shrink-0" />
-            <span className="text-xs text-red-300">Assigned, but blocked: {dispatchError}</span>
-          </div>
-        )}
+        {/* Single source of truth for all block / queue / offline-agent
+            indicators. Previously spread across four render blocks that
+            each read a different slice of task state — see
+            src/lib/blocked-state.ts for the consolidated logic. */}
+        <BlockedBadge task={task} portraitMode={portraitMode} />
 
+        {/* The dedicated "Assigned and validating" / "Stuck in assigned"
+            badge still shows a retry-dispatch button, so keep it when there
+            is no structured block reason yet. */}
         {isAssigned && !dispatchError && (
           <AssignedStatusBadge task={task} portraitMode={portraitMode} />
-        )}
-
-        {task.status === 'inbox' && !task.assigned_agent_id && (
-          <div className={`flex items-center gap-2 ${portraitMode ? 'mb-3 py-2 px-3' : 'mb-2 py-1.5 px-2.5'} bg-amber-500/10 rounded-md border border-amber-500/30`}>
-            <div className="w-2 h-2 bg-amber-400 rounded-full flex-shrink-0" />
-            <span className="text-xs text-amber-200">Needs agent — assign to start</span>
-          </div>
-        )}
-
-        {['testing', 'verification'].includes(task.status) && dispatchError && (
-          <div className={`flex items-start gap-2 ${portraitMode ? 'mb-3 py-2 px-3' : 'mb-2 py-1.5 px-2.5'} bg-red-500/10 rounded-md border border-red-500/30`}>
-            <div className="w-2 h-2 bg-red-400 rounded-full mt-1 flex-shrink-0" />
-            <span className="text-xs text-red-300">{dispatchError}</span>
-          </div>
-        )}
-
-        {task.status === 'review' && !dispatchError && (
-          <div className={`flex items-center gap-2 ${portraitMode ? 'mb-3 py-2 px-3' : 'mb-2 py-1.5 px-2.5'} bg-cyan-500/10 rounded-md border border-cyan-500/30`}>
-            <div className="w-2 h-2 bg-cyan-400 rounded-full flex-shrink-0" />
-            <span className="text-xs text-cyan-200">In queue — waiting for verification</span>
-          </div>
         )}
 
         {task.assigned_agent && (

--- a/src/components/MissionQueue.tsx
+++ b/src/components/MissionQueue.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Plus, ChevronRight, GripVertical, ArrowRightLeft, AlertTriangle, MessageSquare } from 'lucide-react';
+import { Plus, ChevronRight, GripVertical, ArrowRightLeft, AlertTriangle, MessageSquare, Archive, ChevronsLeft } from 'lucide-react';
 import { useMissionControl } from '@/lib/store';
 import { triggerAutoDispatch, shouldTriggerAutoDispatch } from '@/lib/auto-dispatch';
 import { getConfig } from '@/lib/config';
@@ -32,7 +32,25 @@ const COLUMNS: { id: TaskStatus; label: string; color: string }[] = [
 export function MissionQueue({ workspaceId, mobileMode = false, isPortrait = true }: MissionQueueProps) {
   const { tasks, updateTaskStatus, addEvent } = useMissionControl();
   const [compactEmptyColumns, setCompactEmptyColumns] = useState(true);
+  const [showArchived, setShowArchived] = useState(false);
+  // Per-column manual override. Without an entry, the column uses the default
+  // (empty = collapsed to a vertical rail, non-empty = expanded).
+  const [columnOverride, setColumnOverride] = useState<Record<string, 'expanded' | 'collapsed'>>({});
   const unreadCounts = useUnreadCounts();
+
+  const isColumnCollapsed = (id: TaskStatus, count: number): boolean => {
+    const override = columnOverride[id];
+    if (override === 'expanded') return false;
+    if (override === 'collapsed') return true;
+    return count === 0;
+  };
+
+  const toggleColumn = (id: TaskStatus, currentlyCollapsed: boolean) => {
+    setColumnOverride(prev => ({
+      ...prev,
+      [id]: currentlyCollapsed ? 'expanded' : 'collapsed',
+    }));
+  };
 
   useEffect(() => {
     const cfg = getConfig();
@@ -53,7 +71,8 @@ export function MissionQueue({ workspaceId, mobileMode = false, isPortrait = tru
   const [statusMoveTask, setStatusMoveTask] = useState<Task | null>(null);
   const [pendingMove, setPendingMove] = useState<{ task: Task; targetStatus: TaskStatus } | null>(null);
 
-  const getTasksByStatus = (status: TaskStatus) => tasks.filter((task) => task.status === status);
+  const getTasksByStatus = (status: TaskStatus) =>
+    tasks.filter((task) => task.status === status && (showArchived || !task.is_archived));
 
   // Active pipeline states where manual moves are dangerous
   const ACTIVE_PIPELINE_STATES: TaskStatus[] = ['assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification'];
@@ -167,13 +186,28 @@ export function MissionQueue({ workspaceId, mobileMode = false, isPortrait = tru
           <ChevronRight className="w-4 h-4 text-mc-text-secondary" />
           <span className="text-sm font-medium uppercase tracking-wider">Mission Queue</span>
         </div>
-        <button
-          onClick={() => setShowCreateModal(true)}
-          className="flex items-center gap-2 px-4 min-h-11 bg-mc-accent-pink text-mc-bg rounded text-sm font-medium hover:bg-mc-accent-pink/90"
-        >
-          <Plus className="w-4 h-4" />
-          New Task
-        </button>
+        <div className="flex items-center gap-2">
+          <label
+            className="flex items-center gap-1.5 text-xs text-mc-text-secondary cursor-pointer select-none"
+            title="Include archived tasks in the board"
+          >
+            <input
+              type="checkbox"
+              checked={showArchived}
+              onChange={e => setShowArchived(e.target.checked)}
+              className="accent-mc-accent"
+            />
+            <Archive className="w-3.5 h-3.5" />
+            Archived
+          </label>
+          <button
+            onClick={() => setShowCreateModal(true)}
+            className="flex items-center gap-2 px-4 min-h-11 bg-mc-accent-pink text-mc-bg rounded text-sm font-medium hover:bg-mc-accent-pink/90"
+          >
+            <Plus className="w-4 h-4" />
+            New Task
+          </button>
+        </div>
       </div>
 
       {!mobileMode ? (
@@ -181,6 +215,35 @@ export function MissionQueue({ workspaceId, mobileMode = false, isPortrait = tru
           {COLUMNS.map((column) => {
             const columnTasks = getTasksByStatus(column.id);
             const hasTasks = columnTasks.length > 0;
+            const collapsed = isColumnCollapsed(column.id, columnTasks.length);
+
+            if (collapsed) {
+              // Vertical rail — narrow column with rotated label. Still acts as
+              // a drop target. Whole body is a button that expands the column
+              // back to horizontal.
+              return (
+                <button
+                  key={column.id}
+                  type="button"
+                  onClick={() => toggleColumn(column.id, true)}
+                  onDragOver={handleDragOver}
+                  onDrop={(e) => handleDrop(e, column.id)}
+                  className={`flex-none w-10 flex flex-col items-center py-2 gap-2 bg-mc-bg rounded-lg border border-mc-border/50 border-t-2 transition-[width] duration-200 hover:bg-mc-bg-tertiary ${column.color}`}
+                  title={`${column.label} (${columnTasks.length}) — click to expand`}
+                >
+                  <span className="text-[10px] bg-mc-bg-tertiary px-1.5 py-0.5 rounded text-mc-text-secondary">
+                    {columnTasks.length}
+                  </span>
+                  <span
+                    className="text-xs font-medium uppercase text-mc-text-secondary tracking-wider"
+                    style={{ writingMode: 'vertical-rl' }}
+                  >
+                    {column.label}
+                  </span>
+                </button>
+              );
+            }
+
             return (
               <div
                 key={column.id}
@@ -191,7 +254,17 @@ export function MissionQueue({ workspaceId, mobileMode = false, isPortrait = tru
               >
                 <div className="p-2 border-b border-mc-border flex items-center justify-between gap-2">
                   <span className="text-xs font-medium uppercase text-mc-text-secondary whitespace-nowrap">{column.label}</span>
-                  <span className="text-xs bg-mc-bg-tertiary px-2 py-0.5 rounded text-mc-text-secondary">{columnTasks.length}</span>
+                  <div className="flex items-center gap-1">
+                    <span className="text-xs bg-mc-bg-tertiary px-2 py-0.5 rounded text-mc-text-secondary">{columnTasks.length}</span>
+                    <button
+                      type="button"
+                      onClick={() => toggleColumn(column.id, false)}
+                      className="p-0.5 rounded text-mc-text-secondary hover:text-mc-text hover:bg-mc-bg-tertiary"
+                      title="Collapse column"
+                    >
+                      <ChevronsLeft className="w-3.5 h-3.5" />
+                    </button>
+                  </div>
                 </div>
 
                 <div className={`flex-1 overflow-y-auto p-2 ${hasTasks ? 'space-y-2' : ''}`}>
@@ -417,6 +490,8 @@ function TaskCard({ task, onDragStart, onClick, onMoveStatus, isDragging, mobile
   const isAssigned = task.status === 'assigned';
   const dispatchError = task.planning_dispatch_error;
 
+  const isArchived = task.is_archived === 1;
+
   return (
     <div
       draggable={!mobileMode}
@@ -424,7 +499,7 @@ function TaskCard({ task, onDragStart, onClick, onMoveStatus, isDragging, mobile
       onClick={onClick}
       className={`group bg-mc-bg-secondary border rounded-lg cursor-pointer transition-all hover:shadow-lg hover:shadow-black/20 ${
         isDragging ? 'opacity-50 scale-95' : ''
-      } ${isPlanning ? 'border-purple-500/40 hover:border-purple-500' : 'border-mc-border/50 hover:border-mc-accent/40'}`}
+      } ${isArchived ? 'opacity-60 border-dashed' : ''} ${isPlanning ? 'border-purple-500/40 hover:border-purple-500' : 'border-mc-border/50 hover:border-mc-accent/40'}`}
     >
       {!mobileMode && (
         <div className="flex items-center justify-center py-1.5 border-b border-mc-border/30 opacity-0 group-hover:opacity-100 transition-opacity">
@@ -434,7 +509,18 @@ function TaskCard({ task, onDragStart, onClick, onMoveStatus, isDragging, mobile
 
       <div className={portraitMode ? 'p-4' : 'p-3'}>
         <div className="flex items-start justify-between gap-1.5">
-          <h4 className={`font-medium leading-snug line-clamp-2 ${portraitMode ? 'text-sm mb-3' : 'text-xs mb-2'}`}>{task.title}</h4>
+          <h4 className={`font-medium leading-snug line-clamp-2 ${portraitMode ? 'text-sm mb-3' : 'text-xs mb-2'}`}>
+            {isArchived && (
+              <span
+                className="inline-flex items-center gap-0.5 mr-1.5 px-1.5 py-0.5 rounded bg-mc-bg-tertiary text-[10px] text-mc-text-secondary align-middle"
+                title="Archived"
+              >
+                <Archive className="w-2.5 h-2.5" />
+                Archived
+              </span>
+            )}
+            {task.title}
+          </h4>
           {unreadCount > 0 && (
             <span className="flex-shrink-0 flex items-center gap-1 px-1.5 py-0.5 bg-mc-accent/15 text-mc-accent rounded text-[10px] font-medium" title={`${unreadCount} unread message${unreadCount !== 1 ? 's' : ''}`}>
               <MessageSquare className="w-2.5 h-2.5" />

--- a/src/components/ReadyDeliverablesPanel.tsx
+++ b/src/components/ReadyDeliverablesPanel.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+/**
+ * Right-rail panel that surfaces every task with at least one deliverable.
+ * Persistent (state view), not event-stream. Separate from LiveFeed so deliverable
+ * rows don't churn when unrelated events arrive.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ChevronDown, ChevronUp, Archive, Download, Package } from 'lucide-react';
+import { useMissionControl } from '@/lib/store';
+
+const RELEVANT_EVENT_TYPES = [
+  'deliverable_added',
+  'task_status_changed',
+  'task_archived',
+  'task_unarchived',
+  'task_deleted',
+  'task_completed',
+];
+
+interface Row {
+  task_id: string;
+  task_title: string;
+  status: string;
+  is_archived: number;
+  file_count: number;
+  mc_count: number;
+  last_added_at: string;
+}
+
+interface Props {
+  workspaceId?: string;
+}
+
+export function ReadyDeliverablesPanel({ workspaceId }: Props) {
+  const [rows, setRows] = useState<Row[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [expanded, setExpanded] = useState(true);
+  const [showArchived, setShowArchived] = useState(false);
+  const { events } = useMissionControl();
+
+  const load = useCallback(async () => {
+    try {
+      const qs = workspaceId ? `?workspace_id=${encodeURIComponent(workspaceId)}` : '';
+      const res = await fetch(`/api/deliverables/tasks-with-deliverables${qs}`);
+      if (res.ok) {
+        setRows(await res.json());
+      }
+    } catch (e) {
+      console.error('[ReadyDeliverablesPanel] load failed', e);
+    } finally {
+      setLoading(false);
+    }
+  }, [workspaceId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // Refetch when a relevant event arrives. We can't subscribe to the SSE stream
+  // directly from here, but the store holds the last 100 events — so re-running
+  // when a matching one lands at the head is good enough. Comparing the
+  // string-typed column rather than the narrower EventType keeps this in sync
+  // with the broader set of types that actually flow into the store.
+  const latestRelevantId = useMemo(() => {
+    const match = events.find(e => RELEVANT_EVENT_TYPES.includes(e.type as string));
+    return match?.id;
+  }, [events]);
+  useEffect(() => {
+    if (latestRelevantId) load();
+  }, [latestRelevantId, load]);
+
+  const visible = rows.filter(r => showArchived || r.is_archived === 0);
+
+  const statusClass = (s: string) => {
+    if (s === 'done') return 'bg-green-700/30 text-green-300';
+    if (s === 'cancelled') return 'bg-red-700/30 text-red-300';
+    if (s === 'in_progress' || s === 'testing' || s === 'review' || s === 'verification') {
+      return 'bg-yellow-700/30 text-yellow-300';
+    }
+    return 'bg-mc-bg-tertiary text-mc-text-secondary';
+  };
+
+  return (
+    <div className="border-b border-mc-border bg-mc-bg-secondary">
+      <button
+        onClick={() => setExpanded(v => !v)}
+        className="w-full flex items-center justify-between px-3 py-2 hover:bg-mc-bg-tertiary"
+      >
+        <div className="flex items-center gap-2">
+          <Package className="w-4 h-4 text-mc-accent" />
+          <span className="text-sm font-medium uppercase tracking-wider">Deliverables</span>
+          {visible.length > 0 && (
+            <span className="text-xs px-1.5 py-0.5 rounded bg-mc-bg-tertiary text-mc-text-secondary">
+              {visible.length}
+            </span>
+          )}
+        </div>
+        {expanded ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+      </button>
+
+      {expanded && (
+        <div className="px-3 pb-3">
+          <label className="flex items-center gap-2 text-xs text-mc-text-secondary mb-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={showArchived}
+              onChange={e => setShowArchived(e.target.checked)}
+              className="accent-mc-accent"
+            />
+            Show archived
+          </label>
+
+          {loading ? (
+            <div className="text-xs text-mc-text-secondary py-2">Loading...</div>
+          ) : visible.length === 0 ? (
+            <div className="text-xs text-mc-text-secondary py-2">No deliverables yet</div>
+          ) : (
+            <div className="space-y-2 max-h-64 overflow-y-auto">
+              {visible.map(row => (
+                <div
+                  key={row.task_id}
+                  className={`p-2 rounded border border-mc-border bg-mc-bg ${row.is_archived ? 'opacity-60' : ''}`}
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <span
+                      className="flex-1 min-w-0 text-sm text-mc-text truncate"
+                      title={row.task_title}
+                    >
+                      {row.task_title}
+                    </span>
+                    {row.mc_count > 0 && (
+                      <a
+                        href={`/api/tasks/${row.task_id}/deliverables/download`}
+                        className="flex-shrink-0 p-1 rounded text-mc-accent hover:bg-mc-bg-tertiary"
+                        title={`Download ${row.mc_count} file${row.mc_count === 1 ? '' : 's'}`}
+                      >
+                        <Download className="w-3.5 h-3.5" />
+                      </a>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2 mt-1 text-xs">
+                    <span className={`px-1.5 py-0.5 rounded capitalize ${statusClass(row.status)}`}>
+                      {row.status.replace(/_/g, ' ')}
+                    </span>
+                    <span className="text-mc-text-secondary">
+                      {row.file_count} file{row.file_count === 1 ? '' : 's'}
+                    </span>
+                    {row.mc_count < row.file_count && (
+                      <span className="text-mc-text-secondary" title="Some deliverables are host-only">
+                        ({row.mc_count} web)
+                      </span>
+                    )}
+                    {row.is_archived === 1 && (
+                      <span className="flex items-center gap-0.5 text-mc-text-secondary">
+                        <Archive className="w-3 h-3" />
+                        archived
+                      </span>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useCallback } from 'react';
-import { X, Save, Trash2, Activity, Package, Bot, ClipboardList, Plus, Users, ImageIcon, Truck, Radio, MessageSquare, ExternalLink, HardDrive } from 'lucide-react';
+import { X, Save, Trash2, Activity, Package, Bot, ClipboardList, Plus, Users, ImageIcon, Truck, Radio, MessageSquare, ExternalLink, HardDrive, Archive, ArchiveRestore } from 'lucide-react';
 import { useMissionControl } from '@/lib/store';
 import { triggerAutoDispatch, shouldTriggerAutoDispatch } from '@/lib/auto-dispatch';
 import { ActivityLog } from './ActivityLog';
@@ -66,6 +66,7 @@ export function TaskModal({ task, onClose, workspaceId }: TaskModalProps) {
   const [saveError, setSaveError] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [isArchiving, setIsArchiving] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent, keepOpen = false) => {
     e.preventDefault();
@@ -168,6 +169,30 @@ export function TaskModal({ task, onClose, workspaceId }: TaskModalProps) {
       setSaveError(error instanceof Error ? error.message : 'Network error — please try again');
     } finally {
       setIsSubmitting(false);
+    }
+  };
+
+  const handleArchiveToggle = async () => {
+    if (!task) return;
+    const shouldArchive = !task.is_archived;
+    setIsArchiving(true);
+    try {
+      const res = await fetch(`/api/tasks/${task.id}/archive`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ archived: shouldArchive }),
+      });
+      if (res.ok) {
+        const updated = await res.json();
+        useMissionControl.setState((state) => ({
+          tasks: state.tasks.map((t) => (t.id === updated.id ? { ...t, ...updated } : t)),
+        }));
+        onClose();
+      }
+    } catch (error) {
+      console.error('Failed to toggle archive:', error);
+    } finally {
+      setIsArchiving(false);
     }
   };
 
@@ -464,9 +489,20 @@ export function TaskModal({ task, onClose, workspaceId }: TaskModalProps) {
                 <>
                   <button
                     type="button"
+                    onClick={handleArchiveToggle}
+                    disabled={isArchiving}
+                    className="min-h-11 flex items-center gap-2 px-3 py-2 text-mc-text-secondary hover:text-mc-text hover:bg-mc-bg-tertiary rounded text-sm disabled:opacity-50"
+                    title={task.is_archived ? 'Restore from archive' : 'Archive (preserves deliverables)'}
+                  >
+                    {task.is_archived ? <ArchiveRestore className="w-4 h-4" /> : <Archive className="w-4 h-4" />}
+                    {isArchiving ? '...' : task.is_archived ? 'Unarchive' : 'Archive'}
+                  </button>
+                  <button
+                    type="button"
                     onClick={handleDelete}
                     disabled={isDeleting}
                     className="min-h-11 flex items-center gap-2 px-3 py-2 text-mc-accent-red hover:bg-mc-accent-red/10 rounded text-sm disabled:opacity-50"
+                    title="Permanently delete this task and its deliverables"
                   >
                     <Trash2 className="w-4 h-4" />
                     {isDeleting ? 'Deleting...' : 'Delete'}

--- a/src/components/WorkspaceDashboard.tsx
+++ b/src/components/WorkspaceDashboard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Plus, ArrowRight, Folder, Users, CheckSquare, Trash2, AlertTriangle, Activity, Rocket } from 'lucide-react';
+import { Plus, ArrowRight, Folder, Users, CheckSquare, Trash2, AlertTriangle, Activity, Rocket, Bug } from 'lucide-react';
 import Link from 'next/link';
 import type { WorkspaceStats } from '@/lib/types';
 
@@ -63,6 +63,14 @@ export function WorkspaceDashboard() {
               >
                 <Activity className="w-4 h-4" />
                 Activity Dashboard
+              </Link>
+              <Link
+                href="/debug"
+                className="min-h-11 px-4 rounded-lg border border-mc-border bg-mc-bg text-mc-text-secondary hover:text-mc-text hover:bg-mc-bg-tertiary flex items-center gap-2 text-sm"
+                title="Verbose debugging — capture MC↔agent traffic"
+              >
+                <Bug className="w-4 h-4" />
+                Debug
               </Link>
               <button
                 onClick={() => setShowCreateModal(true)}

--- a/src/lib/activity-log.ts
+++ b/src/lib/activity-log.ts
@@ -1,0 +1,71 @@
+import { v4 as uuidv4 } from 'uuid';
+import { queryOne, run } from '@/lib/db';
+
+/**
+ * Typed server-side activity types. NONE of these satisfy the evidence gate
+ * at src/lib/task-governance.ts:hasStageEvidence — that gate deliberately
+ * accepts only ('completed','file_created','updated') and this module must
+ * not broaden it. These types exist for visibility, audit, and stall
+ * detection — they fill in the gap where agent heartbeats used to land as
+ * `activity_type = null`.
+ */
+export type ServerActivityType =
+  | 'heartbeat'        // throttled proof-of-life from runHealthCheckCycle
+  | 'dispatched'       // reserved; dispatch/route.ts still uses status_changed
+  | 'admin_release'    // written by /admin/release-stall
+  | 'stall_detected'   // stall scanner flags a deadlocked task
+  | 'stall_notified'   // stall scanner messaged coordinator / webhook
+  | 'stall_recovered'  // coordinator / dispatch clears a stall flag
+  | 'coordinator_stalled'   // convoy coordinator itself can't be reached
+  | 'coordinator_missing';  // convoy has no live coordinator
+
+interface LogActivityInput {
+  taskId: string;
+  type: ServerActivityType;
+  message: string;
+  agentId?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export function logTaskActivity(input: LogActivityInput): string {
+  const id = uuidv4();
+  const now = new Date().toISOString();
+  run(
+    `INSERT INTO task_activities (id, task_id, agent_id, activity_type, message, metadata, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    [
+      id,
+      input.taskId,
+      input.agentId ?? null,
+      input.type,
+      input.message,
+      input.metadata ? JSON.stringify(input.metadata) : null,
+      now,
+    ]
+  );
+  return id;
+}
+
+/**
+ * Log an activity row only if the most recent activity of the same type for
+ * this task is older than `thresholdSeconds`. Keeps high-frequency signals
+ * (heartbeats, re-scans) from flooding the activity feed.
+ *
+ * Returns the new activity id, or null if throttled.
+ */
+export function logTaskActivityThrottled(
+  input: LogActivityInput,
+  thresholdSeconds: number
+): string | null {
+  const latest = queryOne<{ created_at: string }>(
+    `SELECT created_at FROM task_activities
+     WHERE task_id = ? AND activity_type = ?
+     ORDER BY created_at DESC LIMIT 1`,
+    [input.taskId, input.type]
+  );
+  if (latest) {
+    const ageSeconds = (Date.now() - new Date(latest.created_at).getTime()) / 1000;
+    if (ageSeconds < thresholdSeconds) return null;
+  }
+  return logTaskActivity(input);
+}

--- a/src/lib/agent-catalog-sync.ts
+++ b/src/lib/agent-catalog-sync.ts
@@ -24,11 +24,20 @@ let syncing: Promise<number> | null = null;
 
 function normalizeRole(name: string): string {
   const n = name.toLowerCase();
+  // Order matters: more-specific patterns first. Without the research /
+  // write / coord branches below, gateway-synced agents named "Researcher",
+  // "Writer", or "Coordinator" all fell through to 'builder', which hid
+  // them from pickDynamicAgent's role-based lookup and caused every
+  // convoy sub-task to route to the single `role='builder'` agent.
   if (n.includes('learn')) return 'learner';
   if (n.includes('test')) return 'tester';
   if (n.includes('review') || n.includes('verif')) return 'reviewer';
   if (n.includes('fix')) return 'fixer';
   if (n.includes('senior')) return 'senior';
+  if (n.includes('research')) return 'researcher';
+  if (n.includes('writ')) return 'writer';
+  if (n.includes('design')) return 'designer';
+  if (n.includes('coord')) return 'coordinator';
   if (n.includes('plan') || n.includes('orch')) return 'orchestrator';
   return 'builder';
 }

--- a/src/lib/agent-catalog-sync.ts
+++ b/src/lib/agent-catalog-sync.ts
@@ -146,19 +146,25 @@ export function ensureCatalogSyncScheduled(): void {
 }
 
 export function getAgentByPreferredRoles(taskId: string, preferredRoles: string[]): { id: string; name: string } | null {
+  // Filter out operator-disabled agents (is_active=0). COALESCE(is_active, 1)
+  // guards rows created before the column existed.
   for (const role of preferredRoles) {
     const byTaskRole = queryOne<{ id: string; name: string }>(
       `SELECT a.id, a.name
        FROM task_roles tr
        JOIN agents a ON a.id = tr.agent_id
-       WHERE tr.task_id = ? AND tr.role = ? AND a.status != 'offline'
+       WHERE tr.task_id = ? AND tr.role = ?
+         AND a.status != 'offline'
+         AND COALESCE(a.is_active, 1) = 1
        LIMIT 1`,
       [taskId, role]
     );
     if (byTaskRole) return byTaskRole;
 
     const byGlobalRole = queryOne<{ id: string; name: string }>(
-      `SELECT id, name FROM agents WHERE role = ? AND status != 'offline' ORDER BY updated_at DESC LIMIT 1`,
+      `SELECT id, name FROM agents
+       WHERE role = ? AND status != 'offline' AND COALESCE(is_active, 1) = 1
+       ORDER BY updated_at DESC LIMIT 1`,
       [role]
     );
     if (byGlobalRole) return byGlobalRole;

--- a/src/lib/agent-catalog-sync.ts
+++ b/src/lib/agent-catalog-sync.ts
@@ -1,5 +1,6 @@
 import { queryAll, queryOne, run, transaction } from '@/lib/db';
 import { getOpenClawClient } from '@/lib/openclaw/client';
+import { logDebugEvent } from '@/lib/debug-log';
 
 interface GatewayAgent {
   id?: string;
@@ -57,7 +58,25 @@ export async function syncGatewayAgentsToCatalog(options?: { force?: boolean; re
       await client.connect();
     }
 
-    const gatewayAgents = (await client.listAgents()) as GatewayAgent[];
+    const listStart = Date.now();
+    let gatewayAgents: GatewayAgent[] = [];
+    let listError: string | null = null;
+    try {
+      gatewayAgents = (await client.listAgents()) as GatewayAgent[];
+    } catch (err) {
+      listError = (err as Error).message;
+      throw err;
+    } finally {
+      logDebugEvent({
+        type: 'gateway.list_agents',
+        direction: 'outbound',
+        durationMs: Date.now() - listStart,
+        responseBody: { count: gatewayAgents.length, agents: gatewayAgents.map(a => ({ id: a.id, name: a.name })) },
+        error: listError,
+        metadata: { reason: options?.reason || 'automatic' },
+      });
+    }
+
     const existing = queryAll<{ id: string; gateway_agent_id: string | null }>(
       `SELECT id, gateway_agent_id FROM agents WHERE gateway_agent_id IS NOT NULL`
     );

--- a/src/lib/agent-health.ts
+++ b/src/lib/agent-health.ts
@@ -3,7 +3,14 @@ import { queryOne, queryAll, run } from '@/lib/db';
 import { broadcast } from '@/lib/events';
 import { getMissionControlUrl } from '@/lib/config';
 import { buildCheckpointContext } from '@/lib/checkpoint';
+import { logTaskActivityThrottled } from '@/lib/activity-log';
+import { scanStalledTasks } from '@/lib/stall-detection';
 import type { Agent, AgentHealth, AgentHealthState, Task } from '@/lib/types';
+
+// Heartbeat rows are throttled so the activity feed stays readable. 5 min
+// is a good default: runHealthCheckCycle fires every 2 min (see the SSE
+// stream route), so every 2nd-3rd pulse lands a row.
+const HEARTBEAT_THROTTLE_SECONDS = 300;
 
 const STALL_THRESHOLD_MINUTES = 5;
 const STUCK_THRESHOLD_MINUTES = 15;
@@ -130,6 +137,23 @@ export async function runHealthCheckCycle(): Promise<AgentHealth[]> {
       );
     }
 
+    // Healthy heartbeats were previously not logged at all — agents' 2-minute
+    // pings landed as `activity_type = null` elsewhere, so a task could look
+    // idle (no typed activity rows) even while its agent was alive. The stall
+    // scanner (Phase 3) trusts `task_activities` as the source of truth, so
+    // we need a typed row here. Throttled to 5 min to avoid feed noise.
+    if (activeTask && healthState === 'working') {
+      logTaskActivityThrottled(
+        {
+          taskId: activeTask.id,
+          type: 'heartbeat',
+          agentId,
+          message: `Agent alive — last real activity confirmed by health pulse`,
+        },
+        HEARTBEAT_THROTTLE_SECONDS
+      );
+    }
+
     // Auto-nudge after consecutive stall checks
     const updatedHealth = queryOne<AgentHealth>('SELECT * FROM agent_health WHERE agent_id = ?', [agentId]);
     if (updatedHealth) {
@@ -204,6 +228,17 @@ export async function runHealthCheckCycle(): Promise<AgentHealth[]> {
         [uuidv4(), agentId, now]
       );
     }
+  }
+
+  // Run the stall scanner after the per-agent pass. This is the natural
+  // place for it: both share the same 2-minute cadence from the SSE
+  // stream, and the scanner's throttle windows (NOTIFY_THROTTLE_MINUTES,
+  // STALL_DETECTION_MINUTES) make repeated calls cheap. A scanner failure
+  // should never break the health cycle — so we catch and log.
+  try {
+    await scanStalledTasks();
+  } catch (err) {
+    console.error('[Health] scanStalledTasks failed:', err);
   }
 
   return results;

--- a/src/lib/agent-resolver.ts
+++ b/src/lib/agent-resolver.ts
@@ -32,7 +32,8 @@ export const MIN_NEW_AGENT_RATIONALE_LENGTH = 20;
  * Prefers gateway-linked agents (ones that actually map to a live OpenClaw
  * session) but also includes local agents that carry a session_key_prefix —
  * those still route correctly. Agents with neither are "ghosts" and are
- * filtered out.
+ * filtered out. Operator-disabled agents (is_active=0) are excluded from the
+ * planning roster so the planner doesn't propose work for them.
  */
 export function getAgentRoster(workspaceId: string): RosterAgent[] {
   return queryAll<RosterAgent>(
@@ -41,6 +42,7 @@ export function getAgentRoster(workspaceId: string): RosterAgent[] {
      WHERE workspace_id = ?
        AND (gateway_agent_id IS NOT NULL OR session_key_prefix IS NOT NULL)
        AND status != 'offline'
+       AND COALESCE(is_active, 1) = 1
      ORDER BY is_master DESC, name ASC`,
     [workspaceId]
   );
@@ -83,6 +85,7 @@ export function findAgentForRole(workspaceId: string, role: string): RosterAgent
        AND LOWER(role) = LOWER(?)
        AND (gateway_agent_id IS NOT NULL OR session_key_prefix IS NOT NULL)
        AND status != 'offline'
+       AND COALESCE(is_active, 1) = 1
      ORDER BY gateway_agent_id IS NOT NULL DESC, status = 'standby' DESC, updated_at DESC
      LIMIT 1`,
     [workspaceId, role]
@@ -96,6 +99,7 @@ export function findAgentForRole(workspaceId: string, role: string): RosterAgent
        AND (LOWER(role) LIKE '%' || LOWER(?) || '%' OR LOWER(?) LIKE '%' || LOWER(role) || '%')
        AND (gateway_agent_id IS NOT NULL OR session_key_prefix IS NOT NULL)
        AND status != 'offline'
+       AND COALESCE(is_active, 1) = 1
      ORDER BY gateway_agent_id IS NOT NULL DESC, status = 'standby' DESC, updated_at DESC
      LIMIT 1`,
     [workspaceId, role, role]

--- a/src/lib/agent-resolver.ts
+++ b/src/lib/agent-resolver.ts
@@ -1,0 +1,115 @@
+/**
+ * Agent roster + role-to-agent resolution used by the convoy planner and the
+ * planning-session completion handler.
+ *
+ * Background: the convoy planner and the task-planning LLM both historically
+ * invented new agents every run, which produced "ghost" agents — rows with no
+ * gateway_agent_id and no session_key_prefix that received task assignments
+ * but dispatched nowhere. This module gives callers a single place to look up
+ * existing gateway-linked agents and a single policy for reuse-vs-create.
+ */
+import { queryAll, queryOne } from '@/lib/db';
+
+export interface RosterAgent {
+  id: string;
+  name: string;
+  role: string;
+  description: string | null;
+  status: string;
+  session_key_prefix: string | null;
+  gateway_agent_id: string | null;
+  is_master: number;
+  workspace_id: string;
+}
+
+/** Policy caps shared by planning + convoy flows. Keep small and explicit. */
+export const MAX_CONVOY_SUBTASKS = parseInt(process.env.MAX_CONVOY_SUBTASKS || '6', 10);
+export const MAX_TASKS_PER_AGENT = parseInt(process.env.MAX_TASKS_PER_AGENT || '2', 10);
+export const MIN_NEW_AGENT_RATIONALE_LENGTH = 20;
+
+/**
+ * Return all agents that are eligible to be assigned work in this workspace.
+ * Prefers gateway-linked agents (ones that actually map to a live OpenClaw
+ * session) but also includes local agents that carry a session_key_prefix —
+ * those still route correctly. Agents with neither are "ghosts" and are
+ * filtered out.
+ */
+export function getAgentRoster(workspaceId: string): RosterAgent[] {
+  return queryAll<RosterAgent>(
+    `SELECT id, name, role, description, status, session_key_prefix, gateway_agent_id, is_master, workspace_id
+     FROM agents
+     WHERE workspace_id = ?
+       AND (gateway_agent_id IS NOT NULL OR session_key_prefix IS NOT NULL)
+       AND status != 'offline'
+     ORDER BY is_master DESC, name ASC`,
+    [workspaceId]
+  );
+}
+
+/**
+ * Format the roster as plain-text lines for injection into an LLM prompt.
+ * Empty roster returns a short notice instead of an empty block, so the LLM
+ * handles bootstrap workspaces gracefully ("no existing agents, create new").
+ */
+export function formatRosterForPrompt(roster: RosterAgent[]): string {
+  if (roster.length === 0) {
+    return 'No existing agents are provisioned for this workspace — create whichever roles are needed.';
+  }
+  return roster
+    .map(a => {
+      const linked = a.gateway_agent_id ? ' [gateway]' : '';
+      const master = a.is_master ? ' [orchestrator]' : '';
+      return `- id: ${a.id} | name: ${a.name} | role: ${a.role} | status: ${a.status}${linked}${master}`;
+    })
+    .join('\n');
+}
+
+/**
+ * Look up an existing agent in the workspace whose role matches `role`,
+ * preferring gateway-linked agents. Used by the planning-completion handler
+ * to avoid inserting a duplicate when the LLM proposes an agent for a role
+ * that's already staffed.
+ *
+ * Matching is case-insensitive and also tolerates partial matches (e.g. the
+ * LLM says "Tester" and the roster has role "tester" or "QA Tester"). Exact
+ * matches win over partial matches.
+ */
+export function findAgentForRole(workspaceId: string, role: string): RosterAgent | null {
+  if (!role) return null;
+  const exact = queryOne<RosterAgent>(
+    `SELECT id, name, role, description, status, session_key_prefix, gateway_agent_id, is_master, workspace_id
+     FROM agents
+     WHERE workspace_id = ?
+       AND LOWER(role) = LOWER(?)
+       AND (gateway_agent_id IS NOT NULL OR session_key_prefix IS NOT NULL)
+       AND status != 'offline'
+     ORDER BY gateway_agent_id IS NOT NULL DESC, status = 'standby' DESC, updated_at DESC
+     LIMIT 1`,
+    [workspaceId, role]
+  );
+  if (exact) return exact;
+
+  return queryOne<RosterAgent>(
+    `SELECT id, name, role, description, status, session_key_prefix, gateway_agent_id, is_master, workspace_id
+     FROM agents
+     WHERE workspace_id = ?
+       AND (LOWER(role) LIKE '%' || LOWER(?) || '%' OR LOWER(?) LIKE '%' || LOWER(role) || '%')
+       AND (gateway_agent_id IS NOT NULL OR session_key_prefix IS NOT NULL)
+       AND status != 'offline'
+     ORDER BY gateway_agent_id IS NOT NULL DESC, status = 'standby' DESC, updated_at DESC
+     LIMIT 1`,
+    [workspaceId, role, role]
+  ) ?? null;
+}
+
+/**
+ * Verify that `agentId` is a real agent in the given workspace. Guards against
+ * LLM hallucinations where the planner returns an agent id that doesn't exist.
+ */
+export function verifyAgentInWorkspace(workspaceId: string, agentId: string): RosterAgent | null {
+  return queryOne<RosterAgent>(
+    `SELECT id, name, role, description, status, session_key_prefix, gateway_agent_id, is_master, workspace_id
+     FROM agents WHERE id = ? AND workspace_id = ? LIMIT 1`,
+    [agentId, workspaceId]
+  ) ?? null;
+}

--- a/src/lib/blocked-state.ts
+++ b/src/lib/blocked-state.ts
@@ -1,0 +1,126 @@
+import type { Task } from '@/lib/types';
+
+/**
+ * Structured "why is this task blocked" reason. Pure function — no DB, no
+ * fetch, no React. Runs on the client from the `Task` row that the
+ * `/api/tasks` endpoint already returns (with `assigned_agent.status` and
+ * `assigned_agent.role` joined in).
+ *
+ * Mirrors the `blockedAgentIds` logic in AgentActivityDashboard.tsx, but
+ * at the task level so the Kanban board can show WHY each card is stuck
+ * instead of just dumping `planning_dispatch_error` verbatim.
+ */
+export type BlockedKind =
+  | 'offline_agent'     // agent assigned but currently offline
+  | 'dispatch_failed'   // planning_dispatch_error is populated
+  | 'stalled'           // status_reason starts with 'stalled_' (scanner flag)
+  | 'queued_review'     // in review with no reviewer free (handled by drainQueue)
+  | 'queued_testing'    // in testing with no tester free
+  | 'needs_agent';      // inbox with no assignee — needs operator input
+
+export interface BlockedState {
+  kind: BlockedKind;
+  /** Short label shown on the card. */
+  label: string;
+  /** Longer explanation shown on hover / in the task modal. */
+  tooltip: string;
+  /** Tone for styling — 'error' | 'warn' | 'info'. */
+  tone: 'error' | 'warn' | 'info';
+}
+
+const ACTIVE_STATUSES = new Set(['assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification']);
+
+/**
+ * Parse a Node-fetch-style dispatch error into something operator-friendly.
+ * workflow-engine.ts now stuffs the real cause ({ECONNREFUSED, timeout, ...})
+ * into the stored error after the "fetch failed" sentinel. Strip the noise
+ * so the badge shows "Gateway unreachable" instead of
+ * "Dispatch error: fetch failed (connect ECONNREFUSED 127.0.0.1:4001)".
+ */
+function summarizeDispatchError(raw: string): string {
+  const lower = raw.toLowerCase();
+  if (lower.includes('econnrefused')) return 'Cannot reach Mission Control API — check URL';
+  if (lower.includes('enotfound') || lower.includes('dns')) return 'Mission Control URL does not resolve';
+  if (lower.includes('timeout') || lower.includes('etimedout')) return 'Dispatch timed out';
+  if (lower.includes('gateway') && lower.includes('connect')) return 'Gateway disconnected';
+  if (lower.includes('no eligible agent')) return 'No agent available for this role';
+  if (lower.includes('no routable agent')) return 'No agent available for this role';
+  if (lower.includes('agent has no session') || lower.includes('session')) return 'Agent has no active session';
+  if (lower.includes('openclaw')) return 'Gateway error';
+  // Fallback: trim leading "Dispatch error: " / "Auto-dispatch ... failed: "
+  return raw.replace(/^(dispatch(?:\s+to\s+\S+)?\s+(?:error|failed)(?:\s*\([^)]*\))?:\s*)/i, '').slice(0, 100);
+}
+
+export function getBlockedState(task: Task): BlockedState | null {
+  const status = task.status;
+  const agent = task.assigned_agent;
+  const dispatchError = task.planning_dispatch_error;
+  const statusReason = task.status_reason;
+
+  // 1. Dispatch error — highest priority because it means the server tried
+  //    and failed. Surface the parsed cause so the user knows what to fix.
+  if (dispatchError && ACTIVE_STATUSES.has(status)) {
+    return {
+      kind: 'dispatch_failed',
+      label: `Blocked — ${summarizeDispatchError(dispatchError)}`,
+      tooltip: dispatchError,
+      tone: 'error',
+    };
+  }
+
+  // 2. Assigned agent is offline but task is active. The agent went away
+  //    after being assigned — the Blocked indicator ships the operator
+  //    straight to "reassign or bring the agent back online".
+  if (agent && agent.status === 'offline' && ACTIVE_STATUSES.has(status)) {
+    return {
+      kind: 'offline_agent',
+      label: `Blocked — ${agent.name} is offline`,
+      tooltip: `Agent "${agent.name}" is offline but still assigned to this task. Reassign or bring the agent back online.`,
+      tone: 'error',
+    };
+  }
+
+  // 3. Scanner-flagged stall (PR #2). Distinct from dispatch_failed because
+  //    dispatch succeeded but the agent then went quiet.
+  if (statusReason?.startsWith('stalled_') && ACTIVE_STATUSES.has(status)) {
+    return {
+      kind: 'stalled',
+      label: 'Blocked — stalled',
+      tooltip: statusReason,
+      tone: 'warn',
+    };
+  }
+
+  // 4. Testing / review with no agent assigned = queued waiting for the
+  //    next stage's role to free up. Not an error — operator just needs
+  //    visibility that it's not forgotten. (drainQueue will advance it.)
+  if (status === 'testing' && !task.assigned_agent_id) {
+    return {
+      kind: 'queued_testing',
+      label: 'In queue — waiting for tester',
+      tooltip: 'No tester available yet. Will auto-advance when one frees up.',
+      tone: 'info',
+    };
+  }
+  if (status === 'review' && !task.assigned_agent_id) {
+    return {
+      kind: 'queued_review',
+      label: 'In queue — waiting for reviewer',
+      tooltip: 'No reviewer available yet. Will auto-advance when one frees up.',
+      tone: 'info',
+    };
+  }
+
+  // 5. Inbox with no agent — needs operator to assign someone. Matches the
+  //    existing "Needs agent — assign to start" row in MissionQueue.
+  if (status === 'inbox' && !task.assigned_agent_id) {
+    return {
+      kind: 'needs_agent',
+      label: 'Needs agent — assign to start',
+      tooltip: 'Task has no assigned agent. Pick one from the agent list.',
+      tone: 'warn',
+    };
+  }
+
+  return null;
+}

--- a/src/lib/checkpoint.ts
+++ b/src/lib/checkpoint.ts
@@ -13,6 +13,24 @@ interface SaveCheckpointInput {
 }
 
 /**
+ * Save a checkpoint only if no checkpoint has been saved for this task in
+ * the last `thresholdSeconds`. Used by dispatch / stage-transition /
+ * stall-detection call sites to avoid duplicate rows when recovery loops
+ * hammer the task in quick succession.
+ */
+export function saveCheckpointThrottled(
+  input: SaveCheckpointInput,
+  thresholdSeconds: number
+): WorkCheckpoint | null {
+  const latest = getLatestCheckpoint(input.taskId);
+  if (latest) {
+    const ageSeconds = (Date.now() - new Date(latest.created_at).getTime()) / 1000;
+    if (ageSeconds < thresholdSeconds) return null;
+  }
+  return saveCheckpoint(input);
+}
+
+/**
  * Save a work checkpoint for a task.
  */
 export function saveCheckpoint(input: SaveCheckpointInput): WorkCheckpoint {

--- a/src/lib/convoy.ts
+++ b/src/lib/convoy.ts
@@ -9,6 +9,8 @@ interface CreateSubtaskInput {
   description?: string;
   agent_id?: string;
   depends_on?: string[];
+  /** Role hint for dispatch. If omitted, convoy dispatch falls back to 'builder'. */
+  suggested_role?: string;
 }
 
 interface CreateConvoyInput {
@@ -64,9 +66,9 @@ export function createConvoy(input: CreateConvoyInput): Convoy {
 
       // Create the convoy_subtasks relationship
       run(
-        `INSERT INTO convoy_subtasks (id, convoy_id, task_id, sort_order, depends_on, created_at)
-         VALUES (?, ?, ?, ?, ?, ?)`,
-        [convoySubtaskId, convoyId, subtaskId, i, sub.depends_on ? JSON.stringify(sub.depends_on) : null, now]
+        `INSERT INTO convoy_subtasks (id, convoy_id, task_id, sort_order, depends_on, suggested_role, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        [convoySubtaskId, convoyId, subtaskId, i, sub.depends_on ? JSON.stringify(sub.depends_on) : null, sub.suggested_role || null, now]
       );
     }
 
@@ -281,12 +283,12 @@ export function addSubtasks(convoyId: string, subtasks: CreateSubtaskInput[]): C
       );
 
       run(
-        `INSERT INTO convoy_subtasks (id, convoy_id, task_id, sort_order, depends_on, created_at)
-         VALUES (?, ?, ?, ?, ?, ?)`,
-        [convoySubtaskId, convoyId, subtaskId, maxOrder + i + 1, sub.depends_on ? JSON.stringify(sub.depends_on) : null, now]
+        `INSERT INTO convoy_subtasks (id, convoy_id, task_id, sort_order, depends_on, suggested_role, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        [convoySubtaskId, convoyId, subtaskId, maxOrder + i + 1, sub.depends_on ? JSON.stringify(sub.depends_on) : null, sub.suggested_role || null, now]
       );
 
-      created.push({ id: convoySubtaskId, convoy_id: convoyId, task_id: subtaskId, sort_order: maxOrder + i + 1, depends_on: sub.depends_on, created_at: now });
+      created.push({ id: convoySubtaskId, convoy_id: convoyId, task_id: subtaskId, sort_order: maxOrder + i + 1, depends_on: sub.depends_on, suggested_role: sub.suggested_role || null, created_at: now });
     }
 
     // Update total count

--- a/src/lib/convoy.ts
+++ b/src/lib/convoy.ts
@@ -7,7 +7,10 @@ import type { Convoy, ConvoySubtask, Task, ConvoyStatus, DecompositionStrategy }
 interface CreateSubtaskInput {
   title: string;
   description?: string;
-  agent_id?: string;
+  /** Pre-assigned agent from the decomposition LLM (may be null when the planner
+   *  explicitly asks to create a new agent). Dispatch falls back to role-based
+   *  pick when this is null/undefined. */
+  agent_id?: string | null;
   depends_on?: string[];
   /** Role hint for dispatch. If omitted, convoy dispatch falls back to 'builder'. */
   suggested_role?: string;

--- a/src/lib/db/cleanup-ghost-agents.ts
+++ b/src/lib/db/cleanup-ghost-agents.ts
@@ -1,0 +1,147 @@
+/**
+ * One-shot cleanup for "ghost" agents left over from pre-fix convoy runs.
+ *
+ * A ghost is an agent row with no gateway_agent_id AND no session_key_prefix.
+ * Before the convoy duplication fix, every planning run inserted a fresh set
+ * of these for Builder/Tester/Reviewer/Learner even when real gateway agents
+ * already covered those roles. This script merges each ghost into the live
+ * agent sharing its role (preferring gateway-linked) and re-points any task
+ * assignments so no work is lost.
+ *
+ * Usage:
+ *   cp mission-control.db mission-control.db.bak
+ *   npx tsx src/lib/db/cleanup-ghost-agents.ts           # dry-run
+ *   npx tsx src/lib/db/cleanup-ghost-agents.ts --apply   # execute
+ *
+ * Safe to run repeatedly; it's a no-op once no ghosts remain.
+ */
+import { getDb, closeDb } from './index';
+
+interface AgentRow {
+  id: string;
+  name: string;
+  role: string | null;
+  workspace_id: string;
+  gateway_agent_id: string | null;
+  session_key_prefix: string | null;
+}
+
+interface MergePlan {
+  ghost: AgentRow;
+  keeper: AgentRow;
+  taskReassignments: number;
+}
+
+function findKeeperForGhost(
+  db: ReturnType<typeof getDb>,
+  ghost: AgentRow,
+): AgentRow | null {
+  if (!ghost.role) return null;
+
+  const exact = db.prepare(
+    `SELECT id, name, role, workspace_id, gateway_agent_id, session_key_prefix
+     FROM agents
+     WHERE id != ?
+       AND workspace_id = ?
+       AND LOWER(role) = LOWER(?)
+       AND (gateway_agent_id IS NOT NULL OR session_key_prefix IS NOT NULL)
+     ORDER BY gateway_agent_id IS NOT NULL DESC, updated_at DESC
+     LIMIT 1`,
+  ).get(ghost.id, ghost.workspace_id, ghost.role) as AgentRow | undefined;
+
+  if (exact) return exact;
+
+  const fuzzy = db.prepare(
+    `SELECT id, name, role, workspace_id, gateway_agent_id, session_key_prefix
+     FROM agents
+     WHERE id != ?
+       AND workspace_id = ?
+       AND (LOWER(role) LIKE '%' || LOWER(?) || '%' OR LOWER(?) LIKE '%' || LOWER(role) || '%')
+       AND (gateway_agent_id IS NOT NULL OR session_key_prefix IS NOT NULL)
+     ORDER BY gateway_agent_id IS NOT NULL DESC, updated_at DESC
+     LIMIT 1`,
+  ).get(ghost.id, ghost.workspace_id, ghost.role, ghost.role) as AgentRow | undefined;
+
+  return fuzzy ?? null;
+}
+
+function main() {
+  const apply = process.argv.includes('--apply');
+  const db = getDb();
+
+  const ghosts = db.prepare(
+    `SELECT id, name, role, workspace_id, gateway_agent_id, session_key_prefix
+     FROM agents
+     WHERE gateway_agent_id IS NULL AND session_key_prefix IS NULL AND is_master = 0`,
+  ).all() as AgentRow[];
+
+  if (ghosts.length === 0) {
+    console.log('✅ No ghost agents found. Nothing to do.');
+    closeDb();
+    return;
+  }
+
+  console.log(`Found ${ghosts.length} ghost agent(s):`);
+  for (const g of ghosts) {
+    console.log(`  - ${g.name} (${g.id}) role=${g.role ?? '<none>'} workspace=${g.workspace_id}`);
+  }
+  console.log('');
+
+  const plans: MergePlan[] = [];
+  const orphans: AgentRow[] = [];
+
+  const countTasks = db.prepare('SELECT COUNT(*) as n FROM tasks WHERE assigned_agent_id = ?');
+
+  for (const ghost of ghosts) {
+    const keeper = findKeeperForGhost(db, ghost);
+    if (!keeper) {
+      orphans.push(ghost);
+      continue;
+    }
+    const taskReassignments = (countTasks.get(ghost.id) as { n: number }).n;
+    plans.push({ ghost, keeper, taskReassignments });
+  }
+
+  console.log(`Planned merges: ${plans.length}`);
+  for (const { ghost, keeper, taskReassignments } of plans) {
+    console.log(
+      `  ${ghost.name} (${ghost.id}) → ${keeper.name} (${keeper.id})  [${taskReassignments} task(s) to re-point]`,
+    );
+  }
+  if (orphans.length > 0) {
+    console.log('');
+    console.log(`Orphans (no matching gateway-linked agent for role — left in place):`);
+    for (const o of orphans) {
+      console.log(`  - ${o.name} (${o.id}) role=${o.role ?? '<none>'}`);
+    }
+  }
+
+  if (!apply) {
+    console.log('');
+    console.log('Dry run complete. Re-run with --apply to execute.');
+    closeDb();
+    return;
+  }
+
+  const tx = db.transaction((ps: MergePlan[]) => {
+    const reassign = db.prepare(
+      `UPDATE tasks SET assigned_agent_id = ?, updated_at = datetime('now') WHERE assigned_agent_id = ?`,
+    );
+    const reassignRoles = db.prepare(
+      `UPDATE task_roles SET agent_id = ? WHERE agent_id = ?`,
+    );
+    const del = db.prepare(`DELETE FROM agents WHERE id = ?`);
+    for (const { ghost, keeper } of ps) {
+      reassign.run(keeper.id, ghost.id);
+      try { reassignRoles.run(keeper.id, ghost.id); } catch { /* table may not exist in older DBs */ }
+      del.run(ghost.id);
+    }
+  });
+
+  tx(plans);
+  console.log('');
+  console.log(`✅ Merged ${plans.length} ghost agent(s). ${orphans.length} orphan(s) left in place.`);
+  closeDb();
+}
+
+main();

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -1595,6 +1595,87 @@ const migrations: Migration[] = [
 
       console.log('[Migration 028] product_skills and skill_reports tables created');
     }
+  },
+  {
+    id: '029',
+    name: 'add_cancelled_task_status',
+    up: (db) => {
+      console.log('[Migration 029] Adding cancelled status to tasks CHECK constraint...');
+
+      const taskSchema = db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='tasks'").get() as { sql: string } | undefined;
+      if (!taskSchema || taskSchema.sql.includes("'cancelled'")) {
+        console.log('[Migration 029] cancelled already present — skipping');
+        return;
+      }
+
+      // SQLite can't ALTER a CHECK constraint — recreate the tasks table.
+      // legacy_alter_table is ON during migrations (see runMigrations), so the
+      // RENAME below will NOT rewrite FKs in other tables to point at the
+      // temporary name — the gotcha that migration 011 had to clean up.
+      const oldCols = (db.prepare("PRAGMA table_info(tasks)").all() as { name: string }[]).map(c => c.name);
+
+      db.exec(`ALTER TABLE tasks RENAME TO _tasks_old_029`);
+      db.exec(`
+        CREATE TABLE tasks (
+          id TEXT PRIMARY KEY,
+          title TEXT NOT NULL,
+          description TEXT,
+          status TEXT DEFAULT 'inbox' CHECK (status IN ('pending_dispatch', 'planning', 'inbox', 'assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification', 'done', 'cancelled')),
+          priority TEXT DEFAULT 'normal' CHECK (priority IN ('low', 'normal', 'high', 'urgent')),
+          assigned_agent_id TEXT REFERENCES agents(id),
+          created_by_agent_id TEXT REFERENCES agents(id),
+          workspace_id TEXT DEFAULT 'default' REFERENCES workspaces(id),
+          business_id TEXT DEFAULT 'default',
+          due_date TEXT,
+          workflow_template_id TEXT REFERENCES workflow_templates(id),
+          planning_session_key TEXT,
+          planning_messages TEXT,
+          planning_complete INTEGER DEFAULT 0,
+          planning_spec TEXT,
+          planning_agents TEXT,
+          planning_dispatch_error TEXT,
+          status_reason TEXT,
+          images TEXT,
+          convoy_id TEXT,
+          is_subtask INTEGER DEFAULT 0,
+          product_id TEXT REFERENCES products(id),
+          idea_id TEXT REFERENCES ideas(id),
+          estimated_cost_usd REAL,
+          actual_cost_usd REAL DEFAULT 0,
+          repo_url TEXT,
+          repo_branch TEXT,
+          pr_url TEXT,
+          pr_status TEXT CHECK (pr_status IN ('pending', 'open', 'merged', 'closed')),
+          workspace_path TEXT,
+          workspace_strategy TEXT,
+          workspace_port INTEGER,
+          workspace_base_commit TEXT,
+          merge_status TEXT,
+          merge_pr_url TEXT,
+          retry_count INTEGER DEFAULT 0,
+          next_retry_at TEXT,
+          dispatch_lock TEXT,
+          created_at TEXT DEFAULT (datetime('now')),
+          updated_at TEXT DEFAULT (datetime('now'))
+        )
+      `);
+
+      // Copy data — only columns present in BOTH old and new tables. This is
+      // forward-compatible: any column the old schema has that the new one
+      // doesn't is silently dropped; any new column gets its default.
+      const newCols = new Set(
+        (db.prepare("PRAGMA table_info(tasks)").all() as { name: string }[]).map(c => c.name)
+      );
+      const safeCols = oldCols.filter(c => newCols.has(c)).join(', ');
+      db.exec(`INSERT INTO tasks (${safeCols}) SELECT ${safeCols} FROM _tasks_old_029`);
+      db.exec(`DROP TABLE _tasks_old_029`);
+
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_assigned ON tasks(assigned_agent_id)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_workspace ON tasks(workspace_id)`);
+
+      console.log('[Migration 029] Tasks table recreated with cancelled status');
+    }
   }
 ];
 

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -1730,6 +1730,90 @@ const migrations: Migration[] = [
 
       console.log('[Migration 031] debug_events + debug_config created (collection_enabled=0 by default)');
     }
+  },
+  {
+    id: '032',
+    name: 'active_flag_and_general_mailbox_and_rollcall',
+    up: (db) => {
+      console.log('[Migration 032] Adding agents.is_active, generalizing agent_mailbox, creating rollcall tables...');
+
+      // --- 1. agents.is_active (default 1 so every existing agent is active) ---
+      const agentsInfo = db.prepare("PRAGMA table_info(agents)").all() as { name: string }[];
+      if (!agentsInfo.some(c => c.name === 'is_active')) {
+        db.exec(`ALTER TABLE agents ADD COLUMN is_active INTEGER DEFAULT 1`);
+        db.exec(`UPDATE agents SET is_active = 1 WHERE is_active IS NULL`);
+      }
+
+      // --- 2. agent_mailbox: make convoy_id nullable + add task_id ---
+      // SQLite can't drop NOT NULL on an existing column, so rebuild the
+      // table. PRAGMA foreign_keys must stay ON at commit; we use the
+      // documented 12-step table-rebuild pattern (inside a transaction we
+      // run outside this migration's wrapper — see runMigrations).
+      const mailboxInfo = db.prepare("PRAGMA table_info(agent_mailbox)").all() as { name: string; notnull: number }[];
+      const convoyCol = mailboxInfo.find(c => c.name === 'convoy_id');
+      const hasTaskId = mailboxInfo.some(c => c.name === 'task_id');
+      const needsRebuild = Boolean(convoyCol && convoyCol.notnull === 1) || !hasTaskId;
+
+      if (needsRebuild) {
+        db.exec(`
+          CREATE TABLE agent_mailbox_new (
+            id TEXT PRIMARY KEY,
+            convoy_id TEXT REFERENCES convoys(id) ON DELETE CASCADE,
+            task_id TEXT REFERENCES tasks(id) ON DELETE SET NULL,
+            from_agent_id TEXT NOT NULL REFERENCES agents(id),
+            to_agent_id TEXT NOT NULL REFERENCES agents(id),
+            subject TEXT,
+            body TEXT NOT NULL,
+            read_at TEXT,
+            created_at TEXT DEFAULT (datetime('now'))
+          )
+        `);
+        db.exec(`
+          INSERT INTO agent_mailbox_new (id, convoy_id, task_id, from_agent_id, to_agent_id, subject, body, read_at, created_at)
+          SELECT id, convoy_id, NULL as task_id, from_agent_id, to_agent_id, subject, body, read_at, created_at
+          FROM agent_mailbox
+        `);
+        db.exec(`DROP TABLE agent_mailbox`);
+        db.exec(`ALTER TABLE agent_mailbox_new RENAME TO agent_mailbox`);
+        db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_mailbox_to ON agent_mailbox(to_agent_id, read_at)`);
+        db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_mailbox_convoy ON agent_mailbox(convoy_id) WHERE convoy_id IS NOT NULL`);
+        db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_mailbox_task ON agent_mailbox(task_id) WHERE task_id IS NOT NULL`);
+      }
+
+      // --- 3. rollcall + rollcall_entries ---
+      // One roll-call session can fan out to N agents; we track delivery
+      // and reply independently (the two failure modes are different:
+      // "couldn't deliver the prompt" vs "delivered but agent didn't reply").
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS rollcall_sessions (
+          id TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL REFERENCES workspaces(id),
+          initiator_agent_id TEXT NOT NULL REFERENCES agents(id),
+          mode TEXT NOT NULL CHECK (mode IN ('direct', 'coordinator')),
+          timeout_seconds INTEGER NOT NULL DEFAULT 30,
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          expires_at TEXT NOT NULL
+        )
+      `);
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS rollcall_entries (
+          id TEXT PRIMARY KEY,
+          rollcall_id TEXT NOT NULL REFERENCES rollcall_sessions(id) ON DELETE CASCADE,
+          target_agent_id TEXT NOT NULL REFERENCES agents(id),
+          delivery_status TEXT NOT NULL DEFAULT 'pending' CHECK (delivery_status IN ('pending', 'sent', 'failed', 'skipped')),
+          delivery_error TEXT,
+          delivered_at TEXT,
+          reply_mail_id TEXT REFERENCES agent_mailbox(id) ON DELETE SET NULL,
+          reply_body TEXT,
+          replied_at TEXT,
+          created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+      `);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_rollcall_entries_session ON rollcall_entries(rollcall_id)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_rollcall_entries_target ON rollcall_entries(target_agent_id, replied_at)`);
+
+      console.log('[Migration 032] Complete: is_active flag, mailbox generalized, rollcall tables created.');
+    }
   }
 ];
 

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -1814,6 +1814,36 @@ const migrations: Migration[] = [
 
       console.log('[Migration 032] Complete: is_active flag, mailbox generalized, rollcall tables created.');
     }
+  },
+  {
+    id: '033',
+    name: 'deliverable_storage_and_task_archive',
+    up: (db) => {
+      console.log('[Migration 033] Adding task archive flags and deliverable storage metadata...');
+
+      const tasksInfo = db.prepare("PRAGMA table_info(tasks)").all() as { name: string }[];
+      if (!tasksInfo.some(c => c.name === 'is_archived')) {
+        db.exec(`ALTER TABLE tasks ADD COLUMN is_archived INTEGER DEFAULT 0`);
+        db.exec(`UPDATE tasks SET is_archived = 0 WHERE is_archived IS NULL`);
+      }
+      if (!tasksInfo.some(c => c.name === 'archived_at')) {
+        db.exec(`ALTER TABLE tasks ADD COLUMN archived_at TEXT`);
+      }
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_tasks_archived ON tasks(is_archived, status)`);
+
+      const delivInfo = db.prepare("PRAGMA table_info(task_deliverables)").all() as { name: string }[];
+      if (!delivInfo.some(c => c.name === 'storage_scheme')) {
+        db.exec(`ALTER TABLE task_deliverables ADD COLUMN storage_scheme TEXT DEFAULT 'host'`);
+        // Existing rows: they reference host paths, so 'host' is correct. URL/artifact
+        // rows also get 'host' but the UI keys off deliverable_type, not scheme.
+        db.exec(`UPDATE task_deliverables SET storage_scheme = 'host' WHERE storage_scheme IS NULL`);
+      }
+      if (!delivInfo.some(c => c.name === 'size_bytes')) {
+        db.exec(`ALTER TABLE task_deliverables ADD COLUMN size_bytes INTEGER`);
+      }
+
+      console.log('[Migration 033] Complete: tasks.is_archived/archived_at and task_deliverables.storage_scheme/size_bytes added.');
+    }
   }
 ];
 

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -1676,6 +1676,20 @@ const migrations: Migration[] = [
 
       console.log('[Migration 029] Tasks table recreated with cancelled status');
     }
+  },
+  {
+    id: '030',
+    name: 'add_suggested_role_to_convoy_subtasks',
+    up: (db) => {
+      console.log('[Migration 030] Adding suggested_role to convoy_subtasks...');
+      const cols = db.prepare("PRAGMA table_info(convoy_subtasks)").all() as { name: string }[];
+      if (cols.some(c => c.name === 'suggested_role')) {
+        console.log('[Migration 030] suggested_role already present — skipping');
+        return;
+      }
+      db.exec(`ALTER TABLE convoy_subtasks ADD COLUMN suggested_role TEXT`);
+      console.log('[Migration 030] convoy_subtasks.suggested_role added');
+    }
   }
 ];
 

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -1690,6 +1690,46 @@ const migrations: Migration[] = [
       db.exec(`ALTER TABLE convoy_subtasks ADD COLUMN suggested_role TEXT`);
       console.log('[Migration 030] convoy_subtasks.suggested_role added');
     }
+  },
+  {
+    id: '031',
+    name: 'add_debug_console_tables',
+    up: (db) => {
+      console.log('[Migration 031] Adding debug_events + debug_config tables...');
+
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS debug_events (
+          id TEXT PRIMARY KEY,
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          event_type TEXT NOT NULL,
+          direction TEXT NOT NULL CHECK (direction IN ('outbound', 'inbound', 'internal')),
+          task_id TEXT,
+          agent_id TEXT,
+          session_key TEXT,
+          duration_ms INTEGER,
+          request_body TEXT,
+          response_body TEXT,
+          error TEXT,
+          metadata TEXT
+        )
+      `);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_debug_events_created ON debug_events(created_at DESC)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_debug_events_task ON debug_events(task_id, created_at DESC)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_debug_events_agent ON debug_events(agent_id, created_at DESC)`);
+
+      // Single-row config table. Enforced via CHECK so app code doesn't have
+      // to worry about multi-row races — there is exactly one row at id=1.
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS debug_config (
+          id INTEGER PRIMARY KEY CHECK (id = 1),
+          collection_enabled INTEGER NOT NULL DEFAULT 0,
+          updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+      `);
+      db.exec(`INSERT OR IGNORE INTO debug_config (id, collection_enabled) VALUES (1, 0)`);
+
+      console.log('[Migration 031] debug_events + debug_config created (collection_enabled=0 by default)');
+    }
   }
 ];
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -82,6 +82,8 @@ CREATE TABLE IF NOT EXISTS tasks (
   workspace_base_commit TEXT,
   merge_status TEXT,
   merge_pr_url TEXT,
+  is_archived INTEGER DEFAULT 0,
+  archived_at TEXT,
   created_at TEXT DEFAULT (datetime('now')),
   updated_at TEXT DEFAULT (datetime('now'))
 );
@@ -255,6 +257,8 @@ CREATE TABLE IF NOT EXISTS task_deliverables (
   title TEXT NOT NULL,
   path TEXT,
   description TEXT,
+  storage_scheme TEXT DEFAULT 'host',
+  size_bytes INTEGER,
   created_at TEXT DEFAULT (datetime('now'))
 );
 
@@ -797,6 +801,7 @@ CREATE TABLE IF NOT EXISTS debug_config (
 CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_tasks_assigned ON tasks(assigned_agent_id);
 CREATE INDEX IF NOT EXISTS idx_tasks_workspace ON tasks(workspace_id);
+CREATE INDEX IF NOT EXISTS idx_tasks_archived ON tasks(is_archived, status);
 CREATE INDEX IF NOT EXISTS idx_agents_workspace ON agents(workspace_id);
 CREATE INDEX IF NOT EXISTS idx_messages_conversation ON messages(conversation_id);
 CREATE INDEX IF NOT EXISTS idx_events_created ON events(created_at DESC);

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -736,6 +736,29 @@ CREATE TABLE IF NOT EXISTS skill_reports (
   created_at TEXT DEFAULT (datetime('now'))
 );
 
+-- Debug console: opt-in capture of MC↔agent traffic (dispatch payloads).
+-- Gated by debug_config.collection_enabled; operator toggles from /debug UI.
+CREATE TABLE IF NOT EXISTS debug_events (
+  id TEXT PRIMARY KEY,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  event_type TEXT NOT NULL,
+  direction TEXT NOT NULL CHECK (direction IN ('outbound', 'inbound', 'internal')),
+  task_id TEXT,
+  agent_id TEXT,
+  session_key TEXT,
+  duration_ms INTEGER,
+  request_body TEXT,
+  response_body TEXT,
+  error TEXT,
+  metadata TEXT
+);
+
+CREATE TABLE IF NOT EXISTS debug_config (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  collection_enabled INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
 -- Indexes for performance
 CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_tasks_assigned ON tasks(assigned_agent_id);
@@ -798,4 +821,7 @@ CREATE INDEX IF NOT EXISTS idx_user_task_reads_user_task ON user_task_reads(user
 CREATE INDEX IF NOT EXISTS idx_product_skills_product ON product_skills(product_id, skill_type, status);
 CREATE INDEX IF NOT EXISTS idx_product_skills_confidence ON product_skills(confidence DESC);
 CREATE INDEX IF NOT EXISTS idx_skill_reports_skill ON skill_reports(skill_id);
+CREATE INDEX IF NOT EXISTS idx_debug_events_created ON debug_events(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_debug_events_task ON debug_events(task_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_debug_events_agent ON debug_events(agent_id, created_at DESC);
 `;

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -49,7 +49,7 @@ CREATE TABLE IF NOT EXISTS tasks (
   id TEXT PRIMARY KEY,
   title TEXT NOT NULL,
   description TEXT,
-  status TEXT DEFAULT 'inbox' CHECK (status IN ('pending_dispatch', 'planning', 'inbox', 'assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification', 'done')),
+  status TEXT DEFAULT 'inbox' CHECK (status IN ('pending_dispatch', 'planning', 'inbox', 'assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification', 'done', 'cancelled')),
   priority TEXT DEFAULT 'normal' CHECK (priority IN ('low', 'normal', 'high', 'urgent')),
   assigned_agent_id TEXT REFERENCES agents(id),
   created_by_agent_id TEXT REFERENCES agents(id),

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -279,6 +279,7 @@ CREATE TABLE IF NOT EXISTS convoy_subtasks (
   task_id TEXT NOT NULL UNIQUE REFERENCES tasks(id) ON DELETE CASCADE,
   sort_order INTEGER DEFAULT 0,
   depends_on TEXT,
+  suggested_role TEXT,
   created_at TEXT DEFAULT (datetime('now'))
 );
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -38,6 +38,7 @@ CREATE TABLE IF NOT EXISTS agents (
   source TEXT DEFAULT 'local',
   gateway_agent_id TEXT,
   session_key_prefix TEXT,
+  is_active INTEGER DEFAULT 1,
   total_cost_usd REAL DEFAULT 0,
   total_tokens_used INTEGER DEFAULT 0,
   created_at TEXT DEFAULT (datetime('now')),
@@ -309,10 +310,13 @@ CREATE TABLE IF NOT EXISTS work_checkpoints (
   created_at TEXT DEFAULT (datetime('now'))
 );
 
--- Agent mailbox: inter-agent communication within a convoy
+-- Agent mailbox: inter-agent communication. Optionally scoped to a convoy
+-- or a task. Both scope columns may be NULL for ad-hoc mail (e.g. roll-call,
+-- help-requests to the master orchestrator).
 CREATE TABLE IF NOT EXISTS agent_mailbox (
   id TEXT PRIMARY KEY,
-  convoy_id TEXT NOT NULL REFERENCES convoys(id) ON DELETE CASCADE,
+  convoy_id TEXT REFERENCES convoys(id) ON DELETE CASCADE,
+  task_id TEXT REFERENCES tasks(id) ON DELETE SET NULL,
   from_agent_id TEXT NOT NULL REFERENCES agents(id),
   to_agent_id TEXT NOT NULL REFERENCES agents(id),
   subject TEXT,
@@ -320,6 +324,36 @@ CREATE TABLE IF NOT EXISTS agent_mailbox (
   read_at TEXT,
   created_at TEXT DEFAULT (datetime('now'))
 );
+CREATE INDEX IF NOT EXISTS idx_agent_mailbox_to ON agent_mailbox(to_agent_id, read_at);
+CREATE INDEX IF NOT EXISTS idx_agent_mailbox_convoy ON agent_mailbox(convoy_id) WHERE convoy_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_agent_mailbox_task ON agent_mailbox(task_id) WHERE task_id IS NOT NULL;
+
+-- Roll-call sessions: a master orchestrator asks each active agent to
+-- check in; we track delivery and reply independently so the UI can
+-- surface two distinct failure modes (couldn't deliver vs. agent silent).
+CREATE TABLE IF NOT EXISTS rollcall_sessions (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL REFERENCES workspaces(id),
+  initiator_agent_id TEXT NOT NULL REFERENCES agents(id),
+  mode TEXT NOT NULL CHECK (mode IN ('direct', 'coordinator')),
+  timeout_seconds INTEGER NOT NULL DEFAULT 30,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  expires_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS rollcall_entries (
+  id TEXT PRIMARY KEY,
+  rollcall_id TEXT NOT NULL REFERENCES rollcall_sessions(id) ON DELETE CASCADE,
+  target_agent_id TEXT NOT NULL REFERENCES agents(id),
+  delivery_status TEXT NOT NULL DEFAULT 'pending' CHECK (delivery_status IN ('pending', 'sent', 'failed', 'skipped')),
+  delivery_error TEXT,
+  delivered_at TEXT,
+  reply_mail_id TEXT REFERENCES agent_mailbox(id) ON DELETE SET NULL,
+  reply_body TEXT,
+  replied_at TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_rollcall_entries_session ON rollcall_entries(rollcall_id);
+CREATE INDEX IF NOT EXISTS idx_rollcall_entries_target ON rollcall_entries(target_agent_id, replied_at);
 
 -- Products table (Product Autopilot)
 CREATE TABLE IF NOT EXISTS products (

--- a/src/lib/db/seed.ts
+++ b/src/lib/db/seed.ts
@@ -100,6 +100,21 @@ async function seed() {
     `INSERT OR IGNORE INTO businesses (id, name, description, created_at) VALUES (?, ?, ?, ?)`
   ).run(businessId, 'Mission Control HQ', 'Default workspace for all operations', now);
 
+  // Guard agent seeding: if the DB already has gateway-linked or session-routed
+  // agents (e.g. imported from OpenClaw), do not seed the stock example team.
+  // Overwriting them silently produced ghost duplicates after every reseed.
+  const realAgentCount = db.prepare(
+    `SELECT COUNT(*) as n FROM agents
+     WHERE gateway_agent_id IS NOT NULL OR session_key_prefix IS NOT NULL`
+  ).get() as { n: number };
+
+  if (realAgentCount.n > 0) {
+    console.log(`⏭️  Skipping agent seed — ${realAgentCount.n} gateway-linked agent(s) already exist.`);
+    console.log('✅ Database seed skipped (agents preserved)');
+    closeDb();
+    return;
+  }
+
   // Create master orchestrator agent
   const orchestratorId = uuidv4();
   db.prepare(

--- a/src/lib/debug-log.ts
+++ b/src/lib/debug-log.ts
@@ -1,0 +1,205 @@
+import { v4 as uuidv4 } from 'uuid';
+import { queryOne, queryAll, run } from '@/lib/db';
+import { broadcast } from '@/lib/events';
+
+/**
+ * Debug console — opt-in verbose capture of everything that travels
+ * between Mission Control and an agent. Operator toggles collection via
+ * `/debug` UI or `POST /api/debug/settings`. Off by default; stored rows
+ * grow indefinitely until explicitly cleared.
+ *
+ * Current instrumented surfaces:
+ *   - dispatch/route.ts chat.send (outbound)
+ *
+ * Future expansions (stubs already reserved via `event_type`):
+ *   - inbound POST /activities, /deliverables, PATCH /tasks, /fail
+ *   - openclaw session lifecycle + chat response polling
+ *   - gateway catalog sync + health cycle
+ */
+
+export type DebugEventType =
+  // Outbound
+  | 'chat.send'
+  // Reserved for future instrumentation
+  | 'chat.response'
+  | 'session.create'
+  | 'session.end'
+  | 'agent.activity_post'
+  | 'agent.deliverable_post'
+  | 'agent.status_patch'
+  | 'agent.fail_post'
+  | 'gateway.list_agents'
+  | 'gateway.health_ping';
+
+export type DebugEventDirection = 'outbound' | 'inbound' | 'internal';
+
+export interface DebugEvent {
+  id: string;
+  created_at: string;
+  event_type: DebugEventType;
+  direction: DebugEventDirection;
+  task_id: string | null;
+  agent_id: string | null;
+  session_key: string | null;
+  duration_ms: number | null;
+  request_body: string | null;
+  response_body: string | null;
+  error: string | null;
+  metadata: string | null;
+}
+
+interface LogInput {
+  type: DebugEventType;
+  direction: DebugEventDirection;
+  taskId?: string | null;
+  agentId?: string | null;
+  sessionKey?: string | null;
+  durationMs?: number;
+  requestBody?: unknown;
+  responseBody?: unknown;
+  error?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+function stringifyBody(body: unknown): string | null {
+  if (body === undefined || body === null) return null;
+  if (typeof body === 'string') return body;
+  try {
+    return JSON.stringify(body);
+  } catch {
+    return String(body);
+  }
+}
+
+/**
+ * Check whether debug collection is currently enabled. Reads the single
+ * `debug_config` row; cached in-process for 2 seconds so `isEnabled()`
+ * calls at hot sites (per-dispatch) don't hammer SQLite.
+ */
+let cachedEnabled: { value: boolean; expires: number } | null = null;
+
+export function isDebugCollectionEnabled(): boolean {
+  const now = Date.now();
+  if (cachedEnabled && cachedEnabled.expires > now) return cachedEnabled.value;
+
+  const row = queryOne<{ collection_enabled: number }>(
+    'SELECT collection_enabled FROM debug_config WHERE id = 1'
+  );
+  const value = Boolean(row?.collection_enabled);
+  cachedEnabled = { value, expires: now + 2000 };
+  return value;
+}
+
+export function setDebugCollectionEnabled(enabled: boolean): void {
+  run(
+    `UPDATE debug_config SET collection_enabled = ?, updated_at = ? WHERE id = 1`,
+    [enabled ? 1 : 0, new Date().toISOString()]
+  );
+  cachedEnabled = { value: enabled, expires: Date.now() + 2000 };
+}
+
+export function clearDebugEvents(): number {
+  const before = queryOne<{ cnt: number }>('SELECT COUNT(*) as cnt FROM debug_events')?.cnt ?? 0;
+  run('DELETE FROM debug_events');
+  return before;
+}
+
+/**
+ * Append a debug event. No-op when collection is disabled. Call sites can
+ * invoke this unconditionally — the gate is enforced here so instrumentation
+ * code stays clean.
+ */
+export function logDebugEvent(input: LogInput): void {
+  if (!isDebugCollectionEnabled()) return;
+
+  const id = uuidv4();
+  const now = new Date().toISOString();
+  const row = {
+    id,
+    created_at: now,
+    event_type: input.type,
+    direction: input.direction,
+    task_id: input.taskId ?? null,
+    agent_id: input.agentId ?? null,
+    session_key: input.sessionKey ?? null,
+    duration_ms: input.durationMs ?? null,
+    request_body: stringifyBody(input.requestBody),
+    response_body: stringifyBody(input.responseBody),
+    error: input.error ?? null,
+    metadata: input.metadata ? stringifyBody(input.metadata) : null,
+  };
+
+  try {
+    run(
+      `INSERT INTO debug_events
+         (id, created_at, event_type, direction, task_id, agent_id, session_key, duration_ms, request_body, response_body, error, metadata)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [row.id, row.created_at, row.event_type, row.direction, row.task_id, row.agent_id, row.session_key, row.duration_ms, row.request_body, row.response_body, row.error, row.metadata]
+    );
+
+    // Broadcast for live tail in /debug UI. We emit a generic
+    // autopilot_activity-style payload rather than adding a typed
+    // Payload — SSEEvent.payload permits Record<string, unknown>.
+    broadcast({ type: 'debug_event_logged', payload: row as unknown as Record<string, unknown> });
+  } catch (err) {
+    // Logging must never break the thing it observes. If the INSERT fails,
+    // record it to stderr and carry on. The caller's dispatch/PATCH/etc
+    // continues unaffected.
+    console.error('[DebugLog] insert failed:', err);
+  }
+}
+
+export interface DebugEventFilter {
+  taskId?: string;
+  agentId?: string;
+  eventType?: DebugEventType;
+  direction?: DebugEventDirection;
+  afterId?: string; // for live tail cursor
+  limit?: number;
+}
+
+export function getDebugEvents(filter: DebugEventFilter = {}): DebugEvent[] {
+  const clauses: string[] = [];
+  const params: unknown[] = [];
+
+  if (filter.taskId) {
+    clauses.push('task_id = ?');
+    params.push(filter.taskId);
+  }
+  if (filter.agentId) {
+    clauses.push('agent_id = ?');
+    params.push(filter.agentId);
+  }
+  if (filter.eventType) {
+    clauses.push('event_type = ?');
+    params.push(filter.eventType);
+  }
+  if (filter.direction) {
+    clauses.push('direction = ?');
+    params.push(filter.direction);
+  }
+  if (filter.afterId) {
+    // `afterId` is a cursor — rows with created_at > the created_at of afterId.
+    // Used by the UI's live-tail to fetch only new rows on reconnect.
+    const cursor = queryOne<{ created_at: string }>(
+      'SELECT created_at FROM debug_events WHERE id = ?',
+      [filter.afterId]
+    );
+    if (cursor) {
+      clauses.push('created_at > ?');
+      params.push(cursor.created_at);
+    }
+  }
+
+  const where = clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : '';
+  const limit = Math.max(1, Math.min(filter.limit ?? 200, 1000));
+
+  return queryAll<DebugEvent>(
+    `SELECT * FROM debug_events ${where} ORDER BY created_at DESC LIMIT ?`,
+    [...params, limit]
+  );
+}
+
+export function getDebugEventCount(): number {
+  return queryOne<{ cnt: number }>('SELECT COUNT(*) as cnt FROM debug_events')?.cnt ?? 0;
+}

--- a/src/lib/debug-log.ts
+++ b/src/lib/debug-log.ts
@@ -18,18 +18,31 @@ import { broadcast } from '@/lib/events';
  */
 
 export type DebugEventType =
-  // Outbound
+  // Outbound (MC → agent/gateway)
   | 'chat.send'
-  // Reserved for future instrumentation
-  | 'chat.response'
   | 'session.create'
   | 'session.end'
+  | 'gateway.list_agents'
+  | 'gateway.rpc'
+  | 'gateway.health_ping'
+  // Inbound (agent/gateway → MC)
+  | 'chat.response'
+  | 'agent.event'
   | 'agent.activity_post'
   | 'agent.deliverable_post'
   | 'agent.status_patch'
   | 'agent.fail_post'
-  | 'gateway.list_agents'
-  | 'gateway.health_ping';
+  // WebSocket lifecycle (internal)
+  | 'ws.connect'
+  | 'ws.authenticated'
+  | 'ws.disconnect'
+  | 'ws.error'
+  | 'ws.reconnect'
+  // Scheduler / detectors (internal)
+  | 'stall.flagged'
+  | 'stall.cleared'
+  // Diagnostic flow (internal)
+  | 'diagnostic.step';
 
 export type DebugEventDirection = 'outbound' | 'inbound' | 'internal';
 

--- a/src/lib/deliverables/storage.ts
+++ b/src/lib/deliverables/storage.ts
@@ -1,0 +1,179 @@
+/**
+ * Deliverable storage resolution.
+ *
+ * Two paths matter:
+ *   - HOST path: what the agent (running on the host OS) sees. Injected into
+ *     dispatch prompts so agents write deliverables to the right place.
+ *   - CONTAINER path: what MC (possibly running inside a Docker container)
+ *     sees when reading the same bytes via a mounted volume.
+ *
+ * In local dev the two collapse to one value. In Docker compose a volume
+ * mount makes host → container translation.
+ *
+ * On-disk layout for MC-managed deliverables:
+ *   <root>/<task_id>/<filename>
+ *
+ * (The agent writes the file before it knows the deliverable_id, so we don't
+ * prefix with it at write-time. Collisions between deliverables in the same
+ * task are the agent's responsibility — typically distinct titles produce
+ * distinct filenames.)
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { getProjectsPath } from '@/lib/config';
+import type { TaskDeliverable } from '@/lib/types';
+
+const MIME_TYPES: Record<string, string> = {
+  '.html': 'text/html',
+  '.htm': 'text/html',
+  '.css': 'text/css',
+  '.js': 'application/javascript',
+  '.json': 'application/json',
+  '.txt': 'text/plain',
+  '.md': 'text/markdown',
+  '.xml': 'application/xml',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.pdf': 'application/pdf',
+  '.zip': 'application/zip',
+  '.csv': 'text/csv',
+  '.yaml': 'application/x-yaml',
+  '.yml': 'application/x-yaml',
+};
+
+function expandTilde(p: string): string {
+  if (p.startsWith('~')) {
+    return p.replace(/^~/, process.env.HOME || '');
+  }
+  return p;
+}
+
+export function getDeliverablesHostPath(): string {
+  // Agent-perspective. Defaults to the existing projects location so today's
+  // flow keeps working when the env vars aren't set.
+  return expandTilde(process.env.MC_DELIVERABLES_HOST_PATH || getProjectsPath());
+}
+
+export function getDeliverablesContainerPath(): string {
+  // MC-perspective. In local mode this is identical to the host path.
+  return expandTilde(
+    process.env.MC_DELIVERABLES_CONTAINER_PATH ||
+    process.env.MC_DELIVERABLES_HOST_PATH ||
+    getProjectsPath()
+  );
+}
+
+export function getTaskDeliverableDir(taskId: string, perspective: 'host' | 'container'): string {
+  const root = perspective === 'host' ? getDeliverablesHostPath() : getDeliverablesContainerPath();
+  return path.join(root, taskId);
+}
+
+/**
+ * Given a submitted absolute host path, decide if it lives under the
+ * deliverables root. Used at register-time to tag storage_scheme.
+ */
+export function isUnderDeliverablesHostRoot(submittedPath: string): boolean {
+  if (!submittedPath) return false;
+  const expanded = expandTilde(submittedPath);
+  const root = path.resolve(getDeliverablesHostPath());
+  const abs = path.resolve(expanded);
+  return abs === root || abs.startsWith(root + path.sep);
+}
+
+/**
+ * Translate a host-perspective absolute path to a container-perspective
+ * absolute path by swapping the roots. Used when MC needs to read a file
+ * the agent wrote.
+ */
+export function hostPathToContainerPath(hostPath: string): string {
+  const expanded = expandTilde(hostPath);
+  const hostRoot = path.resolve(getDeliverablesHostPath());
+  const containerRoot = path.resolve(getDeliverablesContainerPath());
+  if (hostRoot === containerRoot) return expanded;
+
+  const abs = path.resolve(expanded);
+  if (abs === hostRoot) return containerRoot;
+  if (abs.startsWith(hostRoot + path.sep)) {
+    return path.join(containerRoot, abs.slice(hostRoot.length + 1));
+  }
+  // Path is outside the deliverables root — can't translate, return as-is and
+  // let the caller's safety check reject it if applicable.
+  return expanded;
+}
+
+export class DeliverableReadError extends Error {
+  status: number;
+  constructor(message: string, status = 500) {
+    super(message);
+    this.status = status;
+  }
+}
+
+/**
+ * Resolve a deliverable record to an absolute, readable path in the MC
+ * (container) filesystem. Validates:
+ *   - scheme is supported (ssh:// is reserved but not yet implemented)
+ *   - real path stays under the configured deliverables container root
+ *     (for MC-managed rows) — this blocks path-traversal / symlink attacks
+ *   - for legacy 'host' rows the stored path is used as-is (this is pre-existing
+ *     behavior we preserve for deliverables created before this feature)
+ */
+export function resolveDeliverableReadPath(deliverable: TaskDeliverable): string {
+  if (!deliverable.path) {
+    throw new DeliverableReadError('Deliverable has no path', 400);
+  }
+  if (deliverable.path.startsWith('ssh://')) {
+    throw new DeliverableReadError('Remote (ssh) deliverable storage is not yet supported', 501);
+  }
+
+  const scheme = deliverable.storage_scheme || 'host';
+
+  if (scheme === 'mc') {
+    // Rebuild from (container_root, task_id, basename(path)). We trust only
+    // the basename of the stored path — the directory part is host-perspective
+    // and not meaningful for reads. The on-disk layout is canonical.
+    const containerDir = getTaskDeliverableDir(deliverable.task_id, 'container');
+    const filename = path.basename(deliverable.path);
+    const candidate = path.join(containerDir, filename);
+
+    // Safety: real path must stay within the container root.
+    const root = path.resolve(getDeliverablesContainerPath());
+    let resolved: string;
+    try {
+      resolved = fs.realpathSync(candidate);
+    } catch {
+      throw new DeliverableReadError('Deliverable file not found', 404);
+    }
+    if (resolved !== root && !resolved.startsWith(root + path.sep)) {
+      throw new DeliverableReadError('Deliverable path escaped storage root', 403);
+    }
+    return resolved;
+  }
+
+  // Legacy host-only row. We still do a basic existence check so callers get
+  // a 404 instead of a 500 when the file has been moved or the host path is
+  // not reachable from the MC process (e.g. MC in Docker without the mount).
+  const translated = hostPathToContainerPath(deliverable.path);
+  if (!fs.existsSync(translated)) {
+    throw new DeliverableReadError('Deliverable file not found', 404);
+  }
+  return translated;
+}
+
+export function mimeTypeForPath(p: string): string {
+  const ext = path.extname(p).toLowerCase();
+  return MIME_TYPES[ext] || 'application/octet-stream';
+}
+
+export function fileSizeBytes(absPath: string): number | undefined {
+  try {
+    return fs.statSync(absPath).size;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/lib/learner.ts
+++ b/src/lib/learner.ts
@@ -8,6 +8,7 @@
 import { queryOne, queryAll, run } from '@/lib/db';
 import { getMissionControlUrl } from '@/lib/config';
 import { getOpenClawClient } from '@/lib/openclaw/client';
+import { resolveAgentSessionKeyPrefix } from '@/lib/openclaw/session-key';
 import type { KnowledgeEntry, TaskRole, OpenClawSession } from '@/lib/types';
 
 /**
@@ -98,7 +99,16 @@ Focus on:
     }
 
     if (session) {
-      const prefix = learnerRole.session_key_prefix || 'agent:main:';
+      // learnerRole has name/session_key_prefix but not gateway_agent_id;
+      // fetch the full agent row so the prefix resolver can choose the
+      // gateway namespace when appropriate instead of the old main catchall.
+      const learnerAgent = queryOne<import('@/lib/types').Agent>(
+        'SELECT * FROM agents WHERE id = ?',
+        [learnerRole.agent_id]
+      );
+      const prefix = learnerAgent
+        ? resolveAgentSessionKeyPrefix(learnerAgent)
+        : `agent:${learnerRole.agent_id}:`;
       const sessionKey = `${prefix}${session.openclaw_session_id}`;
       await client.call('chat.send', {
         sessionKey,

--- a/src/lib/mailbox.ts
+++ b/src/lib/mailbox.ts
@@ -1,40 +1,136 @@
 import { v4 as uuidv4 } from 'uuid';
 import { queryOne, queryAll, run } from '@/lib/db';
 import { broadcast } from '@/lib/events';
-import type { AgentMailMessage } from '@/lib/types';
+import type { Agent, AgentMailMessage, OpenClawSession } from '@/lib/types';
 
 interface SendMailInput {
-  convoyId: string;
+  /** Optional convoy scope (original convoy mail flow). */
+  convoyId?: string | null;
+  /** Optional task scope — mail is associated with this task for context injection. */
+  taskId?: string | null;
   fromAgentId: string;
   toAgentId: string;
   subject?: string;
   body: string;
+  /**
+   * If true, also push-deliver the mail via chat.send to the target's
+   * active OpenClaw session so the target sees it immediately (rather
+   * than on their next dispatch via formatMailForDispatch). Used for
+   * roll-call and urgent help-requests.
+   */
+  push?: boolean;
+}
+
+export interface SendMailResult {
+  message: AgentMailMessage;
+  /** Only set when push=true. */
+  delivery?: {
+    status: 'sent' | 'failed' | 'skipped';
+    error?: string;
+    sessionKey?: string;
+  };
 }
 
 /**
- * Send a message from one agent to another within a convoy.
+ * Send mail from one agent to another. Scope is optional — both convoy_id
+ * and task_id may be null for ad-hoc mail (roll-call, general questions
+ * to the master orchestrator, etc.). When `push=true`, the mail is also
+ * delivered immediately via the target's active session so the target
+ * doesn't have to wait for a dispatch to receive it.
  */
-export function sendMail(input: SendMailInput): AgentMailMessage {
-  const { convoyId, fromAgentId, toAgentId, subject, body } = input;
+export async function sendMail(input: SendMailInput): Promise<SendMailResult> {
+  const { convoyId, taskId, fromAgentId, toAgentId, subject, body, push } = input;
 
-  // Verify convoy exists
-  const convoy = queryOne<{ id: string }>('SELECT id FROM convoys WHERE id = ?', [convoyId]);
-  if (!convoy) throw new Error(`Convoy ${convoyId} not found`);
+  // If a convoy is specified, verify it exists — matches the old strict
+  // behavior for the existing convoy mail API. Non-convoy mail skips this
+  // check, which is what makes the roll-call/help-request paths work.
+  if (convoyId) {
+    const convoy = queryOne<{ id: string }>('SELECT id FROM convoys WHERE id = ?', [convoyId]);
+    if (!convoy) throw new Error(`Convoy ${convoyId} not found`);
+  }
 
   const id = uuidv4();
   const now = new Date().toISOString();
 
   run(
-    `INSERT INTO agent_mailbox (id, convoy_id, from_agent_id, to_agent_id, subject, body, created_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?)`,
-    [id, convoyId, fromAgentId, toAgentId, subject || null, body, now]
+    `INSERT INTO agent_mailbox (id, convoy_id, task_id, from_agent_id, to_agent_id, subject, body, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    [id, convoyId ?? null, taskId ?? null, fromAgentId, toAgentId, subject || null, body, now]
   );
 
   const message = queryOne<AgentMailMessage>('SELECT * FROM agent_mailbox WHERE id = ?', [id])!;
 
   broadcast({ type: 'mail_received', payload: message });
 
-  return message;
+  if (!push) return { message };
+
+  // Push delivery. We frame the mail body so the receiving agent can
+  // distinguish mail from a regular task dispatch, and include the
+  // message_id so the operator can trace the mail row through the debug
+  // feed. If delivery fails, the DB row is still there — a later
+  // dispatch will pick it up via formatMailForDispatch. We surface the
+  // failure in the return value so roll-call can record it accurately.
+  try {
+    // Lazy-import to avoid pulling the openclaw client into non-push callers.
+    const { getOpenClawClient } = await import('@/lib/openclaw/client');
+    const client = getOpenClawClient();
+    if (!client.isConnected()) {
+      await client.connect();
+    }
+
+    // Build a sessionKey that targets the agent's own namespace. The prefix
+    // resolver prefers an explicit `session_key_prefix`, then the gateway
+    // agent id, then a name-slug fallback — anything but the old
+    // `agent:main:` catchall that misrouted to the gateway's main agent.
+    // We append a mail-scoped suffix so each mail occupies its own
+    // session bucket (the gateway creates it on receipt if needed — no
+    // pre-existing openclaw_sessions row required).
+    const { resolveAgentSessionKeyPrefix } = await import('@/lib/openclaw/session-key');
+    const target = queryOne<Pick<OpenClawSession, 'id'> & { name: string; session_key_prefix: string | null; gateway_agent_id: string | null }>(
+      'SELECT id, name, session_key_prefix, gateway_agent_id FROM agents WHERE id = ?',
+      [toAgentId]
+    );
+    if (!target) {
+      return {
+        message,
+        delivery: { status: 'skipped', error: `Target agent ${toAgentId} not found` },
+      };
+    }
+    const fromAgent = queryOne<{ name: string }>('SELECT name FROM agents WHERE id = ?', [fromAgentId]);
+    const prefix = resolveAgentSessionKeyPrefix({
+      session_key_prefix: target.session_key_prefix ?? undefined,
+      gateway_agent_id: target.gateway_agent_id ?? undefined,
+      name: target.name,
+    } as Agent);
+    const sessionKey = `${prefix}mc-mail-${id}`;
+
+    // Frame the mail so the agent recognises it as MC→agent mail (not a
+    // regular task dispatch). We deliberately don't append a generic
+    // "reply by POST" footer here — callers know the exact reply shape
+    // they want (roll-call needs a specific subject format; help-request
+    // flows may not need a reply at all), and appending a generic footer
+    // caused agents to guess URLs / methods / body shapes rather than
+    // follow the caller's explicit instructions.
+    const framedMessage = `📬 **MAIL from ${fromAgent?.name || fromAgentId}** (mail_id=${id})
+${subject ? `**Subject:** ${subject}\n` : ''}
+${body}`;
+
+    await client.call('chat.send', {
+      sessionKey,
+      message: framedMessage,
+      idempotencyKey: `mail-${id}`,
+    });
+
+    return {
+      message,
+      delivery: { status: 'sent', sessionKey },
+    };
+  } catch (err) {
+    return {
+      message,
+      delivery: { status: 'failed', error: (err as Error).message },
+    };
+  }
 }
 
 /**

--- a/src/lib/master-orchestrator.ts
+++ b/src/lib/master-orchestrator.ts
@@ -1,0 +1,40 @@
+import { queryAll } from '@/lib/db';
+import type { Agent } from '@/lib/types';
+
+export type MasterOrchestratorResult =
+  | { ok: true; agent: Agent }
+  | { ok: false; reason: 'none' | 'multiple'; candidates: Agent[] };
+
+/**
+ * Resolve the single master orchestrator for a workspace.
+ *
+ * The roll-call feature (and any future feature that needs a workspace-wide
+ * "governing" agent) requires exactly one agent marked `is_master=1`. We
+ * return a tagged union so callers can raise the right alert:
+ *   - `none`: no master exists → operator must mark one via
+ *     `PATCH /api/agents/[id]` with { is_master: true }
+ *   - `multiple`: more than one → operator must pick by un-marking the others
+ *
+ * Non-active agents (`is_active = 0`) and offline agents are excluded from
+ * consideration — a disabled orchestrator doesn't count even if its
+ * `is_master` flag is still set in the DB.
+ */
+export function resolveMasterOrchestrator(workspaceId: string): MasterOrchestratorResult {
+  const candidates = queryAll<Agent>(
+    `SELECT * FROM agents
+       WHERE is_master = 1
+         AND workspace_id = ?
+         AND COALESCE(is_active, 1) = 1
+         AND COALESCE(status, 'standby') != 'offline'
+       ORDER BY updated_at DESC`,
+    [workspaceId]
+  );
+
+  if (candidates.length === 0) {
+    return { ok: false, reason: 'none', candidates: [] };
+  }
+  if (candidates.length > 1) {
+    return { ok: false, reason: 'multiple', candidates };
+  }
+  return { ok: true, agent: candidates[0] };
+}

--- a/src/lib/openclaw/client.ts
+++ b/src/lib/openclaw/client.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from 'events';
 import type { OpenClawMessage, OpenClawSessionInfo } from '../types';
 import { loadOrCreateDeviceIdentity, signDevicePayload, buildDeviceAuthPayload, publicKeyRawBase64Url } from './device-identity';
 import { createHash } from 'crypto';
+import { logDebugEvent } from '../debug-log';
 
 // Types for gateway model discovery (matches OpenClaw models.list response)
 export interface GatewayModelChoice {
@@ -217,6 +218,14 @@ export class OpenClawClient extends EventEmitter {
           console.log('[OpenClaw] WebSocket opened, waiting for challenge...');
           // Don't send anything yet - wait for Gateway challenge
           // Token is in URL query string
+          logDebugEvent({
+            type: 'ws.connect',
+            direction: 'internal',
+            metadata: {
+              url: this.url,
+              phase: 'socket_open',
+            },
+          });
         };
 
         this.ws.onclose = (event) => {
@@ -230,6 +239,17 @@ export class OpenClawClient extends EventEmitter {
           this.emit('disconnected');
           // Log close reason for debugging
           console.log(`[OpenClaw] Disconnected from Gateway (code: ${event.code}, reason: "${event.reason}", wasClean: ${event.wasClean})`);
+          logDebugEvent({
+            type: 'ws.disconnect',
+            direction: 'internal',
+            metadata: {
+              code: event.code,
+              reason: event.reason,
+              was_clean: event.wasClean,
+              was_connected: wasConnected,
+              auto_reconnect: this.autoReconnect,
+            },
+          });
           // Only auto-reconnect if we were previously connected (not on initial connection failure)
           if (this.autoReconnect && wasConnected) {
             this.scheduleReconnect();
@@ -240,6 +260,12 @@ export class OpenClawClient extends EventEmitter {
           clearTimeout(connectionTimeout);
           console.error('[OpenClaw] WebSocket error');
           this.emit('error', error);
+          logDebugEvent({
+            type: 'ws.error',
+            direction: 'internal',
+            error: (error as unknown as { message?: string })?.message || 'WebSocket error',
+            metadata: { connected: this.connected },
+          });
           if (!this.connected) {
             this.connecting = null;
             reject(new Error('Failed to connect to OpenClaw Gateway'));
@@ -280,9 +306,23 @@ export class OpenClawClient extends EventEmitter {
             // Forward gateway streaming events so subscribers can tap in
             if (data.type === 'event' && data.event === 'agent' && data.payload) {
               this.emit('agent_event', data.payload);
+              logDebugEvent({
+                type: 'agent.event',
+                direction: 'inbound',
+                sessionKey: (data.payload as { sessionKey?: string })?.sessionKey ?? null,
+                responseBody: data.payload,
+                metadata: { seq: data.seq, event: data.event },
+              });
             }
             if (data.type === 'event' && data.event === 'chat' && data.payload) {
               this.emit('chat_event', data.payload);
+              logDebugEvent({
+                type: 'chat.response',
+                direction: 'inbound',
+                sessionKey: (data.payload as { sessionKey?: string })?.sessionKey ?? null,
+                responseBody: data.payload,
+                metadata: { seq: data.seq, event: data.event },
+              });
             }
 
             // Handle challenge-response authentication (OpenClaw RequestFrame format)
@@ -351,11 +391,26 @@ export class OpenClawClient extends EventEmitter {
                   this.connecting = null;
                   this.emit('connected');
                   console.log('[OpenClaw] Authenticated successfully');
+                  logDebugEvent({
+                    type: 'ws.authenticated',
+                    direction: 'internal',
+                    metadata: {
+                      role,
+                      scopes,
+                      device_id: this.deviceIdentity?.deviceId ?? null,
+                    },
+                  });
                   resolve();
                 },
                 reject: (error: Error) => {
                   this.connecting = null;
                   this.ws?.close();
+                  logDebugEvent({
+                    type: 'ws.error',
+                    direction: 'internal',
+                    error: `Authentication failed: ${error.message}`,
+                    metadata: { phase: 'authentication' },
+                  });
                   reject(new Error(`Authentication failed: ${error.message}`));
                 }
               });
@@ -431,6 +486,11 @@ export class OpenClawClient extends EventEmitter {
       if (!this.autoReconnect) return;
 
       console.log('[OpenClaw] Attempting reconnect...');
+      logDebugEvent({
+        type: 'ws.reconnect',
+        direction: 'internal',
+        metadata: { trigger: 'scheduled', interval_ms: 10000 },
+      });
       try {
         await this.connect();
       } catch {
@@ -442,14 +502,60 @@ export class OpenClawClient extends EventEmitter {
 
   async call<T = unknown>(method: string, params?: Record<string, unknown>): Promise<T> {
     if (!this.ws || !this.connected || !this.authenticated) {
+      logDebugEvent({
+        type: 'gateway.rpc',
+        direction: 'outbound',
+        error: 'Not connected to OpenClaw Gateway',
+        metadata: { method, pre_flight: true },
+      });
       throw new Error('Not connected to OpenClaw Gateway');
     }
 
     const id = crypto.randomUUID();
     const message = { type: 'req', id, method, params };
+    const started = Date.now();
+
+    // Keep the request body summary out of the hot path's closure so the
+    // GC can release the full payload once the debug row is serialised.
+    // Some params (chat.send message) can be 10KB+; we store the preview
+    // rather than the full thing when it exceeds a reasonable bound.
+    const paramPreview = (() => {
+      if (!params) return null;
+      try {
+        const s = JSON.stringify(params);
+        return s.length > 4096 ? { _truncated: true, length: s.length, head: s.slice(0, 4096) } : params;
+      } catch {
+        return { _unstringifiable: true };
+      }
+    })();
 
     return new Promise((resolve, reject) => {
-      this.pendingRequests.set(id, { resolve: resolve as (value: unknown) => void, reject });
+      this.pendingRequests.set(id, {
+        resolve: (value: unknown) => {
+          logDebugEvent({
+            type: 'gateway.rpc',
+            direction: 'outbound',
+            sessionKey: (params as { sessionKey?: string } | undefined)?.sessionKey ?? null,
+            durationMs: Date.now() - started,
+            requestBody: { method, params: paramPreview },
+            responseBody: value,
+            metadata: { method, request_id: id },
+          });
+          (resolve as (v: unknown) => void)(value);
+        },
+        reject: (error: Error) => {
+          logDebugEvent({
+            type: 'gateway.rpc',
+            direction: 'outbound',
+            sessionKey: (params as { sessionKey?: string } | undefined)?.sessionKey ?? null,
+            durationMs: Date.now() - started,
+            requestBody: { method, params: paramPreview },
+            error: error.message,
+            metadata: { method, request_id: id },
+          });
+          reject(error);
+        },
+      });
 
       // Timeout after 30 seconds
       setTimeout(() => {

--- a/src/lib/openclaw/session-key.ts
+++ b/src/lib/openclaw/session-key.ts
@@ -1,0 +1,33 @@
+import type { Agent } from '@/lib/types';
+
+/**
+ * Resolve the OpenClaw sessionKey prefix for a target agent.
+ *
+ * Priority:
+ *   1. `agent.session_key_prefix` if explicitly set (operator override).
+ *   2. `agent:<gateway_agent_id>:` — preferred for gateway-synced agents,
+ *      because the gateway treats `agent:<agentId>:<...>` as the agent's
+ *      own namespace (see OpenClaw session-routing docs).
+ *   3. `agent:<slugified_name>:` — last-resort fallback for local/manual
+ *      agents that have never been linked to a gateway agent.
+ *
+ * Previously the default was a hard-coded `agent:main:` which silently
+ * routed every MC→agent chat.send to the gateway's "main" agent
+ * regardless of which agent MC intended to reach. That masked test
+ * failures (e.g. roll-call's "no session" results) and misrouted real
+ * dispatches. Every call site that builds a sessionKey should use this
+ * helper so the change lands uniformly.
+ */
+export function resolveAgentSessionKeyPrefix(
+  agent: Pick<Agent, 'session_key_prefix' | 'gateway_agent_id' | 'name'>
+): string {
+  const explicit = agent.session_key_prefix?.trim();
+  if (explicit) {
+    return explicit.endsWith(':') ? explicit : `${explicit}:`;
+  }
+  if (agent.gateway_agent_id) {
+    return `agent:${agent.gateway_agent_id}:`;
+  }
+  const slug = agent.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  return `agent:${slug || 'unknown'}:`;
+}

--- a/src/lib/rollcall.ts
+++ b/src/lib/rollcall.ts
@@ -1,0 +1,321 @@
+import { v4 as uuidv4 } from 'uuid';
+import { queryAll, queryOne, run, transaction } from '@/lib/db';
+import { broadcast } from '@/lib/events';
+import { sendMail } from '@/lib/mailbox';
+import { resolveMasterOrchestrator } from '@/lib/master-orchestrator';
+import { getMissionControlUrl } from '@/lib/config';
+import type { Agent } from '@/lib/types';
+
+export interface RollCallSession {
+  id: string;
+  workspace_id: string;
+  initiator_agent_id: string;
+  mode: 'direct' | 'coordinator';
+  timeout_seconds: number;
+  created_at: string;
+  expires_at: string;
+}
+
+export interface RollCallEntry {
+  id: string;
+  rollcall_id: string;
+  target_agent_id: string;
+  delivery_status: 'pending' | 'sent' | 'failed' | 'skipped';
+  delivery_error: string | null;
+  delivered_at: string | null;
+  reply_mail_id: string | null;
+  reply_body: string | null;
+  replied_at: string | null;
+  created_at: string;
+  // Joined on read
+  target_agent_name?: string;
+  target_agent_role?: string;
+}
+
+export type InitiateRollCallResult =
+  | {
+      ok: true;
+      rollcall: RollCallSession;
+      entries: RollCallEntry[];
+    }
+  | {
+      ok: false;
+      reason: 'no_master' | 'multiple_masters' | 'no_active_agents';
+      detail: string;
+      candidates?: Agent[];
+    };
+
+/**
+ * Start a roll-call: ask every active agent in the workspace (except the
+ * initiator) to check in. Delivery happens via mail push (chat.send to
+ * the target's active session). Replies are captured when agents POST
+ * back to `/api/agents/<initiator>/mail`.
+ *
+ * Modes:
+ *   - 'direct'      : MC push-delivers the mail itself from the master
+ *                     orchestrator to each target.
+ *   - 'coordinator' : MC dispatches a task to the master orchestrator
+ *                     and the master uses sessions_send / mail to
+ *                     fan-out. Currently both modes use the same direct
+ *                     push path underneath — coordinator mode just also
+ *                     creates the orchestrator-visible task so the master
+ *                     can follow up.
+ */
+export async function initiateRollCall(params: {
+  workspaceId: string;
+  mode: 'direct' | 'coordinator';
+  timeoutSeconds?: number;
+}): Promise<InitiateRollCallResult> {
+  const { workspaceId, mode, timeoutSeconds = 30 } = params;
+
+  // Resolve the master orchestrator (exactly one, else error).
+  const master = resolveMasterOrchestrator(workspaceId);
+  if (!master.ok) {
+    return {
+      ok: false,
+      reason: master.reason === 'none' ? 'no_master' : 'multiple_masters',
+      detail:
+        master.reason === 'none'
+          ? `No master orchestrator found in workspace "${workspaceId}". Mark one agent with is_master=1 via PATCH /api/agents/[id].`
+          : `${master.candidates.length} agents are marked as master orchestrators in workspace "${workspaceId}": ${master.candidates
+              .map(a => a.name)
+              .join(', ')}. Exactly one is required — un-mark the others via PATCH.`,
+      candidates: master.reason === 'multiple' ? master.candidates : undefined,
+    };
+  }
+
+  // Active agents in the workspace, excluding the master itself.
+  const targets = queryAll<Agent>(
+    `SELECT * FROM agents
+       WHERE workspace_id = ?
+         AND id != ?
+         AND COALESCE(is_active, 1) = 1
+         AND COALESCE(status, 'standby') != 'offline'
+       ORDER BY role ASC, name ASC`,
+    [workspaceId, master.agent.id]
+  );
+
+  if (targets.length === 0) {
+    return {
+      ok: false,
+      reason: 'no_active_agents',
+      detail: `No other active agents in workspace "${workspaceId}". Mark at least one agent as is_active=1.`,
+    };
+  }
+
+  const rollcallId = uuidv4();
+  const now = new Date();
+  const nowIso = now.toISOString();
+  const expiresAt = new Date(now.getTime() + timeoutSeconds * 1000).toISOString();
+
+  // Insert session + entries in one transaction so the UI can subscribe
+  // to a single rollcall_id and pick up a complete roster on first read.
+  transaction(() => {
+    run(
+      `INSERT INTO rollcall_sessions (id, workspace_id, initiator_agent_id, mode, timeout_seconds, created_at, expires_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [rollcallId, workspaceId, master.agent.id, mode, timeoutSeconds, nowIso, expiresAt]
+    );
+    for (const t of targets) {
+      run(
+        `INSERT INTO rollcall_entries (id, rollcall_id, target_agent_id, created_at)
+         VALUES (?, ?, ?, ?)`,
+        [uuidv4(), rollcallId, t.id, nowIso]
+      );
+    }
+  });
+
+  broadcast({
+    type: 'rollcall_started',
+    payload: { rollcall_id: rollcallId, workspace_id: workspaceId, mode, target_count: targets.length },
+  });
+
+  // Deliver mail to each target. We do this sequentially (not in parallel)
+  // because our OpenClawClient singleton serializes via a single WebSocket
+  // — parallel fire would interleave RPC requests but gain little given
+  // the typical target count (<10). Keeping it sequential also gives us
+  // deterministic ordering in the debug feed.
+  //
+  // Each target gets a personalized mail body that hard-codes:
+  //   - their own MC agent_id (they don't need to guess / introspect)
+  //   - the fully-qualified MC URL (no "localhost:3120?" probing)
+  //   - a bearer-token hint (the middleware rejects agent POSTs without
+  //     the MC_API_TOKEN in prod; dev without a token omits the header)
+  //   - a ready-to-paste curl command so there's one unambiguous shape
+  //     to mimic
+  // Prior versions of this prompt showed agents trying every port from
+  // 3000 upward, probing with PUT when POST was right, and filling
+  // `from_agent_id` with whatever random uuid they could scrape off
+  // their own session. Being explicit here eliminates all of that.
+  const missionControlUrl = getMissionControlUrl();
+  const token = process.env.MC_API_TOKEN;
+
+  // Sanity check: roll-call replies must be reachable from whichever host
+  // the target agent is running on. If MISSION_CONTROL_URL points to
+  // localhost / 127.0.0.1 / ::1, agents on any other host will see
+  // "connection refused" when they try to reply. We don't block — the
+  // operator may legitimately be running a single-host dev setup — but
+  // log loudly so misconfiguration surfaces before the first 30s timeout.
+  if (/^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:|\/|$)/.test(missionControlUrl)) {
+    console.warn(
+      `[RollCall] MISSION_CONTROL_URL is set to ${missionControlUrl}. ` +
+      `If any target agent runs on a different host it will not be able ` +
+      `to reach this URL to reply. Set MISSION_CONTROL_URL to an address ` +
+      `reachable from the agent host (e.g. your LAN IP) and restart MC.`
+    );
+  }
+  const authHeaderLine = token
+    ? `  -H "Authorization: Bearer ${token}" \\\n`
+    : '';
+  const authNote = token
+    ? `The Authorization header above is required — Mission Control runs with MC_API_TOKEN set and rejects unauthenticated agent callbacks with 403.`
+    : `No Authorization header is required in this dev environment (MC_API_TOKEN is not set).`;
+
+  for (const target of targets) {
+    const replyEndpoint = `${missionControlUrl}/api/agents/${master.agent.id}/mail`;
+    const body = `ROLL CALL — please reply briefly with your current status.
+
+**Your Mission Control agent_id:** \`${target.id}\`
+**Your role:** ${target.role}
+**Reply within:** ${timeoutSeconds}s
+
+**REPLY FORMAT** — copy and run this exact curl, substituting your short status note:
+
+\`\`\`bash
+curl -sS -X POST '${replyEndpoint}' \\
+  -H "Content-Type: application/json" \\
+${authHeaderLine}  -d '{
+    "from_agent_id": "${target.id}",
+    "subject": "roll_call_reply:${rollcallId}",
+    "body": "CHECKED_IN: ${target.role}, status=ok, note=<your short note>"
+  }'
+\`\`\`
+
+${authNote}
+
+Keep the reply brief — a single \`CHECKED_IN:\` line is enough.`;
+
+    let deliveryStatus: 'sent' | 'failed' | 'skipped' = 'failed';
+    let deliveryError: string | null = null;
+    try {
+      const result = await sendMail({
+        fromAgentId: master.agent.id,
+        toAgentId: target.id,
+        subject: `roll_call:${rollcallId}`,
+        body,
+        push: true,
+      });
+      deliveryStatus = result.delivery?.status ?? 'failed';
+      deliveryError = result.delivery?.error ?? null;
+    } catch (err) {
+      deliveryStatus = 'failed';
+      deliveryError = (err as Error).message;
+    }
+
+    run(
+      `UPDATE rollcall_entries
+         SET delivery_status = ?, delivery_error = ?, delivered_at = ?
+       WHERE rollcall_id = ? AND target_agent_id = ?`,
+      [deliveryStatus, deliveryError, new Date().toISOString(), rollcallId, target.id]
+    );
+  }
+
+  // Return the assembled roster. The caller will poll GET for updates as
+  // replies come in — or subscribe to the `rollcall_entry_updated` SSE
+  // event stream we'll emit when replies land.
+  const rollcall = queryOne<RollCallSession>('SELECT * FROM rollcall_sessions WHERE id = ?', [rollcallId])!;
+  const entries = queryAll<RollCallEntry>(
+    `SELECT e.*, a.name as target_agent_name, a.role as target_agent_role
+       FROM rollcall_entries e
+       JOIN agents a ON a.id = e.target_agent_id
+       WHERE e.rollcall_id = ?
+       ORDER BY a.role ASC, a.name ASC`,
+    [rollcallId]
+  );
+
+  broadcast({
+    type: 'rollcall_delivered',
+    payload: { rollcall_id: rollcallId, entries },
+  });
+
+  return { ok: true, rollcall, entries };
+}
+
+/**
+ * Fetch current status of a roll-call, including any replies that have
+ * arrived since delivery.
+ */
+export function getRollCallStatus(rollcallId: string): {
+  rollcall: RollCallSession;
+  entries: RollCallEntry[];
+} | null {
+  const rollcall = queryOne<RollCallSession>(
+    'SELECT * FROM rollcall_sessions WHERE id = ?',
+    [rollcallId]
+  );
+  if (!rollcall) return null;
+
+  const entries = queryAll<RollCallEntry>(
+    `SELECT e.*, a.name as target_agent_name, a.role as target_agent_role
+       FROM rollcall_entries e
+       JOIN agents a ON a.id = e.target_agent_id
+       WHERE e.rollcall_id = ?
+       ORDER BY a.role ASC, a.name ASC`,
+    [rollcallId]
+  );
+
+  return { rollcall, entries };
+}
+
+/**
+ * Try to record a mail message as the reply to an open roll-call entry.
+ * Called from the mail POST handler when `subject` starts with
+ * "roll_call_reply" or "roll_call:<id>" — matches by (rollcall_id,
+ * from_agent_id). No-op if no matching entry is found (e.g. late reply
+ * after expiry or stray mail).
+ */
+export function recordRollCallReplyIfMatch(params: {
+  mailId: string;
+  fromAgentId: string;
+  toAgentId: string;
+  subject: string | null | undefined;
+  body: string;
+}): { matched: boolean; rollcallId?: string } {
+  const { mailId, fromAgentId, toAgentId, subject, body } = params;
+  if (!subject) return { matched: false };
+
+  // Accept either "roll_call_reply:<uuid>" or "roll_call:<uuid>"
+  const match = subject.match(/^roll_call(?:_reply)?:([\w-]+)/i);
+  const rollcallId = match?.[1];
+  if (!rollcallId) return { matched: false };
+
+  const rollcall = queryOne<RollCallSession>(
+    'SELECT * FROM rollcall_sessions WHERE id = ? AND initiator_agent_id = ?',
+    [rollcallId, toAgentId]
+  );
+  if (!rollcall) return { matched: false };
+
+  const entry = queryOne<{ id: string; replied_at: string | null }>(
+    'SELECT id, replied_at FROM rollcall_entries WHERE rollcall_id = ? AND target_agent_id = ?',
+    [rollcallId, fromAgentId]
+  );
+  if (!entry || entry.replied_at) return { matched: false };
+
+  run(
+    `UPDATE rollcall_entries
+       SET reply_mail_id = ?, reply_body = ?, replied_at = ?
+     WHERE id = ?`,
+    [mailId, body, new Date().toISOString(), entry.id]
+  );
+
+  broadcast({
+    type: 'rollcall_entry_updated',
+    payload: {
+      rollcall_id: rollcallId,
+      target_agent_id: fromAgentId,
+      reply_received: true,
+    },
+  });
+
+  return { matched: true, rollcallId };
+}

--- a/src/lib/stall-detection.ts
+++ b/src/lib/stall-detection.ts
@@ -1,0 +1,337 @@
+import { v4 as uuidv4 } from 'uuid';
+import { queryOne, queryAll, run } from '@/lib/db';
+import { sendMail } from '@/lib/mailbox';
+import { logTaskActivity } from '@/lib/activity-log';
+import { saveCheckpointThrottled } from '@/lib/checkpoint';
+import type { Task } from '@/lib/types';
+
+// Active statuses that can go stale. Kept in sync with
+// src/lib/task-governance.ts — not imported so this module remains a thin
+// leaf dependency; a drift test in Phase 9 pins the list.
+const ACTIVE_STATUSES = ['assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification'] as const;
+
+/** Default threshold. Override via STALL_DETECTION_MINUTES env var. */
+const DEFAULT_STALL_MINUTES = 30;
+
+/** Consider the coordinator itself stalled if its last heartbeat is older than this. */
+const COORDINATOR_STALL_MINUTES = 10;
+
+/** Don't re-notify for the same stall within this window. */
+const NOTIFY_THROTTLE_MINUTES = 60;
+
+export interface StallReport {
+  scanned: number;
+  flagged: Array<{
+    task_id: string;
+    title: string;
+    status: string;
+    minutes_idle: number;
+    mode: 'convoy' | 'solo';
+    notified: 'coordinator' | 'webhook' | 'coordinator_stalled' | 'coordinator_missing' | 'throttled' | 'none';
+  }>;
+}
+
+function getThresholdMinutes(): number {
+  const raw = process.env.STALL_DETECTION_MINUTES;
+  if (!raw) return DEFAULT_STALL_MINUTES;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_STALL_MINUTES;
+}
+
+/**
+ * Stall scanner. Flags tasks in an active status whose last typed activity
+ * is older than the threshold AND which have no deliverables. Notifies via
+ * the convoy coordinator (if this is a convoy sub-task) or via webhook.
+ *
+ * Called from `runHealthCheckCycle` in agent-health.ts and also available
+ * as a manual trigger at POST /api/tasks/scan-stalls.
+ *
+ * This function must be idempotent: calling it repeatedly within
+ * NOTIFY_THROTTLE_MINUTES should not re-flag or re-notify the same task.
+ */
+export async function scanStalledTasks(): Promise<StallReport> {
+  const thresholdMinutes = getThresholdMinutes();
+
+  // Join with the max activity timestamp so we rank by freshness. Anything
+  // older than the threshold AND with zero deliverables is a candidate.
+  // `task_activities` is the source of truth — it's task-scoped so convoy
+  // members writing to it count toward the parent's freshness.
+  const placeholders = ACTIVE_STATUSES.map(() => '?').join(',');
+  const candidates = queryAll<Task & { last_activity_at: string | null; deliverable_count: number }>(
+    `SELECT
+       t.*,
+       (SELECT MAX(created_at) FROM task_activities WHERE task_id = t.id) as last_activity_at,
+       (SELECT COUNT(*) FROM task_deliverables WHERE task_id = t.id) as deliverable_count
+     FROM tasks t
+     WHERE t.status IN (${placeholders})`,
+    [...ACTIVE_STATUSES]
+  );
+
+  const report: StallReport = { scanned: candidates.length, flagged: [] };
+  const nowMs = Date.now();
+
+  for (const task of candidates) {
+    if (task.deliverable_count > 0) continue;
+
+    const lastTick = task.last_activity_at || task.updated_at;
+    const minutesIdle = (nowMs - new Date(lastTick).getTime()) / 60000;
+    if (minutesIdle < thresholdMinutes) continue;
+
+    // Skip if we already raced through and flagged this task recently. The
+    // coordinator may be mid-handoff, or a nudge may be in-flight — both
+    // show up as a fresh `status_changed` activity which would bump
+    // `last_activity_at` above. Defense in depth: also skip if we already
+    // wrote a stall_detected row within the throttle window.
+    const lastDetected = queryOne<{ created_at: string }>(
+      `SELECT created_at FROM task_activities
+       WHERE task_id = ? AND activity_type = 'stall_detected'
+       ORDER BY created_at DESC LIMIT 1`,
+      [task.id]
+    );
+    const alreadyFlagged = lastDetected
+      && (nowMs - new Date(lastDetected.created_at).getTime()) / 60000 < NOTIFY_THROTTLE_MINUTES;
+
+    // 1. Mark the task. status_reason is cleared by Phase 3.5
+    //    (recovery-guard) when the coordinator does anything real.
+    if (!alreadyFlagged) {
+      run(
+        `UPDATE tasks SET status_reason = ?, updated_at = ? WHERE id = ?`,
+        [
+          `stalled_no_activity (idle ${Math.round(minutesIdle)}m, detected ${new Date().toISOString()})`,
+          new Date().toISOString(),
+          task.id,
+        ]
+      );
+      logTaskActivity({
+        taskId: task.id,
+        type: 'stall_detected',
+        message: `Task idle for ${Math.round(minutesIdle)}m with no deliverables`,
+        metadata: { minutes_idle: Math.round(minutesIdle), threshold: thresholdMinutes },
+      });
+
+      // Snapshot a checkpoint so a subsequent /checkpoint/restore has
+      // something to resume from. Throttled at 300s (same as the scan
+      // cadence floor) to avoid piling rows on re-flagged tasks.
+      if (task.assigned_agent_id) {
+        try {
+          saveCheckpointThrottled(
+            {
+              taskId: task.id,
+              agentId: task.assigned_agent_id,
+              checkpointType: 'auto',
+              stateSummary: `Stall snapshot — idle ${Math.round(minutesIdle)}m in ${task.status}`,
+              contextData: {
+                minutes_idle: Math.round(minutesIdle),
+                status_at_snapshot: task.status,
+                detected_at: new Date().toISOString(),
+              },
+            },
+            300
+          );
+        } catch (err) {
+          console.warn('[Stall] saveCheckpoint on stall_detected failed:', err);
+        }
+      }
+    }
+
+    // 2. Decide who to notify.
+    const convoyMembership = resolveConvoyMembership(task);
+    const notifyDecision = alreadyFlagged
+      ? 'throttled' as const
+      : await notifyForStall(task, convoyMembership, minutesIdle);
+
+    report.flagged.push({
+      task_id: task.id,
+      title: task.title,
+      status: task.status,
+      minutes_idle: Math.round(minutesIdle),
+      mode: convoyMembership ? 'convoy' : 'solo',
+      notified: notifyDecision,
+    });
+  }
+
+  return report;
+}
+
+interface ConvoyMembership {
+  convoyId: string;
+  parentTaskId: string;
+  coordinatorAgentId: string | null;
+}
+
+/**
+ * Resolve the convoy this task belongs to, if any. Three shapes to handle:
+ *   (a) task is a convoy sub-task  → tasks.convoy_id + convoy_subtasks row
+ *   (b) task is a convoy parent    → convoys.parent_task_id = task.id
+ *   (c) neither                    → null (solo task, webhook path)
+ * In every convoy case, the "coordinator" is the agent assigned to the
+ * convoy's parent task. The schema doesn't model a separate coordinator,
+ * so we synthesize it here — see src/lib/convoy.ts for the idiom.
+ */
+function resolveConvoyMembership(task: Task): ConvoyMembership | null {
+  // Case (b): this task IS the convoy parent
+  const convoyAsParent = queryOne<{ id: string }>(
+    'SELECT id FROM convoys WHERE parent_task_id = ?',
+    [task.id]
+  );
+  if (convoyAsParent) {
+    return {
+      convoyId: convoyAsParent.id,
+      parentTaskId: task.id,
+      coordinatorAgentId: task.assigned_agent_id || null,
+    };
+  }
+
+  // Case (a): this task is a convoy sub-task
+  if (task.convoy_id) {
+    const convoy = queryOne<{ id: string; parent_task_id: string }>(
+      'SELECT id, parent_task_id FROM convoys WHERE id = ?',
+      [task.convoy_id]
+    );
+    if (convoy) {
+      const parent = queryOne<{ assigned_agent_id: string | null }>(
+        'SELECT assigned_agent_id FROM tasks WHERE id = ?',
+        [convoy.parent_task_id]
+      );
+      return {
+        convoyId: convoy.id,
+        parentTaskId: convoy.parent_task_id,
+        coordinatorAgentId: parent?.assigned_agent_id || null,
+      };
+    }
+  }
+
+  return null;
+}
+
+async function notifyForStall(
+  task: Task,
+  convoy: ConvoyMembership | null,
+  minutesIdle: number
+): Promise<StallReport['flagged'][number]['notified']> {
+  if (!convoy) {
+    await fireWebhook(task, minutesIdle);
+    logTaskActivity({
+      taskId: task.id,
+      type: 'stall_notified',
+      message: `Notified via webhook (solo task)`,
+    });
+    return 'webhook';
+  }
+
+  // Convoy path. Coordinator may be missing (agent deleted) or itself
+  // stalled (its own most-recent activity older than COORDINATOR_STALL_MINUTES).
+  if (!convoy.coordinatorAgentId) {
+    logTaskActivity({
+      taskId: task.id,
+      type: 'coordinator_missing',
+      message: `Convoy ${convoy.convoyId} has no assigned coordinator — falling back to webhook`,
+    });
+    await fireWebhook(task, minutesIdle);
+    return 'coordinator_missing';
+  }
+
+  const coordinatorLast = queryOne<{ last_activity_at: string }>(
+    `SELECT MAX(created_at) as last_activity_at FROM task_activities
+     WHERE agent_id = ?`,
+    [convoy.coordinatorAgentId]
+  );
+  const coordinatorIdleMinutes = coordinatorLast?.last_activity_at
+    ? (Date.now() - new Date(coordinatorLast.last_activity_at).getTime()) / 60000
+    : Infinity;
+
+  if (coordinatorIdleMinutes > COORDINATOR_STALL_MINUTES) {
+    logTaskActivity({
+      taskId: task.id,
+      type: 'coordinator_stalled',
+      message: `Coordinator ${convoy.coordinatorAgentId} also stalled (${Math.round(coordinatorIdleMinutes)}m idle) — escalating via webhook`,
+    });
+    await fireWebhook(task, minutesIdle);
+    return 'coordinator_stalled';
+  }
+
+  // Send mail. sendMail requires a from_agent_id — we use the task's
+  // originally-assigned agent as the nominal "from" (the agent that
+  // stalled), falling back to the coordinator itself (self-message) so
+  // the FK check doesn't fail when the stalled task never had an assignee.
+  const fromAgentId = task.assigned_agent_id || convoy.coordinatorAgentId;
+  try {
+    sendMail({
+      convoyId: convoy.convoyId,
+      fromAgentId,
+      toAgentId: convoy.coordinatorAgentId,
+      subject: `Stall on "${task.title}"`,
+      body: [
+        `Sub-task ${task.id} has been idle for ${Math.round(minutesIdle)} minutes in status "${task.status}".`,
+        `No deliverables registered. You can:`,
+        `- Revise the spec and re-dispatch via POST /api/tasks/${task.id}/dispatch`,
+        `- Reassign to another agent via PATCH /api/tasks/${task.id}`,
+        `- Cancel via POST /api/tasks/${task.id}/admin/release-stall`,
+      ].join('\n'),
+    });
+    logTaskActivity({
+      taskId: task.id,
+      type: 'stall_notified',
+      message: `Notified coordinator (agent ${convoy.coordinatorAgentId})`,
+      metadata: { convoy_id: convoy.convoyId, coordinator_agent_id: convoy.coordinatorAgentId },
+    });
+    return 'coordinator';
+  } catch (err) {
+    // sendMail throws if the convoy vanished between the SELECT above and
+    // here — extremely rare but possible. Fall back to webhook so the
+    // operator still gets a signal.
+    console.warn('[Stall] Coordinator sendMail failed, falling back to webhook:', err);
+    await fireWebhook(task, minutesIdle);
+    return 'webhook';
+  }
+}
+
+async function fireWebhook(task: Task, minutesIdle: number): Promise<void> {
+  const url = process.env.MC_STALL_WEBHOOK_URL;
+  if (!url) return;
+
+  const payload = {
+    text: `🚨 Stalled task: "${task.title}" (${task.id}) idle ${Math.round(minutesIdle)}m in status "${task.status}"`,
+    task_id: task.id,
+    title: task.title,
+    status: task.status,
+    minutes_idle: Math.round(minutesIdle),
+    assigned_agent_id: task.assigned_agent_id || null,
+  };
+
+  try {
+    await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(5_000),
+    });
+  } catch (err) {
+    // Webhook failures are best-effort — a failing webhook shouldn't block
+    // the rest of the scan from processing other stalled tasks.
+    console.warn('[Stall] Webhook POST failed:', (err as Error).message);
+  }
+}
+
+/**
+ * Called by dispatch / reassign / plan-revision paths to clear the
+ * stalled flag when the coordinator (or an operator) takes a real action.
+ * Without this the next scan would re-flag the same task and re-notify.
+ */
+export function clearStallFlag(taskId: string): void {
+  const task = queryOne<{ status_reason: string | null }>(
+    'SELECT status_reason FROM tasks WHERE id = ?',
+    [taskId]
+  );
+  if (!task?.status_reason?.startsWith('stalled_')) return;
+
+  run(
+    `UPDATE tasks SET status_reason = NULL, updated_at = ? WHERE id = ?`,
+    [new Date().toISOString(), taskId]
+  );
+  logTaskActivity({
+    taskId,
+    type: 'stall_recovered',
+    message: 'Stall cleared by subsequent action (dispatch / reassign / mail from coordinator)',
+  });
+}

--- a/src/lib/stall-detection.ts
+++ b/src/lib/stall-detection.ts
@@ -269,7 +269,7 @@ async function notifyForStall(
   // the FK check doesn't fail when the stalled task never had an assignee.
   const fromAgentId = task.assigned_agent_id || convoy.coordinatorAgentId;
   try {
-    sendMail({
+    await sendMail({
       convoyId: convoy.convoyId,
       fromAgentId,
       toAgentId: convoy.coordinatorAgentId,

--- a/src/lib/stall-detection.ts
+++ b/src/lib/stall-detection.ts
@@ -3,6 +3,7 @@ import { queryOne, queryAll, run } from '@/lib/db';
 import { sendMail } from '@/lib/mailbox';
 import { logTaskActivity } from '@/lib/activity-log';
 import { saveCheckpointThrottled } from '@/lib/checkpoint';
+import { logDebugEvent } from '@/lib/debug-log';
 import type { Task } from '@/lib/types';
 
 // Active statuses that can go stale. Kept in sync with
@@ -107,6 +108,18 @@ export async function scanStalledTasks(): Promise<StallReport> {
         type: 'stall_detected',
         message: `Task idle for ${Math.round(minutesIdle)}m with no deliverables`,
         metadata: { minutes_idle: Math.round(minutesIdle), threshold: thresholdMinutes },
+      });
+
+      logDebugEvent({
+        type: 'stall.flagged',
+        direction: 'internal',
+        taskId: task.id,
+        agentId: task.assigned_agent_id,
+        metadata: {
+          minutes_idle: Math.round(minutesIdle),
+          threshold_minutes: thresholdMinutes,
+          task_status: task.status,
+        },
       });
 
       // Snapshot a checkpoint so a subsequent /checkpoint/restore has
@@ -333,5 +346,12 @@ export function clearStallFlag(taskId: string): void {
     taskId,
     type: 'stall_recovered',
     message: 'Stall cleared by subsequent action (dispatch / reassign / mail from coordinator)',
+  });
+
+  logDebugEvent({
+    type: 'stall.cleared',
+    direction: 'internal',
+    taskId,
+    metadata: { prior_status_reason: task.status_reason },
   });
 }

--- a/src/lib/task-governance.ts
+++ b/src/lib/task-governance.ts
@@ -3,6 +3,11 @@ import { notifyLearner } from '@/lib/learner';
 import type { Task } from '@/lib/types';
 
 const ACTIVE_STATUSES = ['assigned', 'in_progress', 'convoy_active', 'testing', 'review', 'verification'];
+const TERMINAL_STATUSES = ['done', 'cancelled'];
+
+export function isTerminalStatus(status: string): boolean {
+  return TERMINAL_STATUSES.includes(status);
+}
 
 export function hasStageEvidence(taskId: string): boolean {
   const deliverable = queryOne<{ count: number }>('SELECT COUNT(*) as count FROM task_deliverables WHERE task_id = ?', [taskId]);

--- a/src/lib/task-governance.ts
+++ b/src/lib/task-governance.ts
@@ -138,15 +138,30 @@ export function pickDynamicAgent(taskId: string, stageRole?: string | null): { i
   }
 
   if (stageRole) {
+    // Prefer gateway-linked / session-routed agents. A matching-role "ghost"
+    // (no gateway_agent_id, no session_key_prefix) is never actually reachable
+    // via OpenClaw, so picking one silently breaks the dispatch.
     const byRole = queryOne<{ id: string; name: string }>(
-      `SELECT id, name FROM agents WHERE role = ? AND status != 'offline' ORDER BY status = 'standby' DESC, updated_at DESC LIMIT 1`,
+      `SELECT id, name FROM agents
+       WHERE role = ? AND status != 'offline'
+       ORDER BY
+         (gateway_agent_id IS NOT NULL OR session_key_prefix IS NOT NULL) DESC,
+         status = 'standby' DESC,
+         updated_at DESC
+       LIMIT 1`,
       [stageRole]
     );
     if (byRole) return byRole;
   }
 
   const fallback = queryOne<{ id: string; name: string }>(
-    `SELECT id, name FROM agents WHERE status != 'offline' ORDER BY is_master ASC, updated_at DESC LIMIT 1`
+    `SELECT id, name FROM agents
+     WHERE status != 'offline'
+     ORDER BY
+       (gateway_agent_id IS NOT NULL OR session_key_prefix IS NOT NULL) DESC,
+       is_master ASC,
+       updated_at DESC
+     LIMIT 1`
   );
   if (fallback && !checked.has(fallback.id)) return fallback;
 

--- a/src/lib/task-governance.ts
+++ b/src/lib/task-governance.ts
@@ -126,13 +126,16 @@ export function pickDynamicAgent(taskId: string, stageRole?: string | null): { i
     } catch {}
   }
 
+  // All role/fallback lookups filter on is_active=1 (COALESCE for rows
+  // created before the column existed — default to active). An operator-
+  // marked inactive agent is excluded from every routing decision.
   const checked = new Set<string>();
   for (const candidateId of plannerCandidates) {
-    const candidate = queryOne<{ id: string; name: string; is_master: number; status: string }>(
-      'SELECT id, name, is_master, status FROM agents WHERE id = ? LIMIT 1',
+    const candidate = queryOne<{ id: string; name: string; is_master: number; status: string; is_active: number }>(
+      'SELECT id, name, is_master, status, is_active FROM agents WHERE id = ? LIMIT 1',
       [candidateId]
     );
-    if (!candidate || candidate.status === 'offline') continue;
+    if (!candidate || candidate.status === 'offline' || Number(candidate.is_active ?? 1) !== 1) continue;
     checked.add(candidate.id);
     return { id: candidate.id, name: candidate.name };
   }
@@ -143,7 +146,7 @@ export function pickDynamicAgent(taskId: string, stageRole?: string | null): { i
     // via OpenClaw, so picking one silently breaks the dispatch.
     const byRole = queryOne<{ id: string; name: string }>(
       `SELECT id, name FROM agents
-       WHERE role = ? AND status != 'offline'
+       WHERE role = ? AND status != 'offline' AND COALESCE(is_active, 1) = 1
        ORDER BY
          (gateway_agent_id IS NOT NULL OR session_key_prefix IS NOT NULL) DESC,
          status = 'standby' DESC,
@@ -156,7 +159,7 @@ export function pickDynamicAgent(taskId: string, stageRole?: string | null): { i
 
   const fallback = queryOne<{ id: string; name: string }>(
     `SELECT id, name FROM agents
-     WHERE status != 'offline'
+     WHERE status != 'offline' AND COALESCE(is_active, 1) = 1
      ORDER BY
        (gateway_agent_id IS NOT NULL OR session_key_prefix IS NOT NULL) DESC,
        is_master ASC,

--- a/src/lib/task-notes.ts
+++ b/src/lib/task-notes.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { queryOne, queryAll, run } from '@/lib/db';
 import { broadcast } from '@/lib/events';
 import { getOpenClawClient } from '@/lib/openclaw/client';
+import { resolveAgentSessionKeyPrefix } from '@/lib/openclaw/session-key';
 import type { TaskNote, OpenClawSession, Agent } from '@/lib/types';
 
 /**
@@ -98,7 +99,7 @@ export async function deliverPendingNotesAtCheckpoint(taskId: string): Promise<n
 
     // Get the agent's session key prefix
     const agent = queryOne<Agent>('SELECT * FROM agents WHERE id = ?', [activeSession.agent_id]);
-    const prefix = agent?.session_key_prefix || 'agent:main:';
+    const prefix = agent ? resolveAgentSessionKeyPrefix(agent) : 'agent:main:';
     const sessionKey = `${prefix}${activeSession.openclaw_session_id}`;
 
     // Build the message

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -766,6 +766,10 @@ export interface ConvoySubtask {
   task_id: string;
   sort_order: number;
   depends_on?: string[];
+  /** Role hint produced by decomposition (e.g. 'researcher', 'writer').
+   *  Read by convoy dispatch to route each sub-task to an agent whose
+   *  `agents.role` matches. NULL means "no hint — pick a builder". */
+  suggested_role?: string | null;
   created_at: string;
   // Joined
   task?: Task;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,7 +2,7 @@
 
 export type AgentStatus = 'standby' | 'working' | 'offline';
 
-export type TaskStatus = 'pending_dispatch' | 'planning' | 'inbox' | 'assigned' | 'in_progress' | 'convoy_active' | 'testing' | 'review' | 'verification' | 'done';
+export type TaskStatus = 'pending_dispatch' | 'planning' | 'inbox' | 'assigned' | 'in_progress' | 'convoy_active' | 'testing' | 'review' | 'verification' | 'done' | 'cancelled';
 
 export type TaskPriority = 'low' | 'normal' | 'high' | 'urgent';
 
@@ -174,6 +174,7 @@ export interface WorkspaceStats {
     review: number;
     verification: number;
     done: number;
+    cancelled: number;
     total: number;
   };
   agentCount: number;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -854,7 +854,9 @@ export type SSEEventType =
   | 'skills_extracted'
   | 'debug_event_logged'
   | 'debug_collection_toggled'
-  | 'debug_events_cleared';
+  | 'debug_events_cleared'
+  | 'agents_cleared'
+  | 'tasks_cleared';
 
 export interface SSEEvent {
   type: SSEEventType;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -38,6 +38,7 @@ export interface Agent {
   source: AgentSource;
   gateway_agent_id?: string;
   session_key_prefix?: string;
+  is_active?: number;
   total_cost_usd?: number;
   total_tokens_used?: number;
   created_at: string;
@@ -329,6 +330,7 @@ export interface CreateAgentRequest {
 
 export interface UpdateAgentRequest extends Partial<CreateAgentRequest> {
   status?: AgentStatus;
+  is_active?: boolean;
 }
 
 export interface CreateTaskRequest {
@@ -856,7 +858,10 @@ export type SSEEventType =
   | 'debug_collection_toggled'
   | 'debug_events_cleared'
   | 'agents_cleared'
-  | 'tasks_cleared';
+  | 'tasks_cleared'
+  | 'rollcall_started'
+  | 'rollcall_delivered'
+  | 'rollcall_entry_updated';
 
 export interface SSEEvent {
   type: SSEEventType;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -851,7 +851,10 @@ export type SSEEventType =
   | 'ab_test_cancelled'
   | 'skill_created'
   | 'skill_promoted'
-  | 'skills_extracted';
+  | 'skills_extracted'
+  | 'debug_event_logged'
+  | 'debug_collection_toggled'
+  | 'debug_events_cleared';
 
 export interface SSEEvent {
   type: SSEEventType;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -15,6 +15,8 @@ export type EventType =
   | 'task_assigned'
   | 'task_status_changed'
   | 'task_completed'
+  | 'task_archived'
+  | 'task_unarchived'
   | 'message_sent'
   | 'agent_status_changed'
   | 'agent_joined'
@@ -92,6 +94,8 @@ export interface Task {
   workspace_base_commit?: string;
   merge_status?: 'pending' | 'merged' | 'conflict' | 'pr_created' | 'abandoned';
   merge_pr_url?: string;
+  is_archived?: number;
+  archived_at?: string;
   created_at: string;
   updated_at: string;
   // Joined fields
@@ -253,6 +257,8 @@ export interface TaskActivity {
 
 export type DeliverableType = 'file' | 'url' | 'artifact';
 
+export type DeliverableStorageScheme = 'mc' | 'host' | 'ssh';
+
 export interface TaskDeliverable {
   id: string;
   task_id: string;
@@ -260,6 +266,8 @@ export interface TaskDeliverable {
   title: string;
   path?: string;
   description?: string;
+  storage_scheme?: DeliverableStorageScheme;
+  size_bytes?: number;
   created_at: string;
 }
 
@@ -822,6 +830,8 @@ export type SSEEventType =
   | 'task_updated'
   | 'task_created'
   | 'task_deleted'
+  | 'task_archived'
+  | 'task_unarchived'
   | 'activity_logged'
   | 'deliverable_added'
   | 'agent_spawned'

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -18,7 +18,8 @@ const TaskStatus = z.enum([
   'testing',
   'review',
   'verification',
-  'done'
+  'done',
+  'cancelled'
 ]);
 
 const TaskPriority = z.enum(['low', 'normal', 'high', 'urgent']);
@@ -60,6 +61,15 @@ export const UpdateTaskSchema = z.object({
   override_reason: z.string().max(2000).optional(),
   pr_url: z.string().url().optional().nullable(),
   pr_status: z.enum(['pending', 'open', 'merged', 'closed']).optional(),
+});
+
+// Admin release-stall schema — escape hatch for deadlocked tasks that
+// cannot clear the evidence gate. Deliberately restricted to the two
+// terminal statuses so operators can't use it to bypass normal workflow.
+export const ReleaseStallSchema = z.object({
+  reason: z.string().min(1, 'reason is required').max(500),
+  terminal_state: z.enum(['cancelled', 'done']).optional(),
+  released_by: z.string().max(200).optional(),
 });
 
 // Activity validation schema

--- a/src/lib/workflow-engine.ts
+++ b/src/lib/workflow-engine.ts
@@ -262,7 +262,14 @@ export async function handleStageTransition(
 
     if (!dispatchRes.ok) {
       const errorText = await dispatchRes.text();
-      const error = `Auto-dispatch to ${roleAgent.name} failed (${dispatchRes.status}): ${errorText}`;
+      // Try to pull a clean message out of the JSON body; many routes return
+      // { error: "..." }. Fall back to the raw text if it isn't JSON.
+      let parsedMessage = errorText;
+      try {
+        const parsed = JSON.parse(errorText);
+        if (parsed?.error) parsedMessage = parsed.error;
+      } catch { /* not JSON — use raw */ }
+      const error = `Dispatch to ${roleAgent.name} failed (HTTP ${dispatchRes.status}): ${parsedMessage}`;
       console.error(`[Workflow] ${error}`);
       run('UPDATE tasks SET planning_dispatch_error = ?, updated_at = ? WHERE id = ?', [error, now, taskId]);
       return { success: false, handedOff: true, newAgentId: roleAgent.id, newAgentName: roleAgent.name, error };
@@ -271,8 +278,17 @@ export async function handleStageTransition(
     console.log(`[Workflow] Dispatched task ${taskId} to ${roleAgent.name} (role: ${targetStage.role})`);
     return { success: true, handedOff: true, newAgentId: roleAgent.id, newAgentName: roleAgent.name };
   } catch (err) {
-    const error = `Dispatch error: ${(err as Error).message}`;
-    console.error(`[Workflow] ${error}`);
+    // Node's global fetch throws `TypeError: fetch failed` and stashes the
+    // real reason on `err.cause` (ECONNREFUSED, DNS, TLS, timeout, etc).
+    // Without this the operator sees "Dispatch error: fetch failed" and has
+    // no idea whether the gateway is down, the MC URL is wrong, or the
+    // internal route is broken. Surface the cause so the card's Blocked
+    // badge can actually diagnose the problem.
+    const e = err as Error & { cause?: { code?: string; message?: string } };
+    const causeMsg = e.cause?.message || e.cause?.code;
+    const reason = causeMsg ? `${e.message} (${causeMsg})` : e.message;
+    const error = `Dispatch error: ${reason}`;
+    console.error(`[Workflow] ${error}`, e.cause || '');
     run('UPDATE tasks SET planning_dispatch_error = ?, updated_at = ? WHERE id = ?', [error, now, taskId]);
     return { success: false, handedOff: true, newAgentId: roleAgent.id, newAgentName: roleAgent.name, error };
   }

--- a/src/lib/workflow-engine.ts
+++ b/src/lib/workflow-engine.ts
@@ -9,6 +9,7 @@ import { queryOne, queryAll, run } from '@/lib/db';
 import { pickDynamicAgent, escalateFailureIfNeeded, recordLearnerOnTransition } from '@/lib/task-governance';
 import { getMissionControlUrl } from '@/lib/config';
 import { broadcast } from '@/lib/events';
+import { saveCheckpointThrottled } from '@/lib/checkpoint';
 import type { Task, WorkflowTemplate, WorkflowStage, TaskRole } from '@/lib/types';
 
 interface StageTransitionResult {
@@ -203,6 +204,39 @@ export async function handleStageTransition(
       now
     ]
   );
+
+  // Auto-checkpoint on every stage transition. Counts + status are cheap
+  // to compute and give checkpoint/restore a reliable recovery point even
+  // if the agent never saves one itself. Throttled to 60s so a rapid
+  // handoff chain doesn't bloat work_checkpoints.
+  try {
+    const counts = queryOne<{ act: number; del: number }>(
+      `SELECT
+         (SELECT COUNT(*) FROM task_activities WHERE task_id = ?) as act,
+         (SELECT COUNT(*) FROM task_deliverables WHERE task_id = ?) as del`,
+      [taskId, taskId]
+    );
+    saveCheckpointThrottled(
+      {
+        taskId,
+        agentId: roleAgent.id,
+        checkpointType: 'auto',
+        stateSummary: `Stage handoff to "${targetStage.label}" (role=${targetStage.role})`,
+        contextData: {
+          previous_status: options?.previousStatus,
+          new_status: newStatus,
+          stage_label: targetStage.label,
+          activity_count: counts?.act ?? 0,
+          deliverable_count: counts?.del ?? 0,
+          fail_reason: options?.failReason,
+        },
+      },
+      60
+    );
+  } catch (err) {
+    // Non-fatal: checkpoint failures shouldn't block a stage transition.
+    console.warn('[Workflow] saveCheckpoint on transition failed:', err);
+  }
 
   recordLearnerOnTransition(taskId, options?.previousStatus || newStatus, newStatus, true).catch(err =>
     console.error('[Learner] transition record failed:', err)


### PR DESCRIPTION
## Summary
- Deliverables written to `MC_DELIVERABLES_HOST_PATH/<task_id>/` are now web-downloadable: per-file and per-task zip. Host/container split keeps it working when MC runs in Docker; `ssh://` prefix is reserved for future remote hosts.
- New **Ready Deliverables** right-rail panel lists every task that has produced output (persistent state view, not event stream). Each row has inline zip download.
- **Task archiving** via an orthogonal `is_archived` flag — any task can be archived with deliverables preserved. Board hides archived by default, toggle on the header to show. Archive/Unarchive button in TaskModal.
- **Mission Queue** empty columns collapse to a narrow vertical rail (still a drop target); each column has manual collapse/expand.
- **Right rail** has three independent collapses: whole panel, Live Feed section, Deliverables section.

## Why
Agents and MC may run on different hosts (or MC in a container), so reveal-in-Finder and host-path deliverables stop being reachable from the operator. Web download is the one reliable access pattern. Archive keeps tasks with deliverables accessible without cluttering the board.

## Schema (migration 033)
- `tasks`: `is_archived INTEGER DEFAULT 0`, `archived_at TEXT`
- `task_deliverables`: `storage_scheme TEXT DEFAULT 'host'` (values: `mc` | `host` | `ssh`), `size_bytes INTEGER`
- Existing deliverables default to `'host'` — they remain reveal-only (shown with a "host-only" pill) so nothing pre-existing breaks.

## Env vars
- `MC_DELIVERABLES_HOST_PATH` — path agents see (injected into dispatch prompts)
- `MC_DELIVERABLES_CONTAINER_PATH` — path MC reads via
- Both default to existing `getProjectsPath()` when unset, so local dev is unchanged.

## Test plan
- [ ] Start app against an existing DB, confirm migration 033 runs, backup is created, existing deliverables get `storage_scheme='host'`
- [ ] Dispatch a builder task, confirm the prompt shows `DELIVERABLES DIR: <host>/<task_id>/`
- [ ] Have an agent drop a file in that dir and POST to `/api/tasks/:id/deliverables` — row gets `storage_scheme='mc'` and `size_bytes`
- [ ] Click per-item Download in the Deliverables tab — file downloads with correct MIME + filename
- [ ] Click "Download all" on the tab — zip arrives with one entry per MC-managed file
- [ ] Legacy pre-migration row shows "host-only" pill, Reveal still works, no Download button
- [ ] Ready Deliverables panel populates; SSE `deliverable_added` / `task_archived` updates it without reload
- [ ] Archive a done task — disappears from board, reappears with "Show archived" toggle, still listed in Ready Deliverables. Unarchive restores.
- [ ] `ssh://` path submission is rejected with 501
- [ ] Empty board columns render as vertical rails; dragging a card onto a rail still drops into that status
- [ ] Right-rail: whole-panel minimize, Live Feed collapse, and Deliverables collapse all work independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)