### PR TITLE
fix(openclaw): support gateway protocol v4 (#137)

### DIFF
--- a/src/lib/openclaw/client.ts
+++ b/src/lib/openclaw/client.ts
@@ -329,7 +329,7 @@ export class OpenClawClient extends EventEmitter {
                 method: 'connect',
                 params: {
                   minProtocol: 3,
-                  maxProtocol: 3,
+                  maxProtocol: 4,
                   client: {
                     id: clientId,
                     version: '1.0.1',


### PR DESCRIPTION
## Summary

OpenClaw v2026.5.9-beta.1 bumped its WebSocket gateway protocol from v3 to v4 (CHANGELOG: *"move Canvas/A2UI clients to gateway protocol v4 plugin surfaces"*). Mission Control's connect handshake hardcoded `minProtocol: 3, maxProtocol: 3` in `src/lib/openclaw/client.ts`, so v4 gateways close every connection with code `1002 / "protocol mismatch"` before processing the connect request — confirmed in #137 by @rriggs.

This PR widens the advertised range to `[3, 4]` so MC connects against both stable v3 gateways and the v4 beta. The gateway's check is `if (maxProtocol < N || minProtocol > N)` — any client whose range contains the gateway's N is accepted, so this works for either version without forcing v3 users to upgrade.

Fixes #137.

## What I verified before opening this PR

- All 10 RPC method names MC sends (`sessions.list`, `sessions.history`, `sessions.send`, `sessions.create`, `agents.list`, `node.list`, `node.describe`, `models.list`, `config.get`, plus the `connect` handshake) exist verbatim in both `openclaw@2026.4.23` (v3) and `openclaw@2026.5.9-beta.1` (v4) bundles. No renames.
- Spot-checked the v3 vs v4 handler implementations for `agents.list` and `sessions.list` — wire contracts identical. v4 changes are server-internal (`loadConfig()` → `context.getRuntimeConfig()`, sync → async) plus **added** optional params (`agentId`, `configuredAgentsOnly`). Adding optional params is backward-compatible.
- `req`/`res` envelope (`type`, `id`, `method`, `params`, `payload`, `error`) is unchanged.
- `tsc --noEmit` passes.

## Test plan

- [ ] @rriggs to pull this branch and run Mission Control against the OpenClaw build that surfaced this (`v2026.5.9-beta.1` or later) and confirm the connection succeeds and basic operations (list sessions/agents, dispatch a task, etc.) work.
- [ ] Smoke-test against a stable `v3` gateway (e.g., `openclaw@2026.5.7`) to confirm no regression for users who haven't upgraded.

## Notes for the reporter

@rriggs — thanks for the detailed bug report; the gateway log line `expectedProtocol: 4` made the root cause unambiguous. Could you check out `fix/openclaw-protocol-v4` and try connecting Mission Control to your OpenClaw v2026.5.9-beta.1 gateway? If the connection succeeds and basic functionality works, I'll mark this ready and merge to `main`. If anything still misbehaves, gateway logs from the failing operation would help — there could be something in v4 we haven't caught.

This is a draft PR until you've had a chance to verify.