### PR TITLE
[codex] Fail fast for missing OpenClaw routes

### DIFF
--- a/src/app/api/agents/import/route.ts
+++ b/src/app/api/agents/import/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { v4 as uuidv4 } from 'uuid';
 import { queryOne, queryAll, run, transaction } from '@/lib/db';
+import { routePrefixForGatewayAgent } from '@/lib/agent-routing';
 import type { Agent } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -96,8 +97,8 @@ export async function POST(request: NextRequest) {
         ].join('\n');
 
         run(
-          `INSERT INTO agents (id, name, role, description, avatar_emoji, is_master, workspace_id, soul_md, user_md, agents_md, model, source, gateway_agent_id, created_at, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          `INSERT INTO agents (id, name, role, description, avatar_emoji, is_master, workspace_id, soul_md, user_md, agents_md, model, source, gateway_agent_id, session_key_prefix, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
           [
             id,
             agentReq.name,
@@ -112,6 +113,7 @@ export async function POST(request: NextRequest) {
             agentReq.model || null,
             'gateway',
             agentReq.gateway_agent_id,
+            routePrefixForGatewayAgent(agentReq.gateway_agent_id),
             now,
             now,
           ]

--- a/src/app/api/tasks/[id]/convoy/route.ts
+++ b/src/app/api/tasks/[id]/convoy/route.ts
@@ -3,6 +3,7 @@ import { createConvoy, getConvoy, updateConvoyStatus, deleteConvoy } from '@/lib
 import { queryOne, queryAll } from '@/lib/db';
 import { getOpenClawClient } from '@/lib/openclaw/client';
 import { extractJSON, getMessagesFromOpenClaw } from '@/lib/planning-utils';
+import { resolveAgentSessionKeyPrefix } from '@/lib/agent-routing';
 import type { Task, Agent, ConvoyStatus, DecompositionStrategy } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -82,7 +83,7 @@ async function runAIDecomposition(task: Task): Promise<{
   }
 
   // Create a unique session key for this decomposition
-  const prefix = masterAgent.session_key_prefix || 'agent:main:';
+  const prefix = resolveAgentSessionKeyPrefix(masterAgent);
   const sessionKey = `${prefix}decompose:${task.id}`;
 
   const prompt = buildDecompositionPrompt(task);

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -12,6 +12,7 @@ import { buildCheckpointContext } from '@/lib/checkpoint';
 import { formatMailForDispatch } from '@/lib/mailbox';
 import { getPendingNotesForDispatch } from '@/lib/task-notes';
 import { createTaskWorkspace, determineIsolationStrategy } from '@/lib/workspace-isolation';
+import { resolveAgentSessionKeyPrefix } from '@/lib/agent-routing';
 import type { Task, Agent, Product, OpenClawSession, WorkflowStage, TaskImage } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -94,6 +95,14 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
     if (!agent) {
       return dispatchErrorResponse(id, 'Assigned agent not found', 404);
+    }
+
+    let sessionKeyPrefix: string;
+    try {
+      sessionKeyPrefix = resolveAgentSessionKeyPrefix(agent);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Assigned agent has no valid OpenClaw route';
+      return dispatchErrorResponse(id, message, 409);
     }
 
     // Check if dispatching to the master agent while there are other orchestrators available
@@ -460,10 +469,7 @@ If you need help or clarification, ask the orchestrator.`;
 
     // Send message to agent's session using chat.send
     try {
-      // Use sessionKey for routing to the agent's session
-      // Format: {prefix}{openclaw_session_id} where prefix defaults to 'agent:main:'
-      const prefix = agent.session_key_prefix || 'agent:main:';
-      const sessionKey = `${prefix}${session.openclaw_session_id}`;
+      const sessionKey = `${sessionKeyPrefix}${session.openclaw_session_id}`;
       await client.call('chat.send', {
         sessionKey,
         message: finalMessage,

--- a/src/app/api/tasks/[id]/planning/force-complete/route.ts
+++ b/src/app/api/tasks/[id]/planning/force-complete/route.ts
@@ -3,8 +3,9 @@ import { queryOne, run } from '@/lib/db';
 import { extractJSON } from '@/lib/planning-utils';
 import { broadcast } from '@/lib/events';
 import { getMissionControlUrl } from '@/lib/config';
+import { resolveAgentSessionKeyPrefix } from '@/lib/agent-routing';
 import { v4 as uuidv4 } from 'uuid';
-import type { Task } from '@/lib/types';
+import type { Agent, Task } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
 
@@ -82,11 +83,14 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     let firstAgentId: string | null = null;
 
     if (allowDynamicAgents && completionParsed.agents?.length > 0) {
-      const masterAgent = queryOne<{ session_key_prefix?: string }>(
-        `SELECT session_key_prefix FROM agents WHERE is_master = 1 AND workspace_id = ? ORDER BY created_at ASC LIMIT 1`,
+      const masterAgent = queryOne<Agent>(
+        `SELECT * FROM agents WHERE is_master = 1 AND workspace_id = ? ORDER BY created_at ASC LIMIT 1`,
         [task.workspace_id]
       );
-      const sessionKeyPrefix = masterAgent?.session_key_prefix || 'agent:main:';
+      if (!masterAgent) {
+        throw new Error('No orchestrator route is configured for generated planning agents');
+      }
+      const sessionKeyPrefix = resolveAgentSessionKeyPrefix(masterAgent);
 
       for (const agent of completionParsed.agents) {
         const agentId = crypto.randomUUID();

--- a/src/app/api/tasks/[id]/planning/poll/route.ts
+++ b/src/app/api/tasks/[id]/planning/poll/route.ts
@@ -4,7 +4,8 @@ import { getOpenClawClient } from '@/lib/openclaw/client';
 import { broadcast } from '@/lib/events';
 import { getMissionControlUrl } from '@/lib/config';
 import { extractJSON, getMessagesFromOpenClaw } from '@/lib/planning-utils';
-import { Task } from '@/lib/types';
+import { resolveAgentSessionKeyPrefix } from '@/lib/agent-routing';
+import type { Agent, Task } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
 // Planning timeout and poll interval configuration with validation
@@ -35,10 +36,13 @@ async function handlePlanningCompletion(taskId: string, parsed: any, messages: a
       // Get the master agent's session_key_prefix to use for new agents
       const task = db.prepare('SELECT workspace_id FROM tasks WHERE id = ?').get(taskId) as { workspace_id: string } | undefined;
       const masterAgent = task ? db.prepare(
-        `SELECT session_key_prefix FROM agents WHERE is_master = 1 AND workspace_id = ? ORDER BY created_at ASC LIMIT 1`
-      ).get(task.workspace_id) as { session_key_prefix?: string } | undefined : undefined;
-      
-      const sessionKeyPrefix = masterAgent?.session_key_prefix || 'agent:main:';
+        `SELECT * FROM agents WHERE is_master = 1 AND workspace_id = ? ORDER BY created_at ASC LIMIT 1`
+      ).get(task.workspace_id) as Agent | undefined : undefined;
+
+      if (!masterAgent) {
+        throw new Error('No orchestrator route is configured for generated planning agents');
+      }
+      const sessionKeyPrefix = resolveAgentSessionKeyPrefix(masterAgent);
 
       const insertAgent = db.prepare(`
         INSERT INTO agents (id, workspace_id, name, role, description, avatar_emoji, status, soul_md, session_key_prefix, created_at, updated_at)

--- a/src/app/api/tasks/[id]/planning/route.ts
+++ b/src/app/api/tasks/[id]/planning/route.ts
@@ -3,13 +3,11 @@ import { getDb, queryAll, queryOne, run } from '@/lib/db';
 import { getOpenClawClient } from '@/lib/openclaw/client';
 import { broadcast } from '@/lib/events';
 import { extractJSON } from '@/lib/planning-utils';
+import { normalizeSessionKeyPrefix, resolveAgentSessionKeyPrefix } from '@/lib/agent-routing';
+import type { Agent } from '@/lib/types';
 // File system imports removed - using OpenClaw API instead
 
 export const dynamic = 'force-dynamic';
-
-// Default planning session prefix for OpenClaw
-// Can be overridden per-agent via the session_key_prefix column on agents table
-const DEFAULT_SESSION_KEY_PREFIX = 'agent:main:';
 
 // GET /api/tasks/[id]/planning - Get planning state
 export async function GET(
@@ -100,18 +98,18 @@ export async function POST(
 
     // Check if there are other orchestrators available before starting planning with the default master agent
     // Get the default master agent for this workspace
-    const defaultMaster = queryOne<{ id: string; session_key_prefix?: string }>(
-      `SELECT id, session_key_prefix FROM agents WHERE is_master = 1 AND workspace_id = ? ORDER BY created_at ASC LIMIT 1`,
+    const defaultMaster = queryOne<Agent>(
+      `SELECT * FROM agents WHERE is_master = 1 AND workspace_id = ? ORDER BY created_at ASC LIMIT 1`,
       [task.workspace_id]
     );
 
     // Get assigned agent if any (for session_key_prefix)
     const taskWithAgent = getDb().prepare(`
-      SELECT a.session_key_prefix 
+      SELECT a.*
       FROM tasks t 
       LEFT JOIN agents a ON t.assigned_agent_id = a.id 
       WHERE t.id = ?
-    `).get(taskId) as { session_key_prefix?: string } | undefined;
+    `).get(taskId) as Agent | undefined;
 
     const otherOrchestrators = queryAll<{
       id: string;
@@ -135,9 +133,30 @@ export async function POST(
       }, { status: 409 }); // 409 Conflict
     }
 
-    // Create session key for this planning task
-    // Priority: custom prefix > assigned agent's prefix > master agent's prefix > default prefix
-    const basePrefix = customSessionKeyPrefix || taskWithAgent?.session_key_prefix || defaultMaster?.session_key_prefix || DEFAULT_SESSION_KEY_PREFIX;
+    let basePrefix: string;
+    try {
+      if (customSessionKeyPrefix) {
+        const normalized = normalizeSessionKeyPrefix(customSessionKeyPrefix);
+        if (!normalized || normalized === 'agent:main:') {
+          throw new Error('Planning session_key_prefix must point to a live OpenClaw agent and cannot be agent:main:');
+        }
+        basePrefix = normalized;
+      } else if (taskWithAgent?.id) {
+        basePrefix = resolveAgentSessionKeyPrefix(taskWithAgent);
+      } else if (defaultMaster) {
+        basePrefix = resolveAgentSessionKeyPrefix(defaultMaster);
+      } else {
+        throw new Error('No orchestrator route is configured for planning');
+      }
+    } catch (err) {
+      return NextResponse.json(
+        { error: err instanceof Error ? err.message : 'No valid OpenClaw route is configured for planning' },
+        { status: 409 }
+      );
+    }
+
+    // Create session key for this planning task.
+    // Priority: custom prefix > assigned agent route > master agent route.
     const planningPrefix = basePrefix + 'planning:';
     const sessionKey = `${planningPrefix}${taskId}`;
 

--- a/src/components/AgentModal.tsx
+++ b/src/components/AgentModal.tsx
@@ -305,10 +305,10 @@ export function AgentModal({ agent, onClose, workspaceId, onAgentCreated }: Agen
                   value={form.session_key_prefix}
                   onChange={(e) => setForm({ ...form, session_key_prefix: e.target.value })}
                   className="w-full min-h-11 bg-mc-bg border border-mc-border rounded px-3 py-2 text-sm focus:outline-none focus:border-mc-accent"
-                  placeholder="agent:main:"
+                  placeholder="agent:my-openclaw-agent:"
                 />
                 <p className="text-xs text-mc-text-secondary mt-1">
-                  OpenClaw session routing prefix. Defaults to &quot;agent:main:&quot; if not set.
+                  OpenClaw session routing prefix. Required for local agents that dispatch to OpenClaw.
                 </p>
               </div>
             </div>

--- a/src/lib/agent-catalog-sync.ts
+++ b/src/lib/agent-catalog-sync.ts
@@ -1,5 +1,6 @@
 import { queryAll, queryOne, run, transaction } from '@/lib/db';
 import { getOpenClawClient } from '@/lib/openclaw/client';
+import { routePrefixForGatewayAgent } from '@/lib/agent-routing';
 
 interface GatewayAgent {
   id?: string;
@@ -68,14 +69,21 @@ export async function syncGatewayAgentsToCatalog(options?: { force?: boolean; re
 
         if (existingId) {
           run(
-            `UPDATE agents SET name = ?, role = CASE WHEN role IS NULL OR role = 'builder' THEN ? ELSE role END, model = COALESCE(?, model), source = 'gateway', updated_at = ? WHERE id = ?`,
-            [name, role, normaliseModel(ga.model), ts, existingId]
+            `UPDATE agents
+             SET name = ?,
+                 role = CASE WHEN role IS NULL OR role = 'builder' THEN ? ELSE role END,
+                 model = COALESCE(?, model),
+                 source = 'gateway',
+                 session_key_prefix = COALESCE(session_key_prefix, ?),
+                 updated_at = ?
+             WHERE id = ?`,
+            [name, role, normaliseModel(ga.model), routePrefixForGatewayAgent(gatewayId), ts, existingId]
           );
         } else {
           run(
-            `INSERT INTO agents (id, name, role, description, avatar_emoji, is_master, workspace_id, model, source, gateway_agent_id, created_at, updated_at)
-             VALUES (lower(hex(randomblob(16))), ?, ?, ?, '🔗', 0, 'default', ?, 'gateway', ?, ?, ?)`,
-            [name, role, `Auto-synced from OpenClaw (${gatewayId})`, normaliseModel(ga.model), gatewayId, ts, ts]
+            `INSERT INTO agents (id, name, role, description, avatar_emoji, is_master, workspace_id, model, source, gateway_agent_id, session_key_prefix, created_at, updated_at)
+             VALUES (lower(hex(randomblob(16))), ?, ?, ?, '🔗', 0, 'default', ?, 'gateway', ?, ?, ?, ?)`,
+            [name, role, `Auto-synced from OpenClaw (${gatewayId})`, normaliseModel(ga.model), gatewayId, routePrefixForGatewayAgent(gatewayId), ts, ts]
           );
         }
         changed += 1;

--- a/src/lib/agent-routing.test.ts
+++ b/src/lib/agent-routing.test.ts
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resolveAgentSessionKeyPrefix, routePrefixForGatewayAgent } from './agent-routing';
+import type { Agent } from './types';
+
+function agent(overrides: Partial<Agent>): Agent {
+  return {
+    id: 'agent-1',
+    name: 'Test Agent',
+    role: 'tester',
+    avatar_emoji: 'x',
+    status: 'standby',
+    is_master: false,
+    workspace_id: 'default',
+    source: 'local',
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+test('resolveAgentSessionKeyPrefix derives prefix from gateway_agent_id', () => {
+  assert.equal(
+    resolveAgentSessionKeyPrefix(agent({ gateway_agent_id: 'linkedin-poster' })),
+    routePrefixForGatewayAgent('linkedin-poster')
+  );
+});
+
+test('resolveAgentSessionKeyPrefix rejects removed agent:main route', () => {
+  assert.throws(
+    () => resolveAgentSessionKeyPrefix(agent({ session_key_prefix: 'agent:main:' })),
+    /removed OpenClaw route/
+  );
+});
+
+test('resolveAgentSessionKeyPrefix fails fast when no route is configured', () => {
+  assert.throws(
+    () => resolveAgentSessionKeyPrefix(agent({ session_key_prefix: undefined, gateway_agent_id: undefined })),
+    /has no OpenClaw route/
+  );
+});

--- a/src/lib/agent-routing.ts
+++ b/src/lib/agent-routing.ts
@@ -1,0 +1,32 @@
+import type { Agent } from '@/lib/types';
+
+const LEGACY_MAIN_PREFIX = 'agent:main:';
+
+export function normalizeSessionKeyPrefix(prefix: string | null | undefined): string | null {
+  const trimmed = prefix?.trim();
+  if (!trimmed) return null;
+  return trimmed.endsWith(':') ? trimmed : `${trimmed}:`;
+}
+
+export function routePrefixForGatewayAgent(gatewayAgentId: string): string {
+  return `agent:${gatewayAgentId}:`;
+}
+
+export function resolveAgentSessionKeyPrefix(
+  agent: Pick<Agent, 'name' | 'gateway_agent_id' | 'session_key_prefix'>,
+): string {
+  const explicitPrefix = normalizeSessionKeyPrefix(agent.session_key_prefix);
+  if (explicitPrefix === LEGACY_MAIN_PREFIX) {
+    throw new Error(
+      `Agent "${agent.name}" is configured with removed OpenClaw route ${LEGACY_MAIN_PREFIX}. ` +
+      'Configure a live gateway agent route before dispatch.'
+    );
+  }
+
+  if (explicitPrefix) return explicitPrefix;
+  if (agent.gateway_agent_id) return routePrefixForGatewayAgent(agent.gateway_agent_id);
+
+  throw new Error(
+    `Agent "${agent.name}" has no OpenClaw route. Configure gateway_agent_id or session_key_prefix before dispatch.`
+  );
+}

--- a/src/lib/learner.ts
+++ b/src/lib/learner.ts
@@ -8,7 +8,8 @@
 import { queryOne, queryAll, run } from '@/lib/db';
 import { getMissionControlUrl } from '@/lib/config';
 import { getOpenClawClient } from '@/lib/openclaw/client';
-import type { KnowledgeEntry, TaskRole, OpenClawSession } from '@/lib/types';
+import { resolveAgentSessionKeyPrefix } from '@/lib/agent-routing';
+import type { Agent, KnowledgeEntry, TaskRole, OpenClawSession } from '@/lib/types';
 
 /**
  * Notify the Learner agent about a stage transition.
@@ -25,8 +26,8 @@ export async function notifyLearner(
   }
 ): Promise<void> {
   // Find learner role assignment for this task
-  const learnerRole = queryOne<TaskRole & { agent_name: string; session_key_prefix?: string }>(
-    `SELECT tr.*, a.name as agent_name, a.session_key_prefix
+  const learnerRole = queryOne<TaskRole & { agent_name: string } & Agent>(
+    `SELECT tr.*, a.*, a.name as agent_name
      FROM task_roles tr
      JOIN agents a ON tr.agent_id = a.id
      WHERE tr.task_id = ? AND tr.role = 'learner'`,
@@ -98,7 +99,7 @@ Focus on:
     }
 
     if (session) {
-      const prefix = learnerRole.session_key_prefix || 'agent:main:';
+      const prefix = resolveAgentSessionKeyPrefix(learnerRole);
       const sessionKey = `${prefix}${session.openclaw_session_id}`;
       await client.call('chat.send', {
         sessionKey,

--- a/src/lib/orchestration.ts
+++ b/src/lib/orchestration.ts
@@ -240,7 +240,7 @@ export async function onSubAgentCompleted(params: {
  * // When spawning a sub-agent:
  * await orchestrator.onSubAgentSpawned({
  *   taskId: 'task-123',
- *   sessionId: 'agent:main:subagent:abc123',
+ *   sessionId: 'agent:my-openclaw-agent:subagent:abc123',
  *   agentName: 'mission-control-integration-fixes',
  *   description: 'Fix Mission Control real-time updates',
  * });
@@ -255,7 +255,7 @@ export async function onSubAgentCompleted(params: {
  * // When complete:
  * await orchestrator.onSubAgentCompleted({
  *   taskId: 'task-123',
- *   sessionId: 'agent:main:subagent:abc123',
+ *   sessionId: 'agent:my-openclaw-agent:subagent:abc123',
  *   agentName: 'mission-control-integration-fixes',
  *   summary: 'All integration issues fixed and tested',
  *   deliverables: [

--- a/src/lib/task-notes.ts
+++ b/src/lib/task-notes.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { queryOne, queryAll, run } from '@/lib/db';
 import { broadcast } from '@/lib/events';
 import { getOpenClawClient } from '@/lib/openclaw/client';
+import { resolveAgentSessionKeyPrefix } from '@/lib/agent-routing';
 import type { TaskNote, OpenClawSession, Agent } from '@/lib/types';
 
 /**
@@ -98,7 +99,10 @@ export async function deliverPendingNotesAtCheckpoint(taskId: string): Promise<n
 
     // Get the agent's session key prefix
     const agent = queryOne<Agent>('SELECT * FROM agents WHERE id = ?', [activeSession.agent_id]);
-    const prefix = agent?.session_key_prefix || 'agent:main:';
+    if (!agent) {
+      throw new Error(`Agent not found for active session ${activeSession.id}`);
+    }
+    const prefix = resolveAgentSessionKeyPrefix(agent);
     const sessionKey = `${prefix}${activeSession.openclaw_session_id}`;
 
     // Build the message
@@ -161,7 +165,8 @@ export function getActiveSessionForTask(taskId: string): { session: OpenClawSess
   if (!session) return null;
 
   const agent = queryOne<Agent>('SELECT * FROM agents WHERE id = ?', [session.agent_id]);
-  const prefix = agent?.session_key_prefix || 'agent:main:';
+  if (!agent) return null;
+  const prefix = resolveAgentSessionKeyPrefix(agent);
   const sessionKey = `${prefix}${session.openclaw_session_id}`;
 
   return { session, sessionKey };


### PR DESCRIPTION
## Summary

This removes Mission Control's implicit fallback to the legacy `agent:main:` OpenClaw route when dispatching executable work.

- Add a shared route resolver that requires an explicit `session_key_prefix` or derives one from `gateway_agent_id`.
- Reject stale `agent:main:` routes with a clear configuration error before dispatch.
- Store `session_key_prefix` when importing or syncing OpenClaw gateway agents.
- Update dispatch, planning, convoy, learner, and task-note delivery paths to use the shared resolver.
- Update UI copy so local agents are not documented as defaulting to `agent:main:`.

## Why

Mission Control can still have local workflow agents such as Tester, Reviewer, or Learner with no gateway route configured. Those records are Mission Control database agents, not necessarily live OpenClaw gateway agents.

When one of those agents is selected, current upstream code falls back to `agent:main:`. If OpenClaw's live gateway configuration no longer exposes a `main` agent, the task can transition into a handoff state and then fail delivery with:

`Agent "main" no longer exists in configuration`

This is confusing because Mission Control may still show a stale imported `main` catalog row even when OpenClaw discovery does not list a live `main` execution target.

## Impact

Missing or stale executable routes now fail fast with a 409 configuration error instead of creating a task loop around a removed OpenClaw namespace. Imported gateway agents get a durable route prefix based on their gateway id.

## Validation

- `git diff --check`
- `npx tsx --test src/lib/agent-routing.test.ts src/lib/agent-catalog-sync.test.ts`
- `npx tsc --noEmit`
