### PR TITLE
Environment recovery actions + task-deletion FK fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # testing
 /coverage
+.playwright-mcp/
 
 # next.js
 /.next/

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # testing
 /coverage
 .playwright-mcp/
+.codex-runs/
 
 # next.js
 /.next/

--- a/specs/agent-skill-creation-loop-spec.md
+++ b/specs/agent-skill-creation-loop-spec.md
@@ -1,0 +1,175 @@
+# Agent Skill Creation Loop — Spec
+
+## Problem
+
+Autensa agents start every dispatch with zero task-specific memory beyond what the knowledge base provides. If a builder agent figures out that LeadsFire needs `--legacy-peer-deps` for npm ci, or that the GFH deploy script must run as www-data, that knowledge either gets captured as a generic text blob in `knowledge_entries` (143 entries, mostly low-signal pattern/baseline noise) or it's lost entirely when the session dies.
+
+The existing learner module captures *what happened* (stage transitions, pass/fail) but not *how to do things* — reusable, executable procedures that agents can follow.
+
+## What We're Building
+
+A closed-loop skill system where agents autonomously create, improve, and consume structured skills scoped to each product. Not generic knowledge entries — **executable playbooks** that compound over time.
+
+### How It's Different from Current Knowledge Base
+
+| Current `knowledge_entries` | New `product_skills` |
+|---|---|
+| Text blobs about what happened | Structured steps with prerequisites, commands, verification |
+| Triggered on stage transitions | Triggered on task completion (success or instructive failure) |
+| Injected as "lessons learned" footnote | Matched by skill type and injected as primary instructions |
+| 143 entries, mostly noise | Curated by confidence scoring + usage tracking |
+| No feedback loop | Skills improve when agents report deviations |
+
+## Schema
+
+### New Table: `product_skills`
+
+```sql
+CREATE TABLE product_skills (
+  id TEXT PRIMARY KEY,
+  product_id TEXT NOT NULL,
+  skill_type TEXT NOT NULL,        -- 'build', 'deploy', 'test', 'fix', 'config', 'pattern'
+  title TEXT NOT NULL,
+  trigger_pattern TEXT,             -- regex/keyword that matches task descriptions
+  prerequisites TEXT,               -- JSON: things that must be true before using this skill
+  steps TEXT NOT NULL,              -- JSON array of step objects
+  verification TEXT,                -- JSON: how to confirm the skill worked
+  confidence REAL DEFAULT 0.5,      -- 0.0-1.0, increases with successful use
+  times_used INTEGER DEFAULT 0,
+  times_succeeded INTEGER DEFAULT 0,
+  last_used_at TEXT,
+  created_by_task_id TEXT,
+  created_by_agent_id TEXT,
+  supersedes_skill_id TEXT,         -- points to older version this replaced
+  status TEXT DEFAULT 'active',     -- 'active', 'deprecated', 'draft'
+  created_at TEXT DEFAULT (datetime('now')),
+  updated_at TEXT DEFAULT (datetime('now')),
+  FOREIGN KEY (product_id) REFERENCES products(id)
+);
+
+CREATE INDEX idx_product_skills_product ON product_skills(product_id, skill_type, status);
+CREATE INDEX idx_product_skills_confidence ON product_skills(confidence DESC);
+```
+
+### Step Object Shape
+
+```typescript
+interface SkillStep {
+  order: number;
+  description: string;
+  command?: string;        // shell command if applicable
+  code?: string;           // code snippet if applicable
+  file_path?: string;      // relevant file
+  expected_output?: string; // what success looks like
+  fallback?: string;       // what to do if this step fails
+  notes?: string;          // context from the agent that created it
+}
+```
+
+## The Loop (4 phases)
+
+### Phase 1: Capture (post-task)
+
+When a task completes with status `done`:
+
+1. MC sends a **skill extraction prompt** to the agent's session before it's killed
+2. Prompt: "Before this session ends, extract any reusable procedures you discovered. For each, provide: title, type, trigger pattern, prerequisite conditions, numbered steps with commands, and verification method. POST to `/api/products/{id}/skills` with the structured JSON."
+3. Agent has 60 seconds to respond before session cleanup
+4. New skills created with `confidence: 0.5` (unproven) and `status: 'draft'`
+
+When a task fails and the failure teaches something:
+
+1. Same extraction prompt but focused on "what procedure would have prevented this failure?"
+2. Skills from failures start at `confidence: 0.4` (lower, needs validation)
+
+### Phase 2: Match (pre-dispatch)
+
+During dispatch (in `dispatch/route.ts`), before building the agent message:
+
+1. Query `product_skills` for the task's product where `status = 'active'` and `confidence >= 0.6`
+2. Match skills by:
+   - `skill_type` matching the agent's role (builder → 'build'/'config'/'pattern', tester → 'test')
+   - `trigger_pattern` regex against task title + description
+   - Fallback: top 3 by confidence for the product
+3. Format matched skills as structured instructions (not footnotes — primary guidance)
+4. Inject BEFORE the planning spec in the dispatch message
+
+### Phase 3: Report (during task)
+
+Add a new API endpoint the agent calls during execution:
+
+```
+POST /api/products/{productId}/skills/{skillId}/report
+{
+  "task_id": "...",
+  "used": true,           // did the agent actually use this skill?
+  "succeeded": true,      // did following it lead to success?
+  "deviation": "...",     // if the agent had to modify the steps, what changed?
+  "suggested_update": {}  // optional: improved version of the skill
+}
+```
+
+On report:
+- `times_used++`
+- If succeeded: `times_succeeded++`, recalculate `confidence = times_succeeded / times_used`
+- If deviation reported: flag for review or auto-update if confidence is high enough
+
+### Phase 4: Improve (periodic)
+
+Cron job (nightly or weekly):
+
+1. Promote `draft` skills to `active` if `times_succeeded >= 2` and `confidence >= 0.6`
+2. Deprecate skills with `confidence < 0.3` and `times_used >= 3` (tried multiple times, keeps failing)
+3. When a `suggested_update` exists with higher confidence than the original, create new version with `supersedes_skill_id` pointing to old one, deprecate old
+4. Merge duplicate skills (same product, similar trigger_pattern, overlapping steps)
+
+## Integration Points
+
+### dispatch/route.ts (modify)
+```typescript
+// After knowledge section, before planning spec
+const skills = getMatchedSkills(task.product_id, task.title, task.description, agent.name);
+const skillsSection = formatSkillsForDispatch(skills);
+// ... inject into message
+```
+
+### New: skill-extraction.ts
+```typescript
+// Called from task-lifecycle when status → done
+export async function requestSkillExtraction(taskId: string, sessionKey: string): Promise<void>
+```
+
+### New API Routes
+- `POST /api/products/[id]/skills` — agent creates a skill
+- `GET /api/products/[id]/skills` — list skills for product
+- `PATCH /api/products/[id]/skills/[skillId]` — update skill
+- `POST /api/products/[id]/skills/[skillId]/report` — agent reports usage
+
+### UI (TaskModal or Product Dashboard)
+- Skills tab showing product's skill library
+- Confidence bars, usage counts, created-by-task links
+- Manual approve/deprecate/edit controls
+
+## What This Unlocks
+
+1. **Agent #1** builds LeadsFire, discovers npm needs `--legacy-peer-deps` → creates "LeadsFire Build" skill
+2. **Agent #2** gets dispatched for LeadsFire feature → receives the skill as primary instructions → succeeds first try → confidence bumps to 0.67
+3. **Agent #3** same product → skill at 0.75 confidence, injected automatically → agent reports it worked with one deviation (new env var needed) → skill auto-updates
+4. After 5 successful uses, the skill is at 0.9+ confidence and effectively becomes the product's build playbook
+
+## Build Order
+
+1. Migration: `product_skills` table + indexes
+2. `src/lib/skills.ts` — CRUD helpers, matching logic, formatting
+3. `src/app/api/products/[id]/skills/` routes (create, list, update, report)
+4. `src/lib/skill-extraction.ts` — post-task extraction prompt
+5. Modify `dispatch/route.ts` — inject matched skills
+6. Modify task completion flow — trigger extraction before session cleanup
+7. UI: Skills tab in product dashboard
+8. Cron: nightly skill promotion/deprecation
+
+## Estimated Scope
+
+~800-1000 lines new code. 1 migration. 4 API routes. 1 new lib module. Modifications to dispatch and task-lifecycle. UI component.
+
+No breaking changes to existing flows — skills injection is additive to the dispatch message, and extraction is best-effort (failure doesn't block task completion).

--- a/specs/devin-parity-features-spec.md
+++ b/specs/devin-parity-features-spec.md
@@ -1,0 +1,377 @@
+# Devin Parity Features — Spec
+
+**Status:** APPROVED  
+**Date:** 2026-03-25  
+**Repo:** crshdn/mission-control  
+**Build order:** 5 independent PRs, each deployable on its own
+
+---
+
+## Overview
+
+Five features that close the gap between Autensa and Devin.ai while preserving Autensa's unique product-discovery pipeline advantage. Each feature is a standalone PR with no cross-dependencies.
+
+---
+
+## Feature 1: PR Review Auto-Fix
+
+**PR branch:** `feature/pr-review-autofix`  
+**Estimated effort:** ~400 lines  
+**Priority:** Highest — immediate ROI, closes biggest workflow gap
+
+### Problem
+When a reviewer leaves comments on an Autensa-generated PR or CI fails post-push, nothing happens. The task sits in "done" and the PR rots. Devin automatically picks up review comments, fixes the code, and pushes again.
+
+### Solution
+Extend the existing GitHub webhook handler to listen for `pull_request_review`, `pull_request_review_comment`, and `issue_comment` events. When comments arrive on an Autensa-created PR:
+
+1. **Webhook receives event** → match PR URL to task via `tasks.pr_url`
+2. **Collect review context** — diff hunks, reviewer comments, CI status
+3. **Re-dispatch to original agent** with a new message:
+   ```
+   PR REVIEW FEEDBACK on "{task.title}"
+   
+   Reviewer comments:
+   {formatted comments with file paths and line numbers}
+   
+   CI Status: {pass/fail with logs if failed}
+   
+   Fix the issues raised, commit, and push to the same branch.
+   Do NOT open a new PR.
+   ```
+4. **Task status** transitions: `done` → `review_fix` → `in_progress` (new status)
+5. **Activity log** records each review-fix cycle with reviewer name and comment count
+6. **Max cycles:** configurable per-product (default 3), after which task goes to `review` for human intervention
+7. **Auto-Fix toggle:** per-product setting `auto_fix_pr_reviews` (default: true for semi_auto/full_auto tiers, false for supervised)
+
+### Schema changes
+```sql
+-- Migration: add_pr_review_autofix
+ALTER TABLE tasks ADD COLUMN review_fix_count INTEGER DEFAULT 0;
+ALTER TABLE tasks ADD COLUMN review_fix_max INTEGER DEFAULT 3;
+ALTER TABLE products ADD COLUMN auto_fix_pr_reviews INTEGER DEFAULT 1;
+-- Add 'review_fix' to tasks status CHECK constraint
+```
+
+### Files to create/modify
+- `src/app/api/webhooks/github/route.ts` — add `pull_request_review`, `issue_comment` handlers
+- `src/lib/pr-review-handler.ts` — NEW: collect comments, format context, trigger re-dispatch
+- `src/lib/types.ts` — add `review_fix` to TaskStatus union
+- `src/lib/db/migrations.ts` — new migration
+- `src/components/TaskModal.tsx` — show review-fix cycle count and reviewer comments
+- `src/components/MissionQueue.tsx` — show "Fixing PR" badge for review_fix status
+
+### Webhook events to handle
+| Event | Action | Behavior |
+|---|---|---|
+| `pull_request_review` | `submitted` (changes_requested) | Trigger auto-fix |
+| `pull_request_review` | `submitted` (approved) | Mark PR approved, skip |
+| `issue_comment` | `created` (on PR, not by bot) | Trigger auto-fix |
+| `check_suite` | `completed` (failure, on open Autensa PR) | Trigger auto-fix with CI logs |
+
+---
+
+## Feature 2: Browser QA (Visual Verification)
+
+**PR branch:** `feature/browser-qa`  
+**Estimated effort:** ~600 lines  
+**Priority:** High — agents can't currently verify UI work
+
+### Problem
+Autensa agents can run `npm test` and `tsc` but can't see what the app actually looks like. Devin spins up the app, clicks through it, takes screenshots, and verifies visually before opening a PR.
+
+### Solution
+Add a browser verification step between "build complete" and "PR created" using Browserbase (already available in our stack, API key in `.env`).
+
+1. **Post-build verification trigger** — after agent reports build success, before PR:
+   - Agent includes `%%QA_READY%%` marker with dev server URL and test scenarios
+   - MC detects marker, launches browser QA
+2. **Browser QA worker** (`src/lib/browser-qa.ts`):
+   - Creates Browserbase session
+   - Navigates to dev server URL (agent provides port from workspace isolation)
+   - Executes test scenarios (click flows, form fills, visual checks)
+   - Takes screenshots at each step
+   - Returns pass/fail with screenshot evidence
+3. **Screenshot storage** — save to `task_images` (existing table) with type `qa_screenshot`
+4. **QA report** — structured JSON attached to task activities
+5. **Failure handling** — if QA fails, send feedback to agent with screenshots showing what's broken
+6. **QA scenarios** — defined in product settings or inferred from task type:
+   - Default: navigate to /, check for console errors, take screenshot
+   - Custom: product-level `qa_scenarios` JSON field
+
+### Schema changes
+```sql
+-- Migration: add_browser_qa
+ALTER TABLE products ADD COLUMN qa_scenarios TEXT; -- JSON array of test scenarios
+ALTER TABLE products ADD COLUMN qa_enabled INTEGER DEFAULT 0;
+ALTER TABLE tasks ADD COLUMN qa_status TEXT CHECK (qa_status IN ('pending', 'running', 'passed', 'failed', 'skipped'));
+ALTER TABLE tasks ADD COLUMN qa_report TEXT; -- JSON report with screenshot refs
+```
+
+### Files to create/modify
+- `src/lib/browser-qa.ts` — NEW: Browserbase integration, scenario runner, screenshot capture
+- `src/lib/browser-qa-scenarios.ts` — NEW: default and custom scenario definitions
+- `src/app/api/tasks/[id]/qa/route.ts` — NEW: trigger QA manually, get QA report
+- `src/app/api/webhooks/agent-completion/route.ts` — hook QA into completion flow
+- `src/components/TaskModal.tsx` — QA tab showing screenshots and pass/fail
+- `src/components/QATab.tsx` — NEW: screenshot gallery, scenario results, re-run button
+
+### QA Scenario Schema
+```typescript
+interface QAScenario {
+  name: string;
+  steps: QAStep[];
+}
+interface QAStep {
+  action: 'navigate' | 'click' | 'type' | 'screenshot' | 'assert_text' | 'assert_no_errors';
+  selector?: string;
+  value?: string;
+  url?: string;
+  description: string;
+}
+```
+
+### Environment
+- `BROWSERBASE_API_KEY` — already in .env
+- `BROWSERBASE_PROJECT_ID` — already in .env
+- Dev server URL comes from workspace isolation (port 4200-4299 range)
+
+---
+
+## Feature 3: Codebase Explorer (Pre-Task Context Builder)
+
+**PR branch:** `feature/codebase-explorer`  
+**Estimated effort:** ~500 lines  
+**Priority:** Medium-High — improves task success rate
+
+### Problem
+Autensa's planning phase asks LLM-generated questions about the task, but doesn't crawl the actual codebase to build context. Devin's "Ask Devin" does structured code search and auto-generates context-rich prompts.
+
+### Solution
+Add a codebase exploration step between planning completion and dispatch. The explorer clones/pulls the repo, analyzes structure, and builds a context document that gets injected into the dispatch message.
+
+1. **Trigger:** after `planning_complete = 1`, before dispatch
+2. **Explorer worker** (`src/lib/codebase-explorer.ts`):
+   - Clone or pull repo to temp workspace
+   - Generate file tree (filtered: no node_modules, .git, dist)
+   - Identify key files: package.json, tsconfig, main entry points, test config
+   - Find files relevant to the task (keyword search from planning spec)
+   - Extract function signatures, type definitions, and imports from relevant files
+   - Count LOC, detect framework/language
+3. **Context document** — structured markdown injected into dispatch message:
+   ```
+   ## Codebase Context
+   
+   **Framework:** Next.js 14 | **Language:** TypeScript | **LOC:** 12,400
+   **Test runner:** vitest | **DB:** PostgreSQL (Prisma)
+   
+   ### Relevant Files (from planning spec keywords)
+   - src/lib/auth.ts (142 lines) — authentication utilities
+   - src/app/api/users/route.ts (89 lines) — user CRUD endpoints
+   
+   ### Key Type Definitions
+   ```typescript
+   interface User { id: string; email: string; ... }
+   ```
+   
+   ### Project Structure
+   src/
+     app/ (14 routes)
+     lib/ (23 modules)
+     components/ (31 components)
+   ```
+4. **Cache** — store exploration results per product+commit, reuse for subsequent tasks
+5. **Depth control** — `exploration_depth` product setting: `shallow` (tree only) | `standard` (tree + relevant files) | `deep` (tree + all exports + dependency graph)
+
+### Schema changes
+```sql
+-- Migration: add_codebase_explorer
+CREATE TABLE IF NOT EXISTS codebase_snapshots (
+  id TEXT PRIMARY KEY,
+  product_id TEXT NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+  commit_sha TEXT NOT NULL,
+  file_tree TEXT NOT NULL,
+  framework TEXT,
+  language TEXT,
+  loc INTEGER,
+  key_files TEXT, -- JSON
+  type_definitions TEXT, -- JSON
+  explored_at TEXT DEFAULT (datetime('now')),
+  UNIQUE(product_id, commit_sha)
+);
+ALTER TABLE products ADD COLUMN exploration_depth TEXT DEFAULT 'standard' 
+  CHECK (exploration_depth IN ('shallow', 'standard', 'deep'));
+```
+
+### Files to create/modify
+- `src/lib/codebase-explorer.ts` — NEW: clone, analyze, generate context document
+- `src/lib/file-analyzer.ts` — NEW: extract exports, types, signatures from TS/JS/Python files
+- `src/app/api/products/[id]/explore/route.ts` — NEW: trigger manual exploration
+- `src/app/api/tasks/[id]/dispatch/route.ts` — inject codebase context into dispatch message
+- `src/components/autopilot/ProductSettings.tsx` — add exploration_depth setting
+
+---
+
+## Feature 4: MCP Integration Framework
+
+**PR branch:** `feature/mcp-integrations`  
+**Estimated effort:** ~700 lines  
+**Priority:** Medium — extensibility play, compound value over time
+
+### Problem
+Autensa agents can only access what OpenClaw skills provide. Devin plugs into Datadog, Sentry, Figma, Notion, Stripe, etc. via MCP. Agents can't investigate production issues, read designs, or query external data during tasks.
+
+### Solution
+Add MCP (Model Context Protocol) server connections to Autensa. Product owners configure MCP servers per product, and agents get those tools injected into their dispatch context.
+
+1. **MCP server registry** — products can have N MCP server connections
+2. **Connection types:**
+   - `stdio` — local command (e.g., `npx @modelcontextprotocol/server-postgres`)
+   - `sse` — remote SSE endpoint (e.g., hosted MCP server URL)
+3. **Tool discovery** — on product setup, MC connects to each MCP server, lists available tools, stores the tool schemas
+4. **Dispatch injection** — when dispatching a task, include MCP tool descriptions in agent instructions:
+   ```
+   ## Available External Tools (MCP)
+   
+   You have access to these external tools via the MCP protocol:
+   - sentry.get_issues(project_slug) — fetch recent Sentry errors
+   - db.query(sql) — run read-only SQL against production DB
+   
+   To use them, call: %%MCP_CALL%%{"server":"sentry","tool":"get_issues","args":{...}}%%END%%
+   ```
+5. **MCP proxy** — MC receives `%%MCP_CALL%%` markers from agent output, executes against the configured MCP server, returns results to agent
+6. **Security** — MCP servers run in product context only, read-only by default, write operations require explicit product-level approval
+
+### Schema changes
+```sql
+-- Migration: add_mcp_integrations
+CREATE TABLE IF NOT EXISTS product_mcp_servers (
+  id TEXT PRIMARY KEY,
+  product_id TEXT NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  transport TEXT NOT NULL CHECK (transport IN ('stdio', 'sse')),
+  command TEXT, -- for stdio: e.g. "npx @mcp/server-postgres"
+  url TEXT, -- for sse: endpoint URL
+  env_vars TEXT, -- JSON: {"DATABASE_URL": "..."} 
+  available_tools TEXT, -- JSON: discovered tool schemas
+  enabled INTEGER DEFAULT 1,
+  created_at TEXT DEFAULT (datetime('now')),
+  updated_at TEXT DEFAULT (datetime('now'))
+);
+```
+
+### Files to create/modify
+- `src/lib/mcp/client.ts` — NEW: MCP client (stdio + SSE transport), tool discovery, tool execution
+- `src/lib/mcp/proxy.ts` — NEW: parse %%MCP_CALL%% markers from agent output, execute, return results
+- `src/lib/mcp/types.ts` — NEW: MCP tool schema types
+- `src/app/api/products/[id]/mcp/route.ts` — NEW: CRUD MCP servers, test connections, discover tools
+- `src/app/api/tasks/[id]/dispatch/route.ts` — inject MCP tool descriptions
+- `src/components/MCPTab.tsx` — NEW: manage MCP connections, test tools, view available tools
+- `src/components/autopilot/ProductSettings.tsx` — link to MCP configuration
+
+### MCP Server Presets (built-in)
+| Preset | Package | Use Case |
+|---|---|---|
+| PostgreSQL | `@modelcontextprotocol/server-postgres` | Query production DB |
+| GitHub | `@modelcontextprotocol/server-github` | Issues, PRs, code search |
+| Sentry | `@mcp/sentry-server` | Error monitoring |
+| Filesystem | `@modelcontextprotocol/server-filesystem` | Read project files |
+
+---
+
+## Feature 5: Session Insights (Post-Task Analytics)
+
+**PR branch:** `feature/session-insights`  
+**Estimated effort:** ~500 lines  
+**Priority:** Medium — improves future task success through feedback loop
+
+### Problem
+After a task completes (or fails), there's no analysis of what happened, where the agent got stuck, or how to write better prompts next time. Devin provides a timeline visualization, identifies bottlenecks, and auto-suggests improved prompts.
+
+### Solution
+Add a post-task analysis system that generates insights from task activities, agent session logs, and outcomes.
+
+1. **Insight generation** — after task → done (or after max retries):
+   - Analyze task_activities timeline (dispatch → first file → build → test → PR)
+   - Identify bottlenecks: long gaps, repeated errors, stall events
+   - Calculate metrics: time-to-first-commit, build attempts, test pass rate
+   - Compare to product baseline (avg task duration, success rate)
+   - Generate improved prompt suggestion via LLM
+2. **Timeline visualization** — horizontal timeline showing:
+   - Activity types color-coded (dispatch=blue, file_created=green, error=red, stalled=yellow)
+   - Duration bars between events
+   - Annotations for key moments (first error, recovery, completion)
+3. **Prompt improvement** — LLM analyzes the original dispatch prompt + what went wrong + what succeeded, suggests a better prompt template for similar future tasks
+4. **Product-level dashboard** — aggregate insights across all tasks:
+   - Success rate trend
+   - Average time-to-completion by task type
+   - Most common failure patterns
+   - Agent performance comparison
+
+### Schema changes
+```sql
+-- Migration: add_session_insights
+CREATE TABLE IF NOT EXISTS task_insights (
+  id TEXT PRIMARY KEY,
+  task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+  product_id TEXT NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+  duration_seconds INTEGER,
+  time_to_first_commit INTEGER, -- seconds
+  build_attempts INTEGER,
+  test_pass_rate REAL,
+  stall_count INTEGER,
+  error_count INTEGER,
+  bottleneck_summary TEXT, -- short text
+  improved_prompt TEXT, -- LLM-generated
+  timeline_data TEXT, -- JSON: [{type, timestamp, duration, annotation}]
+  insights_json TEXT, -- JSON: full analysis
+  generated_at TEXT DEFAULT (datetime('now')),
+  UNIQUE(task_id)
+);
+```
+
+### Files to create/modify
+- `src/lib/session-insights.ts` — NEW: analyze task activities, generate timeline, identify bottlenecks
+- `src/lib/prompt-improver.ts` — NEW: LLM-powered prompt improvement from task outcomes
+- `src/app/api/tasks/[id]/insights/route.ts` — NEW: get/generate insights for a task
+- `src/app/api/products/[id]/insights/route.ts` — NEW: aggregate product-level analytics
+- `src/components/InsightsTab.tsx` — NEW: timeline visualization, metrics, improved prompt
+- `src/components/ProductInsights.tsx` — NEW: product-level analytics dashboard
+- `src/components/TaskModal.tsx` — add Insights tab
+- `src/lib/task-governance.ts` — trigger insight generation on task completion
+
+### Timeline Event Schema
+```typescript
+interface TimelineEvent {
+  type: 'dispatch' | 'file_created' | 'file_modified' | 'build' | 'test' | 'error' | 'stall' | 'recovery' | 'pr_created' | 'completed';
+  timestamp: string;
+  duration_ms?: number;
+  annotation?: string;
+  severity?: 'info' | 'warning' | 'error';
+}
+```
+
+---
+
+## Build Order
+
+All 5 features are independent — no cross-dependencies. Recommended parallel assignment:
+
+| PR | Branch | Agent Type | Est. Lines |
+|---|---|---|---|
+| 1. PR Review Auto-Fix | `feature/pr-review-autofix` | Backend-heavy | ~400 |
+| 2. Browser QA | `feature/browser-qa` | Full-stack | ~600 |
+| 3. Codebase Explorer | `feature/codebase-explorer` | Backend | ~500 |
+| 4. MCP Integration | `feature/mcp-integrations` | Full-stack | ~700 |
+| 5. Session Insights | `feature/session-insights` | Full-stack + LLM | ~500 |
+
+**Total:** ~2,700 lines across 5 PRs
+
+## Shared Conventions
+
+- All new tables use TEXT PRIMARY KEY with UUID v4
+- All timestamps are ISO 8601 via `datetime('now')`
+- All API routes require Bearer token auth (existing middleware)
+- All UI components use existing MC design system (mc-* CSS classes, lucide-react icons)
+- LLM calls use existing `complete()` helper from `src/lib/autopilot/llm.ts`
+- SSE broadcasts use existing `broadcastTaskUpdate()` from `src/lib/events.ts`

--- a/src/app/api/runtime/codex/status/route.ts
+++ b/src/app/api/runtime/codex/status/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import { getCodexCliStatus } from '@/lib/codex/status';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    return NextResponse.json(await getCodexCliStatus());
+  } catch (error) {
+    console.error('Failed to check Codex CLI status:', error);
+    return NextResponse.json(
+      {
+        installed: false,
+        authenticated: false,
+        ready: false,
+        command: process.env.CODEX_CLI_PATH || 'codex',
+        error: 'Failed to check Codex CLI status',
+        loginCommand: 'codex login --device-auth',
+        checkedAt: new Date().toISOString(),
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/runtime/settings/route.ts
+++ b/src/app/api/runtime/settings/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAgentRuntimeSettings, updateAgentRuntimeSettings } from '@/lib/runtime-settings';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    return NextResponse.json(getAgentRuntimeSettings());
+  } catch (error) {
+    console.error('Failed to read runtime settings:', error);
+    return NextResponse.json({ error: 'Failed to read runtime settings' }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const settings = updateAgentRuntimeSettings({
+      provider: body.provider,
+      codexCloudEnvironmentId: body.codexCloudEnvironmentId,
+      codexDefaultBranch: body.codexDefaultBranch,
+    });
+
+    return NextResponse.json(settings);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to update runtime settings';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/src/app/api/tasks/[id]/dispatch/retry/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/retry/route.ts
@@ -1,0 +1,183 @@
+import { NextResponse } from 'next/server';
+import { queryAll, queryOne, run } from '@/lib/db';
+import { dispatchTaskFromServer } from '@/lib/server-dispatch';
+import { broadcast } from '@/lib/events';
+import type { Task } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+type ActiveRuntimeSession = {
+  runtime: 'openclaw' | 'codex';
+  session_id: string;
+  status: string;
+  created_at: string;
+};
+
+type DispatchRetryClassification = {
+  code: 'needs_agent' | 'needs_runtime_setup' | 'repo_access' | 'no_session_recorded' | 'not_allowed' | 'dispatch_failed';
+  retryable: boolean;
+  userMessage: string;
+};
+
+function getActiveRuntimeSessions(taskId: string, agentId: string): ActiveRuntimeSession[] {
+  return queryAll<ActiveRuntimeSession>(
+    `SELECT 'openclaw' AS runtime, openclaw_session_id AS session_id, status, created_at
+     FROM openclaw_sessions
+     WHERE task_id = ?
+       AND agent_id = ?
+       AND status = 'active'
+     UNION ALL
+     SELECT 'codex' AS runtime, id AS session_id, status, created_at
+     FROM codex_sessions
+     WHERE task_id = ?
+       AND agent_id = ?
+       AND status = 'running'
+     ORDER BY created_at DESC`,
+    [taskId, agentId, taskId, agentId]
+  );
+}
+
+function classifyDispatchRetryFailure(error: string): DispatchRetryClassification {
+  const normalized = error.toLowerCase();
+
+  if (normalized.includes('no routable agent') || normalized.includes('no agent') || normalized.includes('assigned agent not found')) {
+    return {
+      code: 'needs_agent',
+      retryable: false,
+      userMessage: 'Assign an available agent before retrying dispatch.',
+    };
+  }
+
+  if (normalized.includes('codex runtime is not ready') || normalized.includes('not authenticated') || normalized.includes('openclaw gateway')) {
+    return {
+      code: 'needs_runtime_setup',
+      retryable: false,
+      userMessage: 'Fix the selected runtime connection in Settings, then retry dispatch.',
+    };
+  }
+
+  if (normalized.includes('git auth') || normalized.includes('repo access') || normalized.includes('repository not found') || normalized.includes('could not read from remote repository')) {
+    return {
+      code: 'repo_access',
+      retryable: false,
+      userMessage: 'Confirm repository access, then retry dispatch.',
+    };
+  }
+
+  if (normalized.includes('no active replacement session') || normalized.includes('no active runtime session')) {
+    return {
+      code: 'no_session_recorded',
+      retryable: true,
+      userMessage: 'Dispatch did not leave a tracked runtime session. Retry dispatch after checking runtime health.',
+    };
+  }
+
+  return {
+    code: 'dispatch_failed',
+    retryable: true,
+    userMessage: 'Dispatch failed. Retry after reviewing the error details.',
+  };
+}
+
+function recordRetryFailure(taskId: string, error: string) {
+  const classification = classifyDispatchRetryFailure(error);
+  const now = new Date().toISOString();
+
+  run(
+    `UPDATE tasks
+     SET planning_dispatch_error = ?,
+         status_reason = ?,
+         updated_at = ?
+     WHERE id = ?`,
+    [`Retry dispatch failed: ${error}`, classification.userMessage, now, taskId]
+  );
+
+  const refreshedTask = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
+  if (refreshedTask) {
+    broadcast({ type: 'task_updated', payload: refreshedTask });
+  }
+
+  return classification;
+}
+
+/**
+ * POST /api/tasks/[id]/dispatch/retry
+ *
+ * Retries dispatch for any blocked task that still has an assigned agent. Unlike
+ * the planning retry route, this does not require planning_complete and verifies
+ * that dispatch actually created a tracked runtime session.
+ */
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: taskId } = await params;
+
+  try {
+    const task = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
+
+    if (!task) {
+      return NextResponse.json({ error: 'Task not found' }, { status: 404 });
+    }
+
+    if (task.status === 'done') {
+      const classification: DispatchRetryClassification = {
+        code: 'not_allowed',
+        retryable: false,
+        userMessage: 'Completed tasks cannot be retried for dispatch.',
+      };
+      return NextResponse.json({ error: classification.userMessage, ...classification }, { status: 409 });
+    }
+
+    if (!task.assigned_agent_id) {
+      const error = 'Task has no assigned agent';
+      const classification = recordRetryFailure(taskId, error);
+      return NextResponse.json({ error, ...classification }, { status: 400 });
+    }
+
+    run(
+      `UPDATE tasks
+       SET planning_dispatch_error = NULL,
+           status_reason = NULL,
+           updated_at = datetime('now')
+       WHERE id = ?`,
+      [taskId]
+    );
+
+    const dispatchResult = await dispatchTaskFromServer(taskId);
+    if (!dispatchResult.success) {
+      const error = dispatchResult.error || 'Dispatch failed';
+      const classification = recordRetryFailure(taskId, error);
+      return NextResponse.json({ error, ...classification }, { status: dispatchResult.status || 500 });
+    }
+
+    const activeSessions = getActiveRuntimeSessions(taskId, task.assigned_agent_id);
+    if (activeSessions.length === 0) {
+      const error = 'Dispatch returned success but no active runtime session was recorded.';
+      const classification = recordRetryFailure(taskId, error);
+      return NextResponse.json({ error, ...classification }, { status: 502 });
+    }
+
+    const refreshedTask = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
+    if (refreshedTask) {
+      broadcast({ type: 'task_updated', payload: refreshedTask });
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: 'Dispatch retry started',
+      runtime: activeSessions[0].runtime,
+      session_id: activeSessions[0].session_id,
+      task: refreshedTask,
+    });
+  } catch (error) {
+    console.error('[Dispatch Retry] Failed to retry dispatch:', error);
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    const classification = recordRetryFailure(taskId, message);
+
+    return NextResponse.json({
+      error: message,
+      ...classification,
+    }, { status: 500 });
+  }
+}

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -12,6 +12,9 @@ import { buildCheckpointContext } from '@/lib/checkpoint';
 import { formatMailForDispatch } from '@/lib/mailbox';
 import { getPendingNotesForDispatch } from '@/lib/task-notes';
 import { createTaskWorkspace, determineIsolationStrategy } from '@/lib/workspace-isolation';
+import { getAgentRuntimeSettings } from '@/lib/runtime-settings';
+import { getCodexCliStatus } from '@/lib/codex/status';
+import { cancelCodexRunsForTask, startCodexTaskRun } from '@/lib/codex/dispatch';
 import type { Task, Agent, Product, OpenClawSession, WorkflowStage, TaskImage } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -41,8 +44,8 @@ function dispatchErrorResponse(taskId: string, error: string, status: number) {
 /**
  * POST /api/tasks/[id]/dispatch
  * 
- * Dispatches a task to its assigned agent's OpenClaw session.
- * Creates session if needed, sends task details to agent.
+ * Dispatches a task to its assigned agent through the configured runtime.
+ * OpenClaw keeps the existing chat-session flow; Codex starts a tracked CLI run.
  */
 export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
@@ -126,65 +129,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       }
     }
 
-    // Connect to OpenClaw Gateway
-    const client = getOpenClawClient();
-    if (!client.isConnected()) {
-      try {
-        await client.connect();
-      } catch (err) {
-        console.error('Failed to connect to OpenClaw Gateway:', err);
-        client.forceReconnect();
-        return dispatchErrorResponse(id, 'Failed to connect to OpenClaw Gateway', 503);
-      }
-    }
-
-    // Get or create OpenClaw session for this agent + task combination
-    let session = queryOne<OpenClawSession>(
-      'SELECT * FROM openclaw_sessions WHERE agent_id = ? AND task_id = ? AND status = ?',
-      [agent.id, id, 'active']
-    );
-    const reusedExistingSession = Boolean(session);
-
     const now = new Date().toISOString();
-
-    if (!session) {
-      // Create session record
-      const sessionId = uuidv4();
-      const openclawSessionId = `mission-control-${agent.name.toLowerCase().replace(/\s+/g, '-')}-${id}`;
-      
-      run(
-        `INSERT INTO openclaw_sessions (id, agent_id, openclaw_session_id, task_id, channel, status, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-        [sessionId, agent.id, openclawSessionId, id, 'mission-control', 'active', now, now]
-      );
-
-      session = queryOne<OpenClawSession>(
-        'SELECT * FROM openclaw_sessions WHERE id = ?',
-        [sessionId]
-      );
-
-      // Log session creation
-      run(
-        `INSERT INTO events (id, type, agent_id, message, created_at)
-         VALUES (?, ?, ?, ?, ?)`,
-        [uuidv4(), 'agent_status_changed', agent.id, `${agent.name} session created`, now]
-      );
-    }
-
-    if (!session) {
-      return dispatchErrorResponse(id, 'Failed to create agent session', 500);
-    }
-
-    console.info('[Dispatch] Agent session resolved for task dispatch', JSON.stringify({
-      taskId: id,
-      taskStatus: task.status,
-      agentId: agent.id,
-      agentName: agent.name,
-      reusedExistingSession,
-      sessionId: session.openclaw_session_id,
-      sessionCreatedAt: session.created_at,
-      sessionUpdatedAt: session.updated_at,
-    }));
 
     // Cost cap warning check
     let costCapWarning: string | undefined;
@@ -457,6 +402,183 @@ If you need help or clarification, ask the orchestrator.`;
     // Inject any pending operator notes (queued via /btw chat)
     const { formatted: pendingNotes } = getPendingNotesForDispatch(id);
     const finalMessage = pendingNotes ? taskMessage + pendingNotes : taskMessage;
+
+    const runtimeSettings = getAgentRuntimeSettings();
+
+    if (runtimeSettings.provider === 'codex') {
+      const codexStatus = await getCodexCliStatus();
+
+      if (!codexStatus.ready) {
+        return dispatchErrorResponse(
+          id,
+          `Codex runtime is not ready: ${codexStatus.error || 'Codex CLI is not authenticated'}`,
+          503
+        );
+      }
+
+      const cancelledRuns = cancelCodexRunsForTask(task.id, agent.id);
+      const codexPrompt = `**CODEX RUNTIME CONTEXT**
+You are running inside Codex CLI for Mission Control.
+Use this Mission Control API base URL exactly as written: ${missionControlUrl}
+Do not replace the hostname with 127.0.0.1 or another loopback spelling.
+When the task requires status, activity, deliverable, or PR updates, call the Mission Control API directly.
+Every Mission Control API curl command must include:
+-H "Authorization: Bearer $MC_API_TOKEN"
+Never print, inspect, or echo MC_API_TOKEN.
+
+${finalMessage}`;
+
+      const codexRun = startCodexTaskRun({
+        task: task as Task,
+        agent,
+        prompt: codexPrompt,
+        workingDirectory: taskProjectDir,
+        env: {
+          CODEX_CLOUD_ENV_ID: runtimeSettings.codexCloudEnvironmentId || undefined,
+          CODEX_DEFAULT_BRANCH: runtimeSettings.codexDefaultBranch || undefined,
+          MISSION_CONTROL_URL: missionControlUrl,
+        },
+      });
+
+      console.info('[Dispatch] Task started through Codex runtime', JSON.stringify({
+        taskId: task.id,
+        agentId: agent.id,
+        agentName: agent.name,
+        sessionId: codexRun.sessionId,
+        pid: codexRun.pid,
+        cwd: codexRun.cwd,
+        cancelledRuns,
+      }));
+
+      if (task.status === 'assigned') {
+        run(
+          'UPDATE tasks SET status = ?, planning_dispatch_error = NULL, status_reason = NULL, updated_at = ? WHERE id = ?',
+          ['in_progress', now, id]
+        );
+      } else {
+        run(
+          'UPDATE tasks SET planning_dispatch_error = NULL, status_reason = NULL, updated_at = ? WHERE id = ?',
+          [now, id]
+        );
+      }
+
+      const updatedTask = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [id]);
+      if (updatedTask) {
+        broadcast({
+          type: 'task_updated',
+          payload: updatedTask,
+        });
+      }
+
+      run(
+        'UPDATE agents SET status = ?, updated_at = ? WHERE id = ?',
+        ['working', now, agent.id]
+      );
+
+      run(
+        `INSERT INTO events (id, type, agent_id, task_id, message, metadata, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        [
+          uuidv4(),
+          'task_dispatched',
+          agent.id,
+          task.id,
+          `Task "${task.title}" dispatched to ${agent.name} through Codex`,
+          JSON.stringify({ runtime: 'codex', codex_session_id: codexRun.sessionId }),
+          now,
+        ]
+      );
+
+      run(
+        `INSERT INTO task_activities (id, task_id, agent_id, activity_type, message, metadata, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        [
+          crypto.randomUUID(),
+          task.id,
+          agent.id,
+          'status_changed',
+          `Task dispatched to ${agent.name} through Codex - Codex is now working on this task`,
+          JSON.stringify({
+            runtime: 'codex',
+            codex_session_id: codexRun.sessionId,
+            pid: codexRun.pid,
+            cwd: codexRun.cwd,
+            log_path: codexRun.logPath,
+          }),
+          now,
+        ]
+      );
+
+      return NextResponse.json({
+        success: true,
+        runtime: 'codex',
+        task_id: task.id,
+        agent_id: agent.id,
+        session_id: codexRun.sessionId,
+        codex_session_id: codexRun.sessionId,
+        message: 'Task dispatched to Codex',
+        ...(costCapWarning ? { cost_cap_warning: costCapWarning } : {}),
+      });
+    }
+
+    // Connect to OpenClaw Gateway only when the configured runtime is OpenClaw.
+    const client = getOpenClawClient();
+    if (!client.isConnected()) {
+      try {
+        await client.connect();
+      } catch (err) {
+        console.error('Failed to connect to OpenClaw Gateway:', err);
+        client.forceReconnect();
+        return dispatchErrorResponse(id, 'Failed to connect to OpenClaw Gateway', 503);
+      }
+    }
+
+    // Get or create OpenClaw session for this agent + task combination
+    let session = queryOne<OpenClawSession>(
+      'SELECT * FROM openclaw_sessions WHERE agent_id = ? AND task_id = ? AND status = ?',
+      [agent.id, id, 'active']
+    );
+    const reusedExistingSession = Boolean(session);
+
+    if (!session) {
+      // Create session record
+      const sessionId = uuidv4();
+      const openclawSessionId = `mission-control-${agent.name.toLowerCase().replace(/\s+/g, '-')}-${id}`;
+
+      run(
+        `INSERT INTO openclaw_sessions (id, agent_id, openclaw_session_id, task_id, channel, status, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        [sessionId, agent.id, openclawSessionId, id, 'mission-control', 'active', now, now]
+      );
+
+      session = queryOne<OpenClawSession>(
+        'SELECT * FROM openclaw_sessions WHERE id = ?',
+        [sessionId]
+      );
+
+      // Log session creation
+      run(
+        `INSERT INTO events (id, type, agent_id, message, created_at)
+         VALUES (?, ?, ?, ?, ?)`,
+        [uuidv4(), 'agent_status_changed', agent.id, `${agent.name} session created`, now]
+      );
+    }
+
+    if (!session) {
+      return dispatchErrorResponse(id, 'Failed to create agent session', 500);
+    }
+
+    console.info('[Dispatch] Agent session resolved for task dispatch', JSON.stringify({
+      runtime: 'openclaw',
+      taskId: id,
+      taskStatus: task.status,
+      agentId: agent.id,
+      agentName: agent.name,
+      reusedExistingSession,
+      sessionId: session.openclaw_session_id,
+      sessionCreatedAt: session.created_at,
+      sessionUpdatedAt: session.updated_at,
+    }));
 
     // Send message to agent's session using chat.send
     try {

--- a/src/app/api/tasks/[id]/dispatch/route.ts
+++ b/src/app/api/tasks/[id]/dispatch/route.ts
@@ -4,18 +4,14 @@ import { queryOne, queryAll, run } from '@/lib/db';
 import { getOpenClawClient } from '@/lib/openclaw/client';
 import { broadcast } from '@/lib/events';
 import { getProjectsPath, getMissionControlUrl } from '@/lib/config';
-import { getRelevantKnowledge, formatKnowledgeForDispatch } from '@/lib/learner';
-import { getTaskWorkflow } from '@/lib/workflow-engine';
 import { syncGatewayAgentsToCatalog } from '@/lib/agent-catalog-sync';
 import { pickDynamicAgent } from '@/lib/task-governance';
-import { buildCheckpointContext } from '@/lib/checkpoint';
-import { formatMailForDispatch } from '@/lib/mailbox';
-import { getPendingNotesForDispatch } from '@/lib/task-notes';
 import { createTaskWorkspace, determineIsolationStrategy } from '@/lib/workspace-isolation';
 import { getAgentRuntimeSettings } from '@/lib/runtime-settings';
 import { getCodexCliStatus } from '@/lib/codex/status';
 import { cancelCodexRunsForTask, startCodexTaskRun } from '@/lib/codex/dispatch';
-import type { Task, Agent, Product, OpenClawSession, WorkflowStage, TaskImage } from '@/lib/types';
+import { buildTaskDispatchContext } from '@/lib/task-dispatch-context';
+import type { Task, Agent, Product, OpenClawSession } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
 interface RouteParams {
@@ -151,14 +147,6 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       }
     }
 
-    // Build task message for agent
-    const priorityEmoji = {
-      low: '🔵',
-      normal: '⚪',
-      high: '🟡',
-      urgent: '🔴'
-    }[task.priority] || '⚪';
-
     // Get project path for deliverables — with workspace isolation if needed
     const projectsPath = getProjectsPath();
     const projectDir = task.title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
@@ -185,223 +173,16 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       }
     }
 
-    // Parse planning_spec and planning_agents if present (stored as JSON text on the task row)
-    const rawTask = task as Task & { assigned_agent_name?: string; workspace_id: string; planning_spec?: string; planning_agents?: string };
-    let planningSpecSection = '';
-    let agentInstructionsSection = '';
-
-    if (rawTask.planning_spec) {
-      try {
-        const spec = JSON.parse(rawTask.planning_spec);
-        // planning_spec may be an object with spec_markdown, or a raw string
-        const specText = typeof spec === 'string' ? spec : (spec.spec_markdown || JSON.stringify(spec, null, 2));
-        planningSpecSection = `\n---\n**📋 PLANNING SPECIFICATION:**\n${specText}\n`;
-      } catch {
-        // If not valid JSON, treat as plain text
-        planningSpecSection = `\n---\n**📋 PLANNING SPECIFICATION:**\n${rawTask.planning_spec}\n`;
-      }
-    }
-
-    if (rawTask.planning_agents) {
-      try {
-        const agents = JSON.parse(rawTask.planning_agents);
-        if (Array.isArray(agents)) {
-          // Find instructions for this specific agent, or include all if none match
-          const myInstructions = agents.find(
-            (a: { agent_id?: string; name?: string; instructions?: string }) =>
-              a.agent_id === agent.id || a.name === agent.name
-          );
-          if (myInstructions?.instructions) {
-            agentInstructionsSection = `\n**🎯 YOUR INSTRUCTIONS:**\n${myInstructions.instructions}\n`;
-          } else {
-            // Include all agent instructions for context
-            const allInstructions = agents
-              .filter((a: { instructions?: string }) => a.instructions)
-              .map((a: { name?: string; role?: string; instructions?: string }) =>
-                `- **${a.name || a.role || 'Agent'}:** ${a.instructions}`
-              )
-              .join('\n');
-            if (allInstructions) {
-              agentInstructionsSection = `\n**🎯 AGENT INSTRUCTIONS:**\n${allInstructions}\n`;
-            }
-          }
-        }
-      } catch {
-        // Ignore malformed planning_agents JSON
-      }
-    }
-
-    // Inject relevant knowledge from the learner knowledge base
-    let knowledgeSection = '';
-    try {
-      const knowledge = getRelevantKnowledge(task.workspace_id, task.title);
-      knowledgeSection = formatKnowledgeForDispatch(knowledge);
-    } catch {
-      // Knowledge injection is best-effort
-    }
-
-    // Inject matched product skills (proven procedures from previous tasks)
-    let skillsSection = '';
-    if (task.product_id) {
-      try {
-        const { getMatchedSkills, formatSkillsForDispatch } = await import('@/lib/skills');
-        const skills = getMatchedSkills(task.product_id, task.title, task.description || '', agent.name);
-        skillsSection = formatSkillsForDispatch(skills);
-      } catch {
-        // Skills injection is best-effort
-      }
-    }
-
-    // Determine role-specific instructions based on workflow template
-    const workflow = getTaskWorkflow(id);
-    let currentStage: WorkflowStage | undefined;
-    let nextStage: WorkflowStage | undefined;
-    if (workflow) {
-      let stageIndex = workflow.stages.findIndex(s => s.status === task.status);
-      // 'assigned' isn't a workflow stage — resolve to the 'build' stage (in_progress)
-      if (stageIndex < 0 && (task.status === 'assigned' || task.status === 'inbox')) {
-        stageIndex = workflow.stages.findIndex(s => s.role === 'builder');
-      }
-      if (stageIndex >= 0) {
-        currentStage = workflow.stages[stageIndex];
-        nextStage = workflow.stages[stageIndex + 1];
-      }
-    }
-
-    const isBuilder = !currentStage || currentStage.role === 'builder' || task.status === 'assigned';
-    const isTester = currentStage?.role === 'tester';
-    const isVerifier = currentStage?.role === 'verifier' || currentStage?.role === 'reviewer';
-    const nextStatus = nextStage?.status || 'review';
-    const failEndpoint = `POST ${missionControlUrl}/api/tasks/${task.id}/fail`;
-
-    let completionInstructions: string;
-    if (isBuilder) {
-      completionInstructions = `**IMPORTANT:** After completing work, you MUST call these APIs:
-1. Log activity: POST ${missionControlUrl}/api/tasks/${task.id}/activities
-   Body: {"activity_type": "completed", "message": "Description of what was done"}
-2. Register deliverable: POST ${missionControlUrl}/api/tasks/${task.id}/deliverables
-   Body: {"deliverable_type": "file", "title": "File name", "path": "${taskProjectDir}/filename.html"}
-3. Update status: PATCH ${missionControlUrl}/api/tasks/${task.id}
-   Body: {"status": "${nextStatus}"}
-
-When complete, reply with:
-\`TASK_COMPLETE: [brief summary of what you did]\``;
-    } else if (isTester) {
-      completionInstructions = `**YOUR ROLE: TESTER** — Test the deliverables for this task.
-
-Review the output directory for deliverables and run any applicable tests.
-
-**If tests PASS:**
-1. Log activity: POST ${missionControlUrl}/api/tasks/${task.id}/activities
-   Body: {"activity_type": "completed", "message": "Tests passed: [summary]"}
-2. Update status: PATCH ${missionControlUrl}/api/tasks/${task.id}
-   Body: {"status": "${nextStatus}"}
-
-**If tests FAIL:**
-1. ${failEndpoint}
-   Body: {"reason": "Detailed description of what failed and what needs fixing"}
-
-Reply with: \`TEST_PASS: [summary]\` or \`TEST_FAIL: [what failed]\``;
-    } else if (isVerifier) {
-      completionInstructions = `**YOUR ROLE: VERIFIER** — Verify that all work meets quality standards.
-
-Review deliverables, test results, and task requirements.
-
-**If verification PASSES:**
-1. Log activity: POST ${missionControlUrl}/api/tasks/${task.id}/activities
-   Body: {"activity_type": "completed", "message": "Verification passed: [summary]"}
-2. Update status: PATCH ${missionControlUrl}/api/tasks/${task.id}
-   Body: {"status": "${nextStatus}"}
-
-**If verification FAILS:**
-1. ${failEndpoint}
-   Body: {"reason": "Detailed description of what failed and what needs fixing"}
-
-Reply with: \`VERIFY_PASS: [summary]\` or \`VERIFY_FAIL: [what failed]\``;
-    } else {
-      // Fallback for unknown roles
-      completionInstructions = `**IMPORTANT:** After completing work:
-1. Update status: PATCH ${missionControlUrl}/api/tasks/${task.id}
-   Body: {"status": "${nextStatus}"}`;
-    }
-
-    // Build image references section
-    let imagesSection = '';
-    if (task.images) {
-      try {
-        const images: TaskImage[] = JSON.parse(task.images);
-        if (images.length > 0) {
-          const imageList = images
-            .map(img => `- ${img.original_name}: ${missionControlUrl}/api/task-images/${task.id}/${img.filename}`)
-            .join('\n');
-          imagesSection = `\n**Reference Images:**\n${imageList}\n`;
-        }
-      } catch {
-        // Ignore malformed images JSON
-      }
-    }
-
-    // Build repo/PR section for builder agents when task has a repo
-    let repoSection = '';
-    if ((task as Task & { repo_url?: string }).repo_url && isBuilder) {
-      const repoUrl = (task as Task & { repo_url?: string }).repo_url!;
-      const repoBranch = (task as Task & { repo_branch?: string }).repo_branch || 'main';
-      const branchName = `autopilot/${task.title.toLowerCase().replace(/[^a-z0-9]+/g, '-').slice(0, 50)}`;
-
-      repoSection = `
----
-**\u{1F517} REPOSITORY:**
-- **Repo:** ${repoUrl}
-- **Base branch:** ${repoBranch}
-- **Feature branch:** ${branchName}
-
-**GIT WORKFLOW:**
-1. First, verify you have git access: run \`git ls-remote ${repoUrl}\`
-   - If this fails, report the error immediately via:
-     PATCH ${missionControlUrl}/api/tasks/${task.id}
-     Body: {"status_reason": "Git auth not configured: [error message]"}
-     Then STOP — do not proceed without repo access.
-2. Clone the repo (or use existing local copy)
-3. Create branch \`${branchName}\` from \`${repoBranch}\`
-4. Implement the feature
-5. Commit with clear messages (reference task: ${task.id})
-6. Push branch and create a Pull Request
-
-**PR REQUIREMENTS:**
-- Title: "\u{1F916} Autopilot: ${task.title}"
-- Body must include:
-  - What was built and why
-  - Research backing (from the idea)
-  - Technical approach taken
-  - Any risks or trade-offs
-  - Task ID: ${task.id}
-- Target branch: ${repoBranch}
-- After creating PR, report the PR URL:
-  PATCH ${missionControlUrl}/api/tasks/${task.id}
-  Body: {"pr_url": "<github PR url>", "pr_status": "open"}
-`;
-    }
-
-    const roleLabel = currentStage?.label || 'Task';
-    const taskMessage = `${priorityEmoji} **${isBuilder ? 'NEW TASK ASSIGNED' : `${roleLabel.toUpperCase()} STAGE — ${task.title}`}**
-
-**Title:** ${task.title}
-${task.description ? `**Description:** ${task.description}\n` : ''}
-**Priority:** ${task.priority.toUpperCase()}
-${task.due_date ? `**Due:** ${task.due_date}\n` : ''}
-**Task ID:** ${task.id}
-${planningSpecSection}${agentInstructionsSection}${skillsSection}${knowledgeSection}${imagesSection}${buildCheckpointContext(task.id) || ''}${formatMailForDispatch(agent.id) || ''}${repoSection}
-${isBuilder ? (workspaceIsolated
-  ? `**\u{1F512} ISOLATED WORKSPACE:** ${taskProjectDir}\n- **Port:** ${workspacePort || 'default'} (use this for dev server, NOT the default)\n${workspaceBranchName ? `- **Branch:** ${workspaceBranchName}\n` : ''}- **IMPORTANT:** Do NOT modify files outside this workspace directory. Other agents may be working on the same project in parallel. All your work must stay within: ${taskProjectDir}\nCreate this directory if needed and save all deliverables there.\n`
-  : `**OUTPUT DIRECTORY:** ${taskProjectDir}\nCreate this directory and save all deliverables there.\n`)
-: `**OUTPUT DIRECTORY:** ${taskProjectDir}\n`}
-${completionInstructions}
-
-If you need help or clarification, ask the orchestrator.`;
-
-    // Inject any pending operator notes (queued via /btw chat)
-    const { formatted: pendingNotes } = getPendingNotesForDispatch(id);
-    const finalMessage = pendingNotes ? taskMessage + pendingNotes : taskMessage;
+    const dispatchContext = buildTaskDispatchContext({
+      task: task as Task,
+      agent,
+      missionControlUrl,
+      taskProjectDir,
+      workspaceIsolated,
+      workspaceBranchName,
+      workspacePort,
+    });
+    const finalMessage = dispatchContext.message;
 
     const runtimeSettings = getAgentRuntimeSettings();
 
@@ -448,6 +229,13 @@ ${finalMessage}`;
         pid: codexRun.pid,
         cwd: codexRun.cwd,
         cancelledRuns,
+        contextVersion: dispatchContext.audit.version,
+        contextChars: dispatchContext.audit.totalChars,
+        contextSections: dispatchContext.audit.sections.map(section => ({
+          key: section.key,
+          chars: section.charCount,
+          truncated: section.truncated,
+        })),
       }));
 
       if (task.status === 'assigned') {
@@ -484,7 +272,11 @@ ${finalMessage}`;
           agent.id,
           task.id,
           `Task "${task.title}" dispatched to ${agent.name} through Codex`,
-          JSON.stringify({ runtime: 'codex', codex_session_id: codexRun.sessionId }),
+          JSON.stringify({
+            runtime: 'codex',
+            codex_session_id: codexRun.sessionId,
+            context: dispatchContext.audit,
+          }),
           now,
         ]
       );
@@ -504,6 +296,7 @@ ${finalMessage}`;
             pid: codexRun.pid,
             cwd: codexRun.cwd,
             log_path: codexRun.logPath,
+            context: dispatchContext.audit,
           }),
           now,
         ]
@@ -516,6 +309,7 @@ ${finalMessage}`;
         agent_id: agent.id,
         session_id: codexRun.sessionId,
         codex_session_id: codexRun.sessionId,
+        context_version: dispatchContext.audit.version,
         message: 'Task dispatched to Codex',
         ...(costCapWarning ? { cost_cap_warning: costCapWarning } : {}),
       });
@@ -568,7 +362,7 @@ ${finalMessage}`;
       return dispatchErrorResponse(id, 'Failed to create agent session', 500);
     }
 
-    console.info('[Dispatch] Agent session resolved for task dispatch', JSON.stringify({
+      console.info('[Dispatch] Agent session resolved for task dispatch', JSON.stringify({
       runtime: 'openclaw',
       taskId: id,
       taskStatus: task.status,
@@ -578,6 +372,13 @@ ${finalMessage}`;
       sessionId: session.openclaw_session_id,
       sessionCreatedAt: session.created_at,
       sessionUpdatedAt: session.updated_at,
+      contextVersion: dispatchContext.audit.version,
+      contextChars: dispatchContext.audit.totalChars,
+      contextSections: dispatchContext.audit.sections.map(section => ({
+        key: section.key,
+        chars: section.charCount,
+        truncated: section.truncated,
+      })),
     }));
 
     // Send message to agent's session using chat.send
@@ -640,17 +441,41 @@ ${finalMessage}`;
       // Log dispatch event to events table
       const eventId = uuidv4();
       run(
-        `INSERT INTO events (id, type, agent_id, task_id, message, created_at)
-         VALUES (?, ?, ?, ?, ?, ?)`,
-        [eventId, 'task_dispatched', agent.id, task.id, `Task "${task.title}" dispatched to ${agent.name}`, now]
+        `INSERT INTO events (id, type, agent_id, task_id, message, metadata, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        [
+          eventId,
+          'task_dispatched',
+          agent.id,
+          task.id,
+          `Task "${task.title}" dispatched to ${agent.name}`,
+          JSON.stringify({
+            runtime: 'openclaw',
+            openclaw_session_id: session.openclaw_session_id,
+            context: dispatchContext.audit,
+          }),
+          now,
+        ]
       );
 
       // Log dispatch activity to task_activities table (for Activity tab)
       const activityId = crypto.randomUUID();
       run(
-        `INSERT INTO task_activities (id, task_id, agent_id, activity_type, message, created_at)
-         VALUES (?, ?, ?, ?, ?, ?)`,
-        [activityId, task.id, agent.id, 'status_changed', `Task dispatched to ${agent.name} - Agent is now working on this task`, now]
+        `INSERT INTO task_activities (id, task_id, agent_id, activity_type, message, metadata, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        [
+          activityId,
+          task.id,
+          agent.id,
+          'status_changed',
+          `Task dispatched to ${agent.name} - Agent is now working on this task`,
+          JSON.stringify({
+            runtime: 'openclaw',
+            openclaw_session_id: session.openclaw_session_id,
+            context: dispatchContext.audit,
+          }),
+          now,
+        ]
       );
 
       return NextResponse.json({
@@ -658,6 +483,7 @@ ${finalMessage}`;
         task_id: task.id,
         agent_id: agent.id,
         session_id: session.openclaw_session_id,
+        context_version: dispatchContext.audit.version,
         message: 'Task dispatched to agent',
         ...(costCapWarning ? { cost_cap_warning: costCapWarning } : {}),
       });

--- a/src/app/api/tasks/[id]/environment/fix/route.ts
+++ b/src/app/api/tasks/[id]/environment/fix/route.ts
@@ -31,6 +31,7 @@ interface RecentActivity {
 }
 
 interface EnvironmentFixActivity {
+  id: string;
   created_at: string;
   activity_type: string;
   message: string;
@@ -46,9 +47,59 @@ interface EnvironmentFixRun {
   retry: boolean;
 }
 
+interface EnvironmentFixMetadata {
+  issue?: EnvironmentIssue;
+  suggestion?: EnvironmentCommandSuggestion | null;
+  nextSuggestion?: EnvironmentCommandSuggestion | null;
+  command?: string;
+  commandSource?: string;
+  error?: string;
+  stdout?: string;
+  stderr?: string;
+  timeoutMs?: number;
+}
+
+type EnvironmentRecoveryAttemptStatus = 'running' | 'failed' | 'completed' | 'retry_failed' | 'stale';
+
+interface EnvironmentRecoveryAttempt {
+  id: string;
+  createdAt: string;
+  status: EnvironmentRecoveryAttemptStatus;
+  command?: string;
+  commandSource?: string;
+  message: string;
+  error?: string;
+  stdout?: string;
+  stderr?: string;
+  suggestion?: EnvironmentCommandSuggestion | null;
+  nextSuggestion?: EnvironmentCommandSuggestion | null;
+}
+
+interface EnvironmentRecoveryState {
+  issue: EnvironmentIssue;
+  running: boolean;
+  runningFix?: { command: string; startedAt: string };
+  attempts: EnvironmentRecoveryAttempt[];
+  failedCommands: string[];
+  nextSuggestion?: EnvironmentCommandSuggestion | null;
+}
+
 function compactOutput(value: string | Buffer | undefined): string {
   const text = Buffer.isBuffer(value) ? value.toString('utf8') : value || '';
   return text.length > MAX_OUTPUT_CHARS ? text.slice(-MAX_OUTPUT_CHARS) : text;
+}
+
+function normalizeCommand(command: string | undefined): string | undefined {
+  return command?.trim().replace(/\s+/g, ' ');
+}
+
+function safeJsonParse<T = unknown>(value: string | null | undefined): T | null {
+  if (!value) return null;
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return null;
+  }
 }
 
 function formatCommandFailure(
@@ -75,12 +126,14 @@ function collectIssueText(task: Task, activities: RecentActivity[], requestText?
   ];
 }
 
-function recordActivity(taskId: string, agentId: string | null, type: string, message: string, metadata?: Record<string, unknown>) {
+function recordActivity(taskId: string, agentId: string | null, type: string, message: string, metadata?: object): string {
+  const id = crypto.randomUUID();
   run(
     `INSERT INTO task_activities (id, task_id, agent_id, activity_type, message, metadata, created_at)
      VALUES (?, ?, ?, ?, ?, ?, ?)`,
-    [crypto.randomUUID(), taskId, agentId, type, message, metadata ? JSON.stringify(metadata) : null, new Date().toISOString()]
+    [id, taskId, agentId, type, message, metadata ? JSON.stringify(metadata) : null, new Date().toISOString()]
   );
+  return id;
 }
 
 function getRunningEnvironmentFix(taskId: string): { command: string; startedAt: string } | null {
@@ -88,7 +141,7 @@ function getRunningEnvironmentFix(taskId: string): { command: string; startedAt:
   if (inMemory) return inMemory;
 
   const latest = queryOne<EnvironmentFixActivity>(
-    `SELECT created_at, activity_type, message, metadata
+    `SELECT id, created_at, activity_type, message, metadata
      FROM task_activities
      WHERE task_id = ?
        AND activity_type IN ('environment_fix_started', 'environment_fix_failed', 'environment_fix_completed', 'environment_fix_retry_failed')
@@ -103,14 +156,153 @@ function getRunningEnvironmentFix(taskId: string): { command: string; startedAt:
   if (!Number.isFinite(startedAtMs) || Date.now() - startedAtMs > RUNNING_STALE_MS) return null;
 
   let command = latest.message.replace(/^Running approved environment command:\s*/i, '').trim();
-  try {
-    const metadata = latest.metadata ? JSON.parse(latest.metadata) as { command?: string } : null;
-    if (metadata?.command) command = metadata.command;
-  } catch {
-    // Ignore malformed historical metadata; the activity message still carries the command.
-  }
+  const metadata = safeJsonParse<EnvironmentFixMetadata>(latest.metadata);
+  if (metadata?.command) command = metadata.command;
 
   return { command, startedAt: latest.created_at };
+}
+
+function getEnvironmentFixActivities(taskId: string, limit = 30): EnvironmentFixActivity[] {
+  return queryAll<EnvironmentFixActivity>(
+    `SELECT id, created_at, activity_type, message, metadata
+     FROM task_activities
+     WHERE task_id = ?
+       AND activity_type IN ('environment_fix_started', 'environment_fix_failed', 'environment_fix_completed', 'environment_fix_retry_failed')
+     ORDER BY created_at DESC
+     LIMIT ?`,
+    [taskId, limit]
+  );
+}
+
+function getRecentContextActivities(taskId: string): RecentActivity[] {
+  return queryAll<RecentActivity>(
+    `SELECT created_at, activity_type, message, metadata
+     FROM task_activities
+     WHERE task_id = ?
+       AND activity_type IN (
+         'environment_blocked',
+         'status_changed',
+         'environment_fix_started',
+         'environment_fix_failed',
+         'environment_fix_completed',
+         'environment_fix_retry_failed'
+       )
+     ORDER BY created_at DESC
+     LIMIT 15`,
+    [taskId]
+  );
+}
+
+function commandFromActivity(activity: EnvironmentFixActivity, metadata: EnvironmentFixMetadata | null): string | undefined {
+  if (metadata?.command) return metadata.command;
+  const fromStartedMessage = activity.message.replace(/^Running approved environment command:\s*/i, '').trim();
+  return fromStartedMessage === activity.message ? undefined : fromStartedMessage;
+}
+
+function buildRecoveryState(taskId: string, issue: EnvironmentIssue): EnvironmentRecoveryState {
+  const runningFix = getRunningEnvironmentFix(taskId);
+  const activities = getEnvironmentFixActivities(taskId).reverse();
+  const attempts: EnvironmentRecoveryAttempt[] = [];
+
+  for (const activity of activities) {
+    const metadata = safeJsonParse<EnvironmentFixMetadata>(activity.metadata);
+    const command = commandFromActivity(activity, metadata);
+
+    if (activity.activity_type === 'environment_fix_started') {
+      attempts.push({
+        id: activity.id,
+        createdAt: activity.created_at,
+        status: 'running',
+        command,
+        commandSource: metadata?.commandSource,
+        message: activity.message,
+        suggestion: metadata?.suggestion,
+      });
+      continue;
+    }
+
+    const status = activity.activity_type === 'environment_fix_completed'
+      ? 'completed'
+      : activity.activity_type === 'environment_fix_retry_failed'
+        ? 'retry_failed'
+        : 'failed';
+    const matchingAttempt = command
+      ? [...attempts].reverse().find((attempt) => (
+        attempt.status === 'running' &&
+        normalizeCommand(attempt.command) === normalizeCommand(command)
+      ))
+      : undefined;
+    const patch: Partial<EnvironmentRecoveryAttempt> = {
+      status,
+      message: activity.message,
+      command,
+      error: metadata?.error,
+      stdout: metadata?.stdout,
+      stderr: metadata?.stderr,
+      suggestion: metadata?.suggestion,
+      nextSuggestion: metadata?.nextSuggestion,
+    };
+
+    if (matchingAttempt) {
+      Object.assign(matchingAttempt, patch);
+    } else {
+      attempts.push({
+        id: activity.id,
+        createdAt: activity.created_at,
+        status,
+        message: activity.message,
+        command,
+        error: metadata?.error,
+        stdout: metadata?.stdout,
+        stderr: metadata?.stderr,
+        suggestion: metadata?.suggestion,
+        nextSuggestion: metadata?.nextSuggestion,
+      });
+    }
+  }
+
+  const now = Date.now();
+  for (const attempt of attempts) {
+    if (attempt.status !== 'running') continue;
+    const startedAtMs = new Date(attempt.createdAt).getTime();
+    if (!Number.isFinite(startedAtMs) || now - startedAtMs > RUNNING_STALE_MS) {
+      attempt.status = 'stale';
+    }
+  }
+
+  const failedCommands = Array.from(new Set(
+    attempts
+      .filter((attempt) => attempt.status === 'failed' || attempt.status === 'retry_failed')
+      .map((attempt) => normalizeCommand(attempt.command))
+      .filter((command): command is string => Boolean(command))
+  ));
+  const latestNextSuggestion = [...attempts]
+    .reverse()
+    .map((attempt) => attempt.nextSuggestion)
+    .find((suggestion) => suggestion?.canFixWithCommand && suggestion.command);
+
+  return {
+    issue,
+    running: Boolean(runningFix),
+    runningFix: runningFix || undefined,
+    attempts: attempts.reverse(),
+    failedCommands,
+    nextSuggestion: latestNextSuggestion || null,
+  };
+}
+
+function updateActivityMetadata(activityId: string, metadata: Record<string, unknown>) {
+  run(
+    `UPDATE task_activities
+     SET metadata = ?
+     WHERE id = ?`,
+    [JSON.stringify(metadata), activityId]
+  );
+}
+
+function hasFailedCommand(recovery: EnvironmentRecoveryState, command: string): boolean {
+  const normalized = normalizeCommand(command);
+  return Boolean(normalized && recovery.failedCommands.includes(normalized));
 }
 
 function updateTaskState(taskId: string, statusReason: string, planningError?: string | null): Task | null {
@@ -149,18 +341,54 @@ async function finishEnvironmentFix(
 
   if (error) {
     const message = formatCommandFailure(command, error, stdout, stderr);
+    const planningError = `Environment fix failed (${issue.code}): ${message}`;
     updateTaskState(
       task.id,
       `Environment fix failed: ${issue.title}`,
-      `Environment fix failed (${issue.code}): ${message}`
+      planningError
     );
 
-    recordActivity(task.id, task.assigned_agent_id, 'environment_fix_failed', `Environment fix failed: ${issue.title}`, {
+    const failureMetadata: EnvironmentFixMetadata = {
       issue,
       suggestion,
       command,
       error: message,
-    });
+    };
+    const failureActivityId = recordActivity(
+      task.id,
+      task.assigned_agent_id,
+      'environment_fix_failed',
+      `Environment fix failed: ${issue.title}`,
+      failureMetadata
+    );
+
+    try {
+      const failedTask = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [task.id]) || task;
+      const contextActivities = getRecentContextActivities(task.id);
+      const nextIssue = classifyEnvironmentIssueFromTexts(collectIssueText(failedTask, contextActivities, message)) || issue;
+      const recovery = buildRecoveryState(task.id, nextIssue);
+      const nextSuggestion = await suggestEnvironmentFixCommand({
+        task: failedTask,
+        issue: nextIssue,
+        activities: contextActivities,
+        requestText: message,
+        attemptedCommands: recovery.failedCommands,
+      });
+
+      if (nextSuggestion.canFixWithCommand && nextSuggestion.command) {
+        updateActivityMetadata(failureActivityId, {
+          ...failureMetadata,
+          nextSuggestion,
+        });
+        updateTaskState(
+          task.id,
+          `Environment fix failed: ${nextIssue.title}. Suggested next action ready.`,
+          planningError
+        );
+      }
+    } catch (suggestionError) {
+      console.error('[Environment Fix] Failed to suggest next recovery action:', suggestionError);
+    }
     return;
   }
 
@@ -239,6 +467,43 @@ function startEnvironmentFix(runConfig: EnvironmentFixRun): { command: string; s
   return { command, startedAt };
 }
 
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: taskId } = await params;
+
+  try {
+    const task = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
+    if (!task) {
+      return NextResponse.json({ error: 'Task not found' }, { status: 404 });
+    }
+
+    const activities = getRecentContextActivities(taskId);
+    const issue = classifyEnvironmentIssueFromTexts(collectIssueText(task, activities));
+    if (!issue) {
+      return NextResponse.json({
+        success: true,
+        issue: null,
+        recovery: null,
+        task,
+      });
+    }
+
+    return NextResponse.json({
+      success: true,
+      issue,
+      recovery: buildRecoveryState(taskId, issue),
+      task,
+    });
+  } catch (error) {
+    console.error('[Environment Fix] Failed to load recovery state:', error);
+    return NextResponse.json({
+      error: error instanceof Error ? error.message : 'Failed to load environment recovery state',
+    }, { status: 500 });
+  }
+}
+
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
@@ -253,6 +518,7 @@ export async function POST(
       approvedCommand?: string;
       userProvidedCommand?: boolean;
       autoSuggestCommand?: boolean;
+      suggestOnly?: boolean;
     }));
     const task = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
 
@@ -264,15 +530,7 @@ export async function POST(
       return NextResponse.json({ error: 'Completed tasks cannot be retried.' }, { status: 409 });
     }
 
-    const activities = queryAll<RecentActivity>(
-      `SELECT created_at, activity_type, message, metadata
-       FROM task_activities
-       WHERE task_id = ?
-         AND activity_type IN ('environment_blocked', 'status_changed')
-       ORDER BY created_at DESC
-       LIMIT 10`,
-      [taskId]
-    );
+    const activities = getRecentContextActivities(taskId);
     const issue = classifyEnvironmentIssueFromTexts(collectIssueText(task, activities, body.reason));
 
     if (!issue) {
@@ -288,7 +546,8 @@ export async function POST(
       }, { status: 409 });
     }
 
-    const runningFix = getRunningEnvironmentFix(taskId);
+    let recovery = buildRecoveryState(taskId, issue);
+    const runningFix = recovery.runningFix;
     if (runningFix) {
       const runningTask = task.status_reason?.toLowerCase().startsWith('environment fix running:')
         ? task
@@ -302,6 +561,7 @@ export async function POST(
         issue,
         suggestion: null,
         fix: { command: runningFix.command, startedAt: runningFix.startedAt },
+        recovery,
         task: runningTask,
       }, { status: 202 });
     }
@@ -318,6 +578,7 @@ export async function POST(
           issue,
           activities,
           requestText: body.reason,
+          attemptedCommands: recovery.failedCommands,
         });
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Failed to suggest an environment command';
@@ -333,15 +594,49 @@ export async function POST(
       }
     }
 
+    if (body.suggestOnly) {
+      const suggestedRecovery = suggestion?.canFixWithCommand && suggestion.command
+        ? { ...recovery, nextSuggestion: suggestion }
+        : recovery;
+
+      if (!suggestion?.canFixWithCommand || !suggestion.command) {
+        return NextResponse.json({
+          success: false,
+          error: suggestion?.rationale || 'Mission Control could not determine a new setup command to run.',
+          issue,
+          suggestion,
+          recovery: suggestedRecovery,
+        }, { status: 409 });
+      }
+
+      return NextResponse.json({
+        success: true,
+        issue,
+        suggestion,
+        recovery: suggestedRecovery,
+        task,
+      });
+    }
+
     if (!commandToRun) {
       return NextResponse.json({
         error: 'Mission Control could not determine a setup command to run.',
         issue,
         suggestion,
+        recovery,
       }, { status: 409 });
     }
 
-    if (approvedCommand && hasEnvironmentIssueCommand(issue) && approvedCommand !== issue.action.command) {
+    if (!body.userProvidedCommand && hasFailedCommand(recovery, commandToRun)) {
+      return NextResponse.json({
+        error: 'That exact command already failed for this task. Review the recovery history or approve a different command.',
+        issue,
+        suggestion,
+        recovery,
+      }, { status: 409 });
+    }
+
+    if (approvedCommand && hasEnvironmentIssueCommand(issue) && !body.userProvidedCommand && approvedCommand !== issue.action.command) {
       return NextResponse.json({
         error: 'The command must be explicitly approved and must match the command shown in the UI.',
         issue,
@@ -364,6 +659,7 @@ export async function POST(
       retry: body.retry !== false,
     });
     const updatedTask = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
+    recovery = buildRecoveryState(taskId, issue);
 
     return NextResponse.json({
       success: true,
@@ -374,6 +670,7 @@ export async function POST(
       issue,
       suggestion,
       fix: fixRun,
+      recovery,
       task: updatedTask,
     }, { status: 202 });
   } catch (error) {

--- a/src/app/api/tasks/[id]/environment/fix/route.ts
+++ b/src/app/api/tasks/[id]/environment/fix/route.ts
@@ -1,5 +1,4 @@
-import { exec } from 'child_process';
-import { promisify } from 'util';
+import { exec, type ExecException } from 'child_process';
 import { NextRequest, NextResponse } from 'next/server';
 import { queryAll, queryOne, run } from '@/lib/db';
 import { broadcast } from '@/lib/events';
@@ -11,15 +10,18 @@ import {
 import {
   classifyEnvironmentIssueFromTexts,
   hasEnvironmentIssueCommand,
+  type EnvironmentIssue,
   type EnvironmentIssueCode,
 } from '@/lib/environment-issues';
 import type { Task } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
 
-const execAsync = promisify(exec);
 const COMMAND_TIMEOUT_MS = 10 * 60 * 1000;
+const RUNNING_STALE_MS = COMMAND_TIMEOUT_MS + 60 * 1000;
 const MAX_OUTPUT_CHARS = 6000;
+
+const runningEnvironmentFixes = new Map<string, { command: string; startedAt: string }>();
 
 interface RecentActivity {
   created_at?: string;
@@ -28,40 +30,40 @@ interface RecentActivity {
   metadata?: string | null;
 }
 
+interface EnvironmentFixActivity {
+  created_at: string;
+  activity_type: string;
+  message: string;
+  metadata?: string | null;
+}
+
+interface EnvironmentFixRun {
+  task: Task;
+  issue: EnvironmentIssue;
+  suggestion: EnvironmentCommandSuggestion | null;
+  command: string;
+  commandSource: string;
+  retry: boolean;
+}
+
 function compactOutput(value: string | Buffer | undefined): string {
   const text = Buffer.isBuffer(value) ? value.toString('utf8') : value || '';
   return text.length > MAX_OUTPUT_CHARS ? text.slice(-MAX_OUTPUT_CHARS) : text;
 }
 
-async function runCommand(command: string, cwd?: string) {
-  try {
-    const result = await execAsync(command, {
-      cwd,
-      timeout: COMMAND_TIMEOUT_MS,
-      maxBuffer: 1024 * 1024 * 8,
-      env: process.env,
-    });
-
-    return {
-      stdout: compactOutput(result.stdout),
-      stderr: compactOutput(result.stderr),
-    };
-  } catch (error) {
-    const err = error as NodeJS.ErrnoException & { stdout?: string | Buffer; stderr?: string | Buffer };
-    const stderr = compactOutput(err.stderr);
-    const stdout = compactOutput(err.stdout);
-    const detail = [stderr, stdout, err.message].filter(Boolean).join('\n').trim();
-    throw new Error(detail || `Command failed: ${command}`);
-  }
-}
-
-async function runEnvironmentFix(task: Task, approvedCommand: string) {
-  const result = await runCommand(approvedCommand, task.workspace_path || undefined);
-  return {
-    command: approvedCommand,
-    stdout: result.stdout,
-    stderr: result.stderr,
-  };
+function formatCommandFailure(
+  command: string,
+  error: ExecException,
+  stdout: string | Buffer | undefined,
+  stderr: string | Buffer | undefined
+): string {
+  const stderrText = compactOutput(stderr);
+  const stdoutText = compactOutput(stdout);
+  const timeoutText = error.killed
+    ? `Command did not finish before the ${Math.round(COMMAND_TIMEOUT_MS / 1000)}s timeout and was stopped.`
+    : '';
+  const detail = [stderrText, stdoutText, timeoutText, error.message].filter(Boolean).join('\n').trim();
+  return detail || `Command failed: ${command}`;
 }
 
 function collectIssueText(task: Task, activities: RecentActivity[], requestText?: string): Array<string | null | undefined> {
@@ -79,6 +81,162 @@ function recordActivity(taskId: string, agentId: string | null, type: string, me
      VALUES (?, ?, ?, ?, ?, ?, ?)`,
     [crypto.randomUUID(), taskId, agentId, type, message, metadata ? JSON.stringify(metadata) : null, new Date().toISOString()]
   );
+}
+
+function getRunningEnvironmentFix(taskId: string): { command: string; startedAt: string } | null {
+  const inMemory = runningEnvironmentFixes.get(taskId);
+  if (inMemory) return inMemory;
+
+  const latest = queryOne<EnvironmentFixActivity>(
+    `SELECT created_at, activity_type, message, metadata
+     FROM task_activities
+     WHERE task_id = ?
+       AND activity_type IN ('environment_fix_started', 'environment_fix_failed', 'environment_fix_completed', 'environment_fix_retry_failed')
+     ORDER BY created_at DESC
+     LIMIT 1`,
+    [taskId]
+  );
+
+  if (!latest || latest.activity_type !== 'environment_fix_started') return null;
+
+  const startedAtMs = new Date(latest.created_at).getTime();
+  if (!Number.isFinite(startedAtMs) || Date.now() - startedAtMs > RUNNING_STALE_MS) return null;
+
+  let command = latest.message.replace(/^Running approved environment command:\s*/i, '').trim();
+  try {
+    const metadata = latest.metadata ? JSON.parse(latest.metadata) as { command?: string } : null;
+    if (metadata?.command) command = metadata.command;
+  } catch {
+    // Ignore malformed historical metadata; the activity message still carries the command.
+  }
+
+  return { command, startedAt: latest.created_at };
+}
+
+function updateTaskState(taskId: string, statusReason: string, planningError?: string | null): Task | null {
+  if (planningError === undefined) {
+    run(
+      `UPDATE tasks
+       SET status_reason = ?,
+           updated_at = ?
+       WHERE id = ?`,
+      [statusReason, new Date().toISOString(), taskId]
+    );
+  } else {
+    run(
+      `UPDATE tasks
+       SET planning_dispatch_error = ?,
+           status_reason = ?,
+           updated_at = ?
+       WHERE id = ?`,
+      [planningError, statusReason, new Date().toISOString(), taskId]
+    );
+  }
+
+  const updatedTask = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
+  if (updatedTask) broadcast({ type: 'task_updated', payload: updatedTask });
+  return updatedTask ?? null;
+}
+
+async function finishEnvironmentFix(
+  runConfig: EnvironmentFixRun,
+  error: ExecException | null,
+  stdout: string | Buffer | undefined,
+  stderr: string | Buffer | undefined
+) {
+  const { task, issue, suggestion, command, retry } = runConfig;
+  runningEnvironmentFixes.delete(task.id);
+
+  if (error) {
+    const message = formatCommandFailure(command, error, stdout, stderr);
+    updateTaskState(
+      task.id,
+      `Environment fix failed: ${issue.title}`,
+      `Environment fix failed (${issue.code}): ${message}`
+    );
+
+    recordActivity(task.id, task.assigned_agent_id, 'environment_fix_failed', `Environment fix failed: ${issue.title}`, {
+      issue,
+      suggestion,
+      command,
+      error: message,
+    });
+    return;
+  }
+
+  const stdoutText = compactOutput(stdout);
+  const stderrText = compactOutput(stderr);
+  recordActivity(task.id, task.assigned_agent_id, 'environment_fix_completed', `Environment fix completed: ${issue.title}`, {
+    issue,
+    suggestion,
+    command,
+    stdout: stdoutText,
+    stderr: stderrText,
+  });
+
+  updateTaskState(
+    task.id,
+    retry
+      ? `Environment fix completed: ${issue.title}. Retrying assigned agent.`
+      : `Environment fix completed: ${issue.title}.`,
+    null
+  );
+
+  if (!retry) return;
+
+  const retryResult = await dispatchTaskFromServer(task.id);
+  if (!retryResult.success) {
+    updateTaskState(
+      task.id,
+      `Environment fix completed: ${issue.title}, but retry failed.`,
+      retryResult.error || 'Environment fixed, but retry failed.'
+    );
+    recordActivity(task.id, task.assigned_agent_id, 'environment_fix_retry_failed', `Environment fix retry failed: ${issue.title}`, {
+      issue,
+      suggestion,
+      command,
+      error: retryResult.error || 'Environment fixed, but retry failed.',
+    });
+    return;
+  }
+
+  const updatedTask = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [task.id]);
+  if (updatedTask) broadcast({ type: 'task_updated', payload: updatedTask });
+}
+
+function startEnvironmentFix(runConfig: EnvironmentFixRun): { command: string; startedAt: string } {
+  const startedAt = new Date().toISOString();
+  const { task, issue, suggestion, command, commandSource } = runConfig;
+  runningEnvironmentFixes.set(task.id, { command, startedAt });
+
+  recordActivity(task.id, task.assigned_agent_id, 'environment_fix_started', `Running approved environment command: ${command}`, {
+    issue,
+    suggestion,
+    command,
+    commandSource,
+    timeoutMs: COMMAND_TIMEOUT_MS,
+  });
+
+  updateTaskState(task.id, `Environment fix running: ${issue.title}`);
+
+  exec(
+    command,
+    {
+      cwd: task.workspace_path || undefined,
+      timeout: COMMAND_TIMEOUT_MS,
+      killSignal: 'SIGTERM',
+      maxBuffer: 1024 * 1024 * 8,
+      env: process.env,
+    },
+    (error, stdout, stderr) => {
+      void finishEnvironmentFix(runConfig, error, stdout, stderr).catch((finishError) => {
+        runningEnvironmentFixes.delete(task.id);
+        console.error('[Environment Fix] Failed to finish background command:', finishError);
+      });
+    }
+  );
+
+  return { command, startedAt };
 }
 
 export async function POST(
@@ -130,6 +288,24 @@ export async function POST(
       }, { status: 409 });
     }
 
+    const runningFix = getRunningEnvironmentFix(taskId);
+    if (runningFix) {
+      const runningTask = task.status_reason?.toLowerCase().startsWith('environment fix running:')
+        ? task
+        : updateTaskState(taskId, `Environment fix running: ${issue.title}`);
+
+      return NextResponse.json({
+        success: true,
+        running: true,
+        fixed: false,
+        retried: false,
+        issue,
+        suggestion: null,
+        fix: { command: runningFix.command, startedAt: runningFix.startedAt },
+        task: runningTask,
+      }, { status: 202 });
+    }
+
     const approvedCommand = body.approvedCommand?.trim();
     let commandToRun = approvedCommand;
     let commandSource = hasEnvironmentIssueCommand(issue) ? issue.action.commandSource || 'detected' : 'user_input';
@@ -179,94 +355,27 @@ export async function POST(
       }, { status: 409 });
     }
 
-    recordActivity(taskId, task.assigned_agent_id, 'environment_fix_started', `Running approved environment command: ${commandToRun}`, {
+    const fixRun = startEnvironmentFix({
+      task,
       issue,
       suggestion,
+      command: commandToRun,
       commandSource,
+      retry: body.retry !== false,
     });
-
-    let fixResult: Awaited<ReturnType<typeof runEnvironmentFix>>;
-    try {
-      fixResult = await runEnvironmentFix(task, commandToRun);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Environment fix failed';
-      run(
-        `UPDATE tasks
-         SET planning_dispatch_error = ?,
-             status_reason = ?,
-             updated_at = ?
-         WHERE id = ?`,
-        [`Environment fix failed (${issue.code}): ${message}`, `Environment fix failed: ${issue.title}`, new Date().toISOString(), taskId]
-      );
-      recordActivity(taskId, task.assigned_agent_id, 'environment_fix_failed', `Environment fix failed: ${issue.title}`, {
-        issue,
-        suggestion,
-        error: message,
-      });
-
-      const failedTask = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
-      if (failedTask) broadcast({ type: 'task_updated', payload: failedTask });
-
-      return NextResponse.json({
-        success: false,
-        fixed: false,
-        issue,
-        suggestion,
-        error: message,
-        task: failedTask,
-      }, { status: 500 });
-    }
-
-    recordActivity(taskId, task.assigned_agent_id, 'environment_fix_completed', `Environment fix completed: ${issue.title}`, {
-      issue,
-      suggestion,
-      command: fixResult.command,
-      stdout: fixResult.stdout,
-      stderr: fixResult.stderr,
-    });
-
-    run(
-      `UPDATE tasks
-       SET planning_dispatch_error = NULL,
-           status_reason = ?,
-           updated_at = ?
-       WHERE id = ?`,
-      [`Environment fix completed: ${issue.title}. Retrying assigned agent.`, new Date().toISOString(), taskId]
-    );
-
-    let retryResult: Awaited<ReturnType<typeof dispatchTaskFromServer>> | null = null;
-    if (body.retry !== false) {
-      retryResult = await dispatchTaskFromServer(taskId);
-    }
-
     const updatedTask = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
-    if (updatedTask) {
-      broadcast({ type: 'task_updated', payload: updatedTask });
-    }
-
-    if (retryResult && !retryResult.success) {
-      return NextResponse.json({
-        success: false,
-        fixed: true,
-        retried: false,
-        issue,
-        suggestion,
-        fix: fixResult,
-        error: retryResult.error || 'Environment fixed, but retry failed.',
-        task: updatedTask,
-      }, { status: retryResult.status || 502 });
-    }
 
     return NextResponse.json({
       success: true,
-      fixed: true,
-      retried: body.retry !== false,
+      running: true,
+      started: true,
+      fixed: false,
+      retried: false,
       issue,
       suggestion,
-      fix: fixResult,
-      retry: retryResult,
+      fix: fixRun,
       task: updatedTask,
-    });
+    }, { status: 202 });
   } catch (error) {
     console.error('[Environment Fix] Failed:', error);
     return NextResponse.json({

--- a/src/app/api/tasks/[id]/environment/fix/route.ts
+++ b/src/app/api/tasks/[id]/environment/fix/route.ts
@@ -1,0 +1,276 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { NextRequest, NextResponse } from 'next/server';
+import { queryAll, queryOne, run } from '@/lib/db';
+import { broadcast } from '@/lib/events';
+import { dispatchTaskFromServer } from '@/lib/server-dispatch';
+import {
+  suggestEnvironmentFixCommand,
+  type EnvironmentCommandSuggestion,
+} from '@/lib/environment-command-suggestion';
+import {
+  classifyEnvironmentIssueFromTexts,
+  hasEnvironmentIssueCommand,
+  type EnvironmentIssueCode,
+} from '@/lib/environment-issues';
+import type { Task } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+const execAsync = promisify(exec);
+const COMMAND_TIMEOUT_MS = 10 * 60 * 1000;
+const MAX_OUTPUT_CHARS = 6000;
+
+interface RecentActivity {
+  created_at?: string;
+  activity_type?: string;
+  message: string;
+  metadata?: string | null;
+}
+
+function compactOutput(value: string | Buffer | undefined): string {
+  const text = Buffer.isBuffer(value) ? value.toString('utf8') : value || '';
+  return text.length > MAX_OUTPUT_CHARS ? text.slice(-MAX_OUTPUT_CHARS) : text;
+}
+
+async function runCommand(command: string, cwd?: string) {
+  try {
+    const result = await execAsync(command, {
+      cwd,
+      timeout: COMMAND_TIMEOUT_MS,
+      maxBuffer: 1024 * 1024 * 8,
+      env: process.env,
+    });
+
+    return {
+      stdout: compactOutput(result.stdout),
+      stderr: compactOutput(result.stderr),
+    };
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException & { stdout?: string | Buffer; stderr?: string | Buffer };
+    const stderr = compactOutput(err.stderr);
+    const stdout = compactOutput(err.stdout);
+    const detail = [stderr, stdout, err.message].filter(Boolean).join('\n').trim();
+    throw new Error(detail || `Command failed: ${command}`);
+  }
+}
+
+async function runEnvironmentFix(task: Task, approvedCommand: string) {
+  const result = await runCommand(approvedCommand, task.workspace_path || undefined);
+  return {
+    command: approvedCommand,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+function collectIssueText(task: Task, activities: RecentActivity[], requestText?: string): Array<string | null | undefined> {
+  return [
+    requestText,
+    task.status_reason,
+    task.planning_dispatch_error,
+    ...activities.flatMap((activity) => [activity.message, activity.metadata || undefined]),
+  ];
+}
+
+function recordActivity(taskId: string, agentId: string | null, type: string, message: string, metadata?: Record<string, unknown>) {
+  run(
+    `INSERT INTO task_activities (id, task_id, agent_id, activity_type, message, metadata, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    [crypto.randomUUID(), taskId, agentId, type, message, metadata ? JSON.stringify(metadata) : null, new Date().toISOString()]
+  );
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: taskId } = await params;
+
+  try {
+    const body = await request.json().catch(() => ({} as {
+      code?: EnvironmentIssueCode;
+      retry?: boolean;
+      reason?: string;
+      approvedCommand?: string;
+      userProvidedCommand?: boolean;
+      autoSuggestCommand?: boolean;
+    }));
+    const task = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
+
+    if (!task) {
+      return NextResponse.json({ error: 'Task not found' }, { status: 404 });
+    }
+
+    if (task.status === 'done') {
+      return NextResponse.json({ error: 'Completed tasks cannot be retried.' }, { status: 409 });
+    }
+
+    const activities = queryAll<RecentActivity>(
+      `SELECT created_at, activity_type, message, metadata
+       FROM task_activities
+       WHERE task_id = ?
+         AND activity_type IN ('environment_blocked', 'status_changed')
+       ORDER BY created_at DESC
+       LIMIT 10`,
+      [taskId]
+    );
+    const issue = classifyEnvironmentIssueFromTexts(collectIssueText(task, activities, body.reason));
+
+    if (!issue) {
+      return NextResponse.json({
+        error: 'No known environment issue is currently recorded for this task.',
+      }, { status: 400 });
+    }
+
+    if (body.code && body.code !== issue.code) {
+      return NextResponse.json({
+        error: `Recorded issue is ${issue.code}, not ${body.code}. Refresh the task and try again.`,
+        issue,
+      }, { status: 409 });
+    }
+
+    const approvedCommand = body.approvedCommand?.trim();
+    let commandToRun = approvedCommand;
+    let commandSource = hasEnvironmentIssueCommand(issue) ? issue.action.commandSource || 'detected' : 'user_input';
+    let suggestion: EnvironmentCommandSuggestion | null = null;
+
+    if (!commandToRun && body.autoSuggestCommand) {
+      try {
+        suggestion = await suggestEnvironmentFixCommand({
+          task,
+          issue,
+          activities,
+          requestText: body.reason,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Failed to suggest an environment command';
+        return NextResponse.json({
+          error: `Could not determine a setup command: ${message}`,
+          issue,
+        }, { status: 502 });
+      }
+
+      if (suggestion.command) {
+        commandToRun = suggestion.command;
+        commandSource = 'agent_suggestion';
+      }
+    }
+
+    if (!commandToRun) {
+      return NextResponse.json({
+        error: 'Mission Control could not determine a setup command to run.',
+        issue,
+        suggestion,
+      }, { status: 409 });
+    }
+
+    if (approvedCommand && hasEnvironmentIssueCommand(issue) && approvedCommand !== issue.action.command) {
+      return NextResponse.json({
+        error: 'The command must be explicitly approved and must match the command shown in the UI.',
+        issue,
+      }, { status: 409 });
+    }
+
+    if (!hasEnvironmentIssueCommand(issue) && !body.userProvidedCommand && !body.autoSuggestCommand) {
+      return NextResponse.json({
+        error: 'Manual environment fixes require a user-provided or agent-suggested command.',
+        issue,
+      }, { status: 409 });
+    }
+
+    recordActivity(taskId, task.assigned_agent_id, 'environment_fix_started', `Running approved environment command: ${commandToRun}`, {
+      issue,
+      suggestion,
+      commandSource,
+    });
+
+    let fixResult: Awaited<ReturnType<typeof runEnvironmentFix>>;
+    try {
+      fixResult = await runEnvironmentFix(task, commandToRun);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Environment fix failed';
+      run(
+        `UPDATE tasks
+         SET planning_dispatch_error = ?,
+             status_reason = ?,
+             updated_at = ?
+         WHERE id = ?`,
+        [`Environment fix failed (${issue.code}): ${message}`, `Environment fix failed: ${issue.title}`, new Date().toISOString(), taskId]
+      );
+      recordActivity(taskId, task.assigned_agent_id, 'environment_fix_failed', `Environment fix failed: ${issue.title}`, {
+        issue,
+        suggestion,
+        error: message,
+      });
+
+      const failedTask = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
+      if (failedTask) broadcast({ type: 'task_updated', payload: failedTask });
+
+      return NextResponse.json({
+        success: false,
+        fixed: false,
+        issue,
+        suggestion,
+        error: message,
+        task: failedTask,
+      }, { status: 500 });
+    }
+
+    recordActivity(taskId, task.assigned_agent_id, 'environment_fix_completed', `Environment fix completed: ${issue.title}`, {
+      issue,
+      suggestion,
+      command: fixResult.command,
+      stdout: fixResult.stdout,
+      stderr: fixResult.stderr,
+    });
+
+    run(
+      `UPDATE tasks
+       SET planning_dispatch_error = NULL,
+           status_reason = ?,
+           updated_at = ?
+       WHERE id = ?`,
+      [`Environment fix completed: ${issue.title}. Retrying assigned agent.`, new Date().toISOString(), taskId]
+    );
+
+    let retryResult: Awaited<ReturnType<typeof dispatchTaskFromServer>> | null = null;
+    if (body.retry !== false) {
+      retryResult = await dispatchTaskFromServer(taskId);
+    }
+
+    const updatedTask = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
+    if (updatedTask) {
+      broadcast({ type: 'task_updated', payload: updatedTask });
+    }
+
+    if (retryResult && !retryResult.success) {
+      return NextResponse.json({
+        success: false,
+        fixed: true,
+        retried: false,
+        issue,
+        suggestion,
+        fix: fixResult,
+        error: retryResult.error || 'Environment fixed, but retry failed.',
+        task: updatedTask,
+      }, { status: retryResult.status || 502 });
+    }
+
+    return NextResponse.json({
+      success: true,
+      fixed: true,
+      retried: body.retry !== false,
+      issue,
+      suggestion,
+      fix: fixResult,
+      retry: retryResult,
+      task: updatedTask,
+    });
+  } catch (error) {
+    console.error('[Environment Fix] Failed:', error);
+    return NextResponse.json({
+      error: error instanceof Error ? error.message : 'Environment fix failed',
+    }, { status: 500 });
+  }
+}

--- a/src/app/api/tasks/[id]/environment/fix/route.ts
+++ b/src/app/api/tasks/[id]/environment/fix/route.ts
@@ -1,4 +1,5 @@
 import { exec, type ExecException } from 'child_process';
+import { createHash } from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
 import { queryAll, queryOne, run } from '@/lib/db';
 import { broadcast } from '@/lib/events';
@@ -45,6 +46,7 @@ interface EnvironmentFixRun {
   command: string;
   commandSource: string;
   retry: boolean;
+  generation: number;
 }
 
 interface EnvironmentFixMetadata {
@@ -54,6 +56,9 @@ interface EnvironmentFixMetadata {
   command?: string;
   commandSource?: string;
   error?: string;
+  failureFingerprint?: string;
+  generation?: number;
+  repeatedFailure?: boolean;
   stdout?: string;
   stderr?: string;
   timeoutMs?: number;
@@ -67,8 +72,11 @@ interface EnvironmentRecoveryAttempt {
   status: EnvironmentRecoveryAttemptStatus;
   command?: string;
   commandSource?: string;
+  generation: number;
   message: string;
   error?: string;
+  failureFingerprint?: string;
+  repeatedFailure?: boolean;
   stdout?: string;
   stderr?: string;
   suggestion?: EnvironmentCommandSuggestion | null;
@@ -80,7 +88,9 @@ interface EnvironmentRecoveryState {
   running: boolean;
   runningFix?: { command: string; startedAt: string };
   attempts: EnvironmentRecoveryAttempt[];
+  generation: number;
   failedCommands: string[];
+  repeatedFailures: Array<{ command: string; generation: number; firstGeneration: number; failureFingerprint: string }>;
   nextSuggestion?: EnvironmentCommandSuggestion | null;
 }
 
@@ -100,6 +110,26 @@ function safeJsonParse<T = unknown>(value: string | null | undefined): T | null 
   } catch {
     return null;
   }
+}
+
+function normalizeFailureText(value: string | undefined): string {
+  return (value || '')
+    .toLowerCase()
+    .replace(/\b\d{4}-\d{2}-\d{2}[t\s]\d{2}:\d{2}:\d{2}(?:\.\d+)?z?\b/g, '<timestamp>')
+    .replace(/\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/g, '<uuid>')
+    .replace(/\b0x[0-9a-f]+\b/g, '<hex>')
+    .replace(/\[[^\]]*?\d+:\d+[^\]]*?\]/g, '[process]')
+    .replace(/\bpid\s+\d+\b/g, 'pid <num>')
+    .replace(/\b\d{4,}\b/g, '<num>')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 4000);
+}
+
+function createFailureFingerprint(value: string | undefined): string | undefined {
+  const normalized = normalizeFailureText(value);
+  if (!normalized) return undefined;
+  return createHash('sha256').update(normalized).digest('hex').slice(0, 16);
 }
 
 function formatCommandFailure(
@@ -203,10 +233,14 @@ function buildRecoveryState(taskId: string, issue: EnvironmentIssue): Environmen
   const runningFix = getRunningEnvironmentFix(taskId);
   const activities = getEnvironmentFixActivities(taskId).reverse();
   const attempts: EnvironmentRecoveryAttempt[] = [];
+  const firstFailureByCommandAndFingerprint = new Map<string, { generation: number }>();
+  const repeatedFailures: EnvironmentRecoveryState['repeatedFailures'] = [];
+  let generation = 0;
 
   for (const activity of activities) {
     const metadata = safeJsonParse<EnvironmentFixMetadata>(activity.metadata);
     const command = commandFromActivity(activity, metadata);
+    const metadataGeneration = typeof metadata?.generation === 'number' ? metadata.generation : undefined;
 
     if (activity.activity_type === 'environment_fix_started') {
       attempts.push({
@@ -215,6 +249,7 @@ function buildRecoveryState(taskId: string, issue: EnvironmentIssue): Environmen
         status: 'running',
         command,
         commandSource: metadata?.commandSource,
+        generation: metadataGeneration ?? generation,
         message: activity.message,
         suggestion: metadata?.suggestion,
       });
@@ -232,11 +267,46 @@ function buildRecoveryState(taskId: string, issue: EnvironmentIssue): Environmen
         normalizeCommand(attempt.command) === normalizeCommand(command)
       ))
       : undefined;
+    const attemptGeneration = metadataGeneration ?? matchingAttempt?.generation ?? generation;
+    const failureFingerprint = metadata?.failureFingerprint || (
+      status === 'failed' || status === 'retry_failed'
+        ? createFailureFingerprint(metadata?.error || metadata?.stderr || metadata?.stdout || activity.message)
+        : undefined
+    );
+    let repeatedFailure = Boolean(metadata?.repeatedFailure);
+    const normalizedCommand = normalizeCommand(command);
+
+    if ((status === 'failed' || status === 'retry_failed') && normalizedCommand && failureFingerprint) {
+      const key = `${normalizedCommand}\0${failureFingerprint}`;
+      const firstFailure = firstFailureByCommandAndFingerprint.get(key);
+      if (firstFailure && firstFailure.generation < attemptGeneration) {
+        repeatedFailure = true;
+        if (!repeatedFailures.some((failure) => (
+          failure.command === normalizedCommand &&
+          failure.failureFingerprint === failureFingerprint &&
+          failure.generation === attemptGeneration
+        ))) {
+          repeatedFailures.push({
+            command: normalizedCommand,
+            generation: attemptGeneration,
+            firstGeneration: firstFailure.generation,
+            failureFingerprint,
+          });
+        }
+      }
+      if (!firstFailure) {
+        firstFailureByCommandAndFingerprint.set(key, { generation: attemptGeneration });
+      }
+    }
+
     const patch: Partial<EnvironmentRecoveryAttempt> = {
       status,
       message: activity.message,
       command,
+      generation: attemptGeneration,
       error: metadata?.error,
+      failureFingerprint,
+      repeatedFailure,
       stdout: metadata?.stdout,
       stderr: metadata?.stderr,
       suggestion: metadata?.suggestion,
@@ -252,12 +322,19 @@ function buildRecoveryState(taskId: string, issue: EnvironmentIssue): Environmen
         status,
         message: activity.message,
         command,
+        generation: attemptGeneration,
         error: metadata?.error,
+        failureFingerprint,
+        repeatedFailure,
         stdout: metadata?.stdout,
         stderr: metadata?.stderr,
         suggestion: metadata?.suggestion,
         nextSuggestion: metadata?.nextSuggestion,
       });
+    }
+
+    if (status === 'completed') {
+      generation = Math.max(generation, attemptGeneration + 1);
     }
   }
 
@@ -272,21 +349,32 @@ function buildRecoveryState(taskId: string, issue: EnvironmentIssue): Environmen
 
   const failedCommands = Array.from(new Set(
     attempts
-      .filter((attempt) => attempt.status === 'failed' || attempt.status === 'retry_failed')
+      .filter((attempt) => (
+        (attempt.status === 'failed' || attempt.status === 'retry_failed') &&
+        attempt.generation === generation
+      ))
       .map((attempt) => normalizeCommand(attempt.command))
       .filter((command): command is string => Boolean(command))
   ));
+  const failedCommandSet = new Set(failedCommands);
   const latestNextSuggestion = [...attempts]
     .reverse()
+    .filter((attempt) => attempt.generation === generation)
     .map((attempt) => attempt.nextSuggestion)
-    .find((suggestion) => suggestion?.canFixWithCommand && suggestion.command);
+    .find((suggestion) => (
+      suggestion?.canFixWithCommand &&
+      suggestion.command &&
+      !failedCommandSet.has(normalizeCommand(suggestion.command) || '')
+    ));
 
   return {
     issue,
     running: Boolean(runningFix),
     runningFix: runningFix || undefined,
     attempts: attempts.reverse(),
+    generation,
     failedCommands,
+    repeatedFailures,
     nextSuggestion: latestNextSuggestion || null,
   };
 }
@@ -336,11 +424,12 @@ async function finishEnvironmentFix(
   stdout: string | Buffer | undefined,
   stderr: string | Buffer | undefined
 ) {
-  const { task, issue, suggestion, command, retry } = runConfig;
+  const { task, issue, suggestion, command, retry, generation } = runConfig;
   runningEnvironmentFixes.delete(task.id);
 
   if (error) {
     const message = formatCommandFailure(command, error, stdout, stderr);
+    const failureFingerprint = createFailureFingerprint(message);
     const planningError = `Environment fix failed (${issue.code}): ${message}`;
     updateTaskState(
       task.id,
@@ -353,6 +442,8 @@ async function finishEnvironmentFix(
       suggestion,
       command,
       error: message,
+      failureFingerprint,
+      generation,
     };
     const failureActivityId = recordActivity(
       task.id,
@@ -372,7 +463,7 @@ async function finishEnvironmentFix(
         issue: nextIssue,
         activities: contextActivities,
         requestText: message,
-        attemptedCommands: recovery.failedCommands,
+        blockedCommands: recovery.failedCommands,
       });
 
       if (nextSuggestion.canFixWithCommand && nextSuggestion.command) {
@@ -383,6 +474,16 @@ async function finishEnvironmentFix(
         updateTaskState(
           task.id,
           `Environment fix failed: ${nextIssue.title}. Suggested next action ready.`,
+          planningError
+        );
+      } else if (recovery.repeatedFailures.some((failure) => (
+        failure.command === normalizeCommand(command) &&
+        failure.failureFingerprint === failureFingerprint &&
+        failure.generation === generation
+      ))) {
+        updateTaskState(
+          task.id,
+          `Environment fix failed again with the same error: ${nextIssue.title}. Manual intervention needed.`,
           planningError
         );
       }
@@ -398,6 +499,7 @@ async function finishEnvironmentFix(
     issue,
     suggestion,
     command,
+    generation,
     stdout: stdoutText,
     stderr: stderrText,
   });
@@ -423,7 +525,9 @@ async function finishEnvironmentFix(
       issue,
       suggestion,
       command,
+      generation,
       error: retryResult.error || 'Environment fixed, but retry failed.',
+      failureFingerprint: createFailureFingerprint(retryResult.error || 'Environment fixed, but retry failed.'),
     });
     return;
   }
@@ -434,7 +538,7 @@ async function finishEnvironmentFix(
 
 function startEnvironmentFix(runConfig: EnvironmentFixRun): { command: string; startedAt: string } {
   const startedAt = new Date().toISOString();
-  const { task, issue, suggestion, command, commandSource } = runConfig;
+  const { task, issue, suggestion, command, commandSource, generation } = runConfig;
   runningEnvironmentFixes.set(task.id, { command, startedAt });
 
   recordActivity(task.id, task.assigned_agent_id, 'environment_fix_started', `Running approved environment command: ${command}`, {
@@ -442,6 +546,7 @@ function startEnvironmentFix(runConfig: EnvironmentFixRun): { command: string; s
     suggestion,
     command,
     commandSource,
+    generation,
     timeoutMs: COMMAND_TIMEOUT_MS,
   });
 
@@ -578,7 +683,7 @@ export async function POST(
           issue,
           activities,
           requestText: body.reason,
-          attemptedCommands: recovery.failedCommands,
+          blockedCommands: recovery.failedCommands,
         });
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Failed to suggest an environment command';
@@ -657,6 +762,7 @@ export async function POST(
       command: commandToRun,
       commandSource,
       retry: body.retry !== false,
+      generation: recovery.generation,
     });
     const updatedTask = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
     recovery = buildRecoveryState(taskId, issue);

--- a/src/app/api/tasks/[id]/fail/route.ts
+++ b/src/app/api/tasks/[id]/fail/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { queryOne } from '@/lib/db';
+import { queryOne, run } from '@/lib/db';
 import { handleStageFailure, drainQueue } from '@/lib/workflow-engine';
 import { notifyLearner } from '@/lib/learner';
+import { broadcast } from '@/lib/events';
+import { classifyEnvironmentIssue } from '@/lib/environment-issues';
 import type { Task } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -40,6 +42,47 @@ export async function POST(
         { error: `Cannot fail from status: ${task.status}. Must be in ${failableStatuses.join(', ')}` },
         { status: 400 }
       );
+    }
+
+    const environmentIssue = classifyEnvironmentIssue(reason);
+    if (environmentIssue) {
+      const now = new Date().toISOString();
+      const environmentMessage = `Environment action required: ${environmentIssue.userMessage}`;
+
+      run(
+        `UPDATE tasks
+         SET planning_dispatch_error = ?,
+             status_reason = ?,
+             updated_at = ?
+         WHERE id = ?`,
+        [`Environment blocked (${environmentIssue.code}): ${reason}`, environmentMessage, now, taskId]
+      );
+
+      run(
+        `INSERT INTO task_activities (id, task_id, agent_id, activity_type, message, metadata, created_at)
+         VALUES (?, ?, ?, 'environment_blocked', ?, ?, ?)`,
+        [
+          crypto.randomUUID(),
+          taskId,
+          task.assigned_agent_id || null,
+          environmentMessage,
+          JSON.stringify({ issue: environmentIssue, original_reason: reason }),
+          now,
+        ]
+      );
+
+      const updatedTask = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
+      if (updatedTask) {
+        broadcast({ type: 'task_updated', payload: updatedTask });
+      }
+
+      return NextResponse.json({
+        success: true,
+        environmentBlocked: true,
+        issue: environmentIssue,
+        message: environmentIssue.userMessage,
+        task: updatedTask,
+      });
     }
 
     // Notify learner about the failure

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -10,6 +10,7 @@ import { syncGatewayAgentsToCatalog } from '@/lib/agent-catalog-sync';
 import { triggerWorkspaceMerge } from '@/lib/workspace-isolation';
 import { cancelCodexRunsForTask } from '@/lib/codex/dispatch';
 import { UpdateTaskSchema } from '@/lib/validation';
+import { classifyEnvironmentIssueFromTexts } from '@/lib/environment-issues';
 import type { Task, UpdateTaskRequest, Agent, TaskDeliverable } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -44,10 +45,18 @@ export async function GET(
 ) {
   try {
     const { id } = await params;
-    const task = queryOne<Task>(
+    const task = queryOne<Task & { assigned_agent_name?: string; assigned_agent_emoji?: string; latest_activity_context?: string | null }>(
       `SELECT t.*,
         aa.name as assigned_agent_name,
-        aa.avatar_emoji as assigned_agent_emoji
+        aa.avatar_emoji as assigned_agent_emoji,
+        (
+          SELECT ta.message || ' ' || COALESCE(ta.metadata, '')
+          FROM task_activities ta
+          WHERE ta.task_id = t.id
+            AND ta.activity_type IN ('environment_blocked', 'status_changed')
+          ORDER BY ta.created_at DESC
+          LIMIT 1
+        ) as latest_activity_context
        FROM tasks t
        LEFT JOIN agents aa ON t.assigned_agent_id = aa.id
        WHERE t.id = ?`,
@@ -58,7 +67,25 @@ export async function GET(
       return NextResponse.json({ error: 'Task not found' }, { status: 404 });
     }
 
-    return NextResponse.json(task);
+    const environmentIssue = classifyEnvironmentIssueFromTexts([
+      task.status_reason,
+      task.planning_dispatch_error,
+      task.latest_activity_context,
+    ]);
+    const { latest_activity_context: _latestActivityContext, ...taskFields } = task;
+
+    return NextResponse.json({
+      ...taskFields,
+      status_reason: task.status_reason || (environmentIssue ? `Environment action required: ${environmentIssue.userMessage}` : task.status_reason),
+      planning_dispatch_error: task.planning_dispatch_error || (environmentIssue ? `Environment blocked (${environmentIssue.code})` : task.planning_dispatch_error),
+      assigned_agent: task.assigned_agent_id
+        ? {
+            id: task.assigned_agent_id,
+            name: task.assigned_agent_name,
+            avatar_emoji: task.assigned_agent_emoji,
+          }
+        : undefined,
+    });
   } catch (error) {
     console.error('Failed to fetch task:', error);
     return NextResponse.json({ error: 'Failed to fetch task' }, { status: 500 });

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -36,6 +36,8 @@ function clearTaskReferences(taskId: string): void {
   run('UPDATE conversations SET task_id = NULL WHERE task_id = ?', [taskId]);
   run('UPDATE knowledge_entries SET task_id = NULL WHERE task_id = ?', [taskId]);
   run('UPDATE product_skills SET created_by_task_id = NULL WHERE created_by_task_id = ?', [taskId]);
+  run('UPDATE ideas SET task_id = NULL WHERE task_id = ?', [taskId]);
+  run('UPDATE content_inventory SET task_id = NULL WHERE task_id = ?', [taskId]);
 }
 
 // GET /api/tasks/[id] - Get a single task

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -8,10 +8,34 @@ import { hasStageEvidence, canUseBoardOverride, auditBoardOverride, taskCanBeDon
 import { updateConvoyProgress, checkConvoyCompletion } from '@/lib/convoy';
 import { syncGatewayAgentsToCatalog } from '@/lib/agent-catalog-sync';
 import { triggerWorkspaceMerge } from '@/lib/workspace-isolation';
+import { cancelCodexRunsForTask } from '@/lib/codex/dispatch';
 import { UpdateTaskSchema } from '@/lib/validation';
 import type { Task, UpdateTaskRequest, Agent, TaskDeliverable } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
+
+function clearTaskReferences(taskId: string): void {
+  cancelCodexRunsForTask(taskId);
+  run('DELETE FROM task_roles WHERE task_id = ?', [taskId]);
+  run('DELETE FROM work_checkpoints WHERE task_id = ?', [taskId]);
+  run('DELETE FROM workspace_ports WHERE task_id = ?', [taskId]);
+  run('DELETE FROM workspace_merges WHERE task_id = ?', [taskId]);
+  run('DELETE FROM planning_questions WHERE task_id = ?', [taskId]);
+  run('DELETE FROM planning_specs WHERE task_id = ?', [taskId]);
+  run('DELETE FROM task_notes WHERE task_id = ?', [taskId]);
+  run('DELETE FROM user_task_reads WHERE task_id = ?', [taskId]);
+  run('DELETE FROM task_activities WHERE task_id = ?', [taskId]);
+  run('DELETE FROM task_deliverables WHERE task_id = ?', [taskId]);
+  run('DELETE FROM openclaw_sessions WHERE task_id = ?', [taskId]);
+  run('DELETE FROM codex_sessions WHERE task_id = ?', [taskId]);
+  run('DELETE FROM events WHERE task_id = ?', [taskId]);
+  run('DELETE FROM skill_reports WHERE task_id = ?', [taskId]);
+  run('UPDATE agent_health SET task_id = NULL WHERE task_id = ?', [taskId]);
+  run('UPDATE cost_events SET task_id = NULL WHERE task_id = ?', [taskId]);
+  run('UPDATE conversations SET task_id = NULL WHERE task_id = ?', [taskId]);
+  run('UPDATE knowledge_entries SET task_id = NULL WHERE task_id = ?', [taskId]);
+  run('UPDATE product_skills SET created_by_task_id = NULL WHERE created_by_task_id = ?', [taskId]);
+}
 
 // GET /api/tasks/[id] - Get a single task
 export async function GET(
@@ -511,9 +535,7 @@ export async function DELETE(
       // Delete sub-tasks first (CASCADE handles convoy_subtasks)
       const subtaskIds = queryAll<{ task_id: string }>('SELECT task_id FROM convoy_subtasks WHERE convoy_id = ?', [convoy.id]);
       for (const { task_id } of subtaskIds) {
-        run('DELETE FROM work_checkpoints WHERE task_id = ?', [task_id]);
-        run('DELETE FROM openclaw_sessions WHERE task_id = ?', [task_id]);
-        run('DELETE FROM events WHERE task_id = ?', [task_id]);
+        clearTaskReferences(task_id);
         run('DELETE FROM tasks WHERE id = ?', [task_id]);
       }
       run('DELETE FROM agent_mailbox WHERE convoy_id = ?', [convoy.id]);
@@ -521,13 +543,7 @@ export async function DELETE(
     }
 
     // Delete or nullify related records first (foreign key constraints)
-    // Note: task_activities and task_deliverables have ON DELETE CASCADE
-    run('DELETE FROM work_checkpoints WHERE task_id = ?', [id]);
-    run('DELETE FROM openclaw_sessions WHERE task_id = ?', [id]);
-    run('DELETE FROM events WHERE task_id = ?', [id]);
-    // Conversations and Knowledge reference tasks - nullify or delete
-    run('UPDATE conversations SET task_id = NULL WHERE task_id = ?', [id]);
-    run('UPDATE knowledge_entries SET task_id = NULL WHERE task_id = ?', [id]);
+    clearTaskReferences(id);
 
     // Now delete the task (cascades to task_activities and task_deliverables)
     run('DELETE FROM tasks WHERE id = ?', [id]);

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -5,6 +5,7 @@ import { broadcast } from '@/lib/events';
 import { CreateTaskSchema } from '@/lib/validation';
 import { populateTaskRolesFromAgents } from '@/lib/workflow-engine';
 import { dispatchTaskFromServer } from '@/lib/server-dispatch';
+import { classifyEnvironmentIssueFromTexts } from '@/lib/environment-issues';
 import type { Task, CreateTaskRequest, Agent } from '@/lib/types';
 
 // GET /api/tasks - List all tasks with optional filters
@@ -23,7 +24,15 @@ export async function GET(request: NextRequest) {
         t.*,
         aa.name as assigned_agent_name,
         aa.avatar_emoji as assigned_agent_emoji,
-        ca.name as created_by_agent_name
+        ca.name as created_by_agent_name,
+        (
+          SELECT ta.message || ' ' || COALESCE(ta.metadata, '')
+          FROM task_activities ta
+          WHERE ta.task_id = t.id
+            AND ta.activity_type IN ('environment_blocked', 'status_changed')
+          ORDER BY ta.created_at DESC
+          LIMIT 1
+        ) as latest_activity_context
       FROM tasks t
       LEFT JOIN agents aa ON t.assigned_agent_id = aa.id
       LEFT JOIN agents ca ON t.created_by_agent_id = ca.id
@@ -57,19 +66,30 @@ export async function GET(request: NextRequest) {
 
     sql += ' ORDER BY t.created_at DESC';
 
-    const tasks = queryAll<Task & { assigned_agent_name?: string; assigned_agent_emoji?: string; created_by_agent_name?: string }>(sql, params);
+    const tasks = queryAll<Task & { assigned_agent_name?: string; assigned_agent_emoji?: string; created_by_agent_name?: string; latest_activity_context?: string | null }>(sql, params);
 
     // Transform to include nested agent info
-    const transformedTasks = tasks.map((task) => ({
-      ...task,
-      assigned_agent: task.assigned_agent_id
-        ? {
-            id: task.assigned_agent_id,
-            name: task.assigned_agent_name,
-            avatar_emoji: task.assigned_agent_emoji,
-          }
-        : undefined,
-    }));
+    const transformedTasks = tasks.map((task) => {
+      const environmentIssue = classifyEnvironmentIssueFromTexts([
+        task.status_reason,
+        task.planning_dispatch_error,
+        task.latest_activity_context,
+      ]);
+      const { latest_activity_context: _latestActivityContext, ...taskFields } = task;
+
+      return {
+        ...taskFields,
+        status_reason: task.status_reason || (environmentIssue ? `Environment action required: ${environmentIssue.userMessage}` : task.status_reason),
+        planning_dispatch_error: task.planning_dispatch_error || (environmentIssue ? `Environment blocked (${environmentIssue.code})` : task.planning_dispatch_error),
+        assigned_agent: task.assigned_agent_id
+          ? {
+              id: task.assigned_agent_id,
+              name: task.assigned_agent_name,
+              avatar_emoji: task.assigned_agent_emoji,
+            }
+          : undefined,
+      };
+    });
 
     return NextResponse.json(transformedTasks);
   } catch (error) {

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -11,6 +11,7 @@ import {
   Settings, Save, RotateCcw, Home, FolderOpen, Link as LinkIcon,
   HardDrive, Download, Upload, Trash2, RotateCw, ChevronDown, ChevronRight,
   AlertTriangle, Check, Loader2, Cloud, CloudOff, Shield,
+  Bot, Terminal, Copy, CheckCircle2,
 } from 'lucide-react';
 import { getConfig, updateConfig, resetConfig, type MissionControlConfig } from '@/lib/config';
 
@@ -31,6 +32,37 @@ interface BackupListResponse {
   backups: BackupMetadata[];
   total: number;
   s3: { configured: boolean; endpoint?: string; bucket?: string };
+}
+
+type RuntimeProvider = 'openclaw' | 'codex';
+
+interface RuntimeSettings {
+  provider: RuntimeProvider;
+  codexCloudEnvironmentId: string;
+  codexDefaultBranch: string;
+  envOverrides: {
+    provider: boolean;
+    codexCloudEnvironmentId: boolean;
+    codexDefaultBranch: boolean;
+  };
+}
+
+interface CodexStatus {
+  installed: boolean;
+  authenticated: boolean;
+  ready: boolean;
+  command: string;
+  version?: string;
+  authMethod?: string;
+  error?: string;
+  loginCommand: string;
+}
+
+interface OpenClawStatus {
+  connected: boolean;
+  sessions_count?: number;
+  gateway_url?: string;
+  error?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -66,6 +98,11 @@ export default function SettingsPage() {
   const [isSaving, setIsSaving] = useState(false);
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [runtimeSettings, setRuntimeSettings] = useState<RuntimeSettings | null>(null);
+  const [codexStatus, setCodexStatus] = useState<CodexStatus | null>(null);
+  const [openClawStatus, setOpenClawStatus] = useState<OpenClawStatus | null>(null);
+  const [runtimeStatusLoading, setRuntimeStatusLoading] = useState(false);
+  const [copiedCodexCommand, setCopiedCodexCommand] = useState(false);
 
   // Backup state
   const [backups, setBackups] = useState<BackupMetadata[]>([]);
@@ -82,7 +119,39 @@ export default function SettingsPage() {
 
   useEffect(() => {
     setConfig(getConfig());
+    loadRuntimeSettings();
+    refreshRuntimeStatus();
   }, []);
+
+  const loadRuntimeSettings = async () => {
+    try {
+      const res = await fetch('/api/runtime/settings');
+      if (!res.ok) throw new Error('Failed to load runtime settings');
+      setRuntimeSettings(await res.json());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load runtime settings');
+    }
+  };
+
+  const refreshRuntimeStatus = async () => {
+    setRuntimeStatusLoading(true);
+    try {
+      const [openClawRes, codexRes] = await Promise.all([
+        fetch('/api/openclaw/status'),
+        fetch('/api/runtime/codex/status'),
+      ]);
+
+      if (openClawRes.ok) {
+        setOpenClawStatus(await openClawRes.json());
+      }
+
+      if (codexRes.ok) {
+        setCodexStatus(await codexRes.json());
+      }
+    } finally {
+      setRuntimeStatusLoading(false);
+    }
+  };
 
   // Fetch backups on mount
   const fetchBackups = useCallback(async () => {
@@ -119,6 +188,26 @@ export default function SettingsPage() {
 
     try {
       updateConfig(config);
+
+      if (runtimeSettings) {
+        const res = await fetch('/api/runtime/settings', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            provider: runtimeSettings.provider,
+            codexCloudEnvironmentId: runtimeSettings.codexCloudEnvironmentId,
+            codexDefaultBranch: runtimeSettings.codexDefaultBranch,
+          }),
+        });
+
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({ error: 'Failed to save runtime settings' }));
+          throw new Error(body.error || 'Failed to save runtime settings');
+        }
+
+        setRuntimeSettings(await res.json());
+      }
+
       setSaveSuccess(true);
       setTimeout(() => setSaveSuccess(false), 3000);
     } catch (err) {
@@ -128,12 +217,31 @@ export default function SettingsPage() {
     }
   };
 
-  const handleReset = () => {
+  const handleReset = async () => {
     if (confirm('Reset all settings to defaults? This cannot be undone.')) {
-      resetConfig();
-      setConfig(getConfig());
-      setSaveSuccess(true);
-      setTimeout(() => setSaveSuccess(false), 3000);
+      try {
+        resetConfig();
+        setConfig(getConfig());
+
+        const res = await fetch('/api/runtime/settings', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            provider: 'openclaw',
+            codexCloudEnvironmentId: '',
+            codexDefaultBranch: '',
+          }),
+        });
+
+        if (res.ok) {
+          setRuntimeSettings(await res.json());
+        }
+
+        setSaveSuccess(true);
+        setTimeout(() => setSaveSuccess(false), 3000);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to reset settings');
+      }
     }
   };
 
@@ -141,6 +249,32 @@ export default function SettingsPage() {
     if (!config) return;
     setConfig({ ...config, [field]: value });
   };
+
+  const handleRuntimeChange = (updates: Partial<RuntimeSettings>) => {
+    setRuntimeSettings((current) => current ? { ...current, ...updates } : current);
+  };
+
+  const copyCodexLoginCommand = async () => {
+    const command = codexStatus?.loginCommand || 'codex login --device-auth';
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopiedCodexCommand(true);
+      setTimeout(() => setCopiedCodexCommand(false), 2000);
+    } catch {
+      setError(`Run this command in your terminal: ${command}`);
+    }
+  };
+
+  const statusBadge = (ready: boolean | undefined, label: string) => (
+    <span className={`inline-flex items-center gap-1 px-2 py-1 rounded text-xs border ${
+      ready
+        ? 'border-green-500/40 bg-green-500/10 text-green-400'
+        : 'border-amber-500/40 bg-amber-500/10 text-amber-300'
+    }`}>
+      {ready ? <CheckCircle2 className="w-3 h-3" /> : <AlertTriangle className="w-3 h-3" />}
+      {label}
+    </span>
+  );
 
   // ---------------------------------------------------------------------------
   // Backup handlers
@@ -369,6 +503,151 @@ export default function SettingsPage() {
               </p>
             </div>
           </div>
+        </section>
+
+        {/* Agent Runtime */}
+        <section className="mb-8 p-6 bg-mc-bg-secondary border border-mc-border rounded-lg">
+          <div className="flex items-center justify-between gap-3 mb-4">
+            <div className="flex items-center gap-2">
+              <Bot className="w-5 h-5 text-mc-accent" />
+              <h2 className="text-xl font-semibold text-mc-text">Agent Runtime</h2>
+            </div>
+            <button
+              onClick={refreshRuntimeStatus}
+              disabled={runtimeStatusLoading}
+              className="px-3 py-2 border border-mc-border rounded hover:bg-mc-bg-tertiary text-mc-text-secondary flex items-center gap-2 disabled:opacity-50"
+            >
+              <RotateCw className={`w-4 h-4 ${runtimeStatusLoading ? 'animate-spin' : ''}`} />
+              Refresh
+            </button>
+          </div>
+          <p className="text-sm text-mc-text-secondary mb-4">
+            Choose the runtime Mission Control should prepare for agent work.
+          </p>
+
+          {runtimeSettings ? (
+            <div className="space-y-4">
+              <div className="grid md:grid-cols-2 gap-3">
+                <label className={`p-4 bg-mc-bg border rounded cursor-pointer ${
+                  runtimeSettings.provider === 'openclaw' ? 'border-mc-accent' : 'border-mc-border'
+                }`}>
+                  <input
+                    type="radio"
+                    name="agent-runtime-provider"
+                    value="openclaw"
+                    checked={runtimeSettings.provider === 'openclaw'}
+                    onChange={() => handleRuntimeChange({ provider: 'openclaw' })}
+                    disabled={runtimeSettings.envOverrides.provider}
+                    className="sr-only"
+                  />
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2 text-sm font-semibold text-mc-text">
+                        <Terminal className="w-4 h-4 text-mc-accent" />
+                        OpenClaw Gateway
+                      </div>
+                      <div className="text-xs text-mc-text-secondary mt-2">
+                        {openClawStatus?.gateway_url || 'ws://127.0.0.1:18789'}
+                      </div>
+                    </div>
+                    {statusBadge(openClawStatus?.connected, openClawStatus?.connected ? 'Ready' : 'Check')}
+                  </div>
+                  <div className="mt-3 text-xs text-mc-text-secondary">
+                    Sessions: {openClawStatus?.sessions_count ?? 0}
+                    {openClawStatus?.error ? ` - ${openClawStatus.error}` : ''}
+                  </div>
+                </label>
+
+                <label className={`p-4 bg-mc-bg border rounded cursor-pointer ${
+                  runtimeSettings.provider === 'codex' ? 'border-mc-accent' : 'border-mc-border'
+                }`}>
+                  <input
+                    type="radio"
+                    name="agent-runtime-provider"
+                    value="codex"
+                    checked={runtimeSettings.provider === 'codex'}
+                    onChange={() => handleRuntimeChange({ provider: 'codex' })}
+                    disabled={runtimeSettings.envOverrides.provider}
+                    className="sr-only"
+                  />
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2 text-sm font-semibold text-mc-text">
+                        <Terminal className="w-4 h-4 text-mc-accent" />
+                        Codex CLI
+                      </div>
+                      <div className="text-xs text-mc-text-secondary mt-2">
+                        {codexStatus?.version || codexStatus?.command || 'codex'}
+                      </div>
+                    </div>
+                    {statusBadge(codexStatus?.ready, codexStatus?.ready ? 'Ready' : 'Login')}
+                  </div>
+                  <div className="mt-3 text-xs text-mc-text-secondary">
+                    Auth: {codexStatus?.authenticated ? codexStatus.authMethod || 'Logged in' : codexStatus?.error || 'Not checked'}
+                  </div>
+                </label>
+              </div>
+
+              <div className="grid md:grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm font-medium text-mc-text mb-2">
+                    Codex Cloud Environment ID
+                  </label>
+                  <input
+                    type="text"
+                    value={runtimeSettings.codexCloudEnvironmentId}
+                    onChange={(e) => handleRuntimeChange({ codexCloudEnvironmentId: e.target.value })}
+                    placeholder="env_..."
+                    disabled={runtimeSettings.envOverrides.codexCloudEnvironmentId}
+                    className="w-full px-4 py-2 bg-mc-bg border border-mc-border rounded text-mc-text focus:border-mc-accent focus:outline-none disabled:opacity-60"
+                  />
+                  <p className="text-xs text-mc-text-secondary mt-1">
+                    Used by Codex Cloud task submission once Codex dispatch is enabled.
+                  </p>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-mc-text mb-2">
+                    Codex Default Branch
+                  </label>
+                  <input
+                    type="text"
+                    value={runtimeSettings.codexDefaultBranch}
+                    onChange={(e) => handleRuntimeChange({ codexDefaultBranch: e.target.value })}
+                    placeholder="main"
+                    disabled={runtimeSettings.envOverrides.codexDefaultBranch}
+                    className="w-full px-4 py-2 bg-mc-bg border border-mc-border rounded text-mc-text focus:border-mc-accent focus:outline-none disabled:opacity-60"
+                  />
+                  <p className="text-xs text-mc-text-secondary mt-1">
+                    Leave blank to let Codex use the current branch.
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-2 pt-1">
+                <button
+                  onClick={copyCodexLoginCommand}
+                  className="px-3 py-2 border border-mc-border rounded hover:bg-mc-bg-tertiary text-mc-text-secondary flex items-center gap-2"
+                >
+                  <Copy className="w-4 h-4" />
+                  {copiedCodexCommand ? 'Copied' : 'Copy Codex Login Command'}
+                </button>
+                <span className="text-xs text-mc-text-secondary">
+                  {codexStatus?.loginCommand || 'codex login --device-auth'}
+                </span>
+              </div>
+
+              {runtimeSettings.envOverrides.provider && (
+                <div className="text-xs text-amber-300">
+                  Runtime provider is currently controlled by AGENT_RUNTIME_PROVIDER.
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="p-4 bg-mc-bg border border-mc-border rounded text-sm text-mc-text-secondary">
+              Loading runtime settings...
+            </div>
+          )}
         </section>
 
         {/* Kanban UX */}
@@ -679,6 +958,10 @@ export default function SettingsPage() {
             <li><code>PROJECTS_PATH</code> - Projects directory</li>
             <li><code>OPENCLAW_GATEWAY_URL</code> - Gateway WebSocket URL</li>
             <li><code>OPENCLAW_GATEWAY_TOKEN</code> - Gateway auth token</li>
+            <li><code>AGENT_RUNTIME_PROVIDER</code> - Runtime provider override (<code>openclaw</code> or <code>codex</code>)</li>
+            <li><code>CODEX_CLI_PATH</code> - Codex CLI executable path</li>
+            <li><code>CODEX_CLOUD_ENV_ID</code> - Codex Cloud environment ID</li>
+            <li><code>CODEX_DEFAULT_BRANCH</code> - Default branch for Codex Cloud runs</li>
             <li><code>S3_ENDPOINT</code>, <code>S3_BUCKET</code>, <code>S3_ACCESS_KEY</code>, <code>S3_SECRET_KEY</code> - S3 backup storage</li>
           </ul>
           <p className="text-xs text-blue-400 mt-3">

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -960,6 +960,7 @@ export default function SettingsPage() {
             <li><code>OPENCLAW_GATEWAY_TOKEN</code> - Gateway auth token</li>
             <li><code>AGENT_RUNTIME_PROVIDER</code> - Runtime provider override (<code>openclaw</code> or <code>codex</code>)</li>
             <li><code>CODEX_CLI_PATH</code> - Codex CLI executable path</li>
+            <li><code>CODEX_DISPATCH_SANDBOX</code> - Codex CLI dispatch sandbox mode</li>
             <li><code>CODEX_CLOUD_ENV_ID</code> - Codex Cloud environment ID</li>
             <li><code>CODEX_DEFAULT_BRANCH</code> - Default branch for Codex Cloud runs</li>
             <li><code>S3_ENDPOINT</code>, <code>S3_BUCKET</code>, <code>S3_ACCESS_KEY</code>, <code>S3_SECRET_KEY</code> - S3 backup storage</li>

--- a/src/components/EnvironmentIssuePanel.tsx
+++ b/src/components/EnvironmentIssuePanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState, type MouseEvent } from 'react';
-import { AlertTriangle, CheckCircle2, Clipboard, ExternalLink, RefreshCw, Wrench } from 'lucide-react';
+import { useEffect, useState, type MouseEvent } from 'react';
+import { AlertTriangle, CheckCircle2, Clipboard, ExternalLink, History, RefreshCw, Wrench } from 'lucide-react';
 import { classifyEnvironmentIssueFromTexts, type EnvironmentIssue } from '@/lib/environment-issues';
 import { useMissionControl } from '@/lib/store';
 import type { Task } from '@/lib/types';
@@ -18,6 +18,7 @@ interface TaskActionResponse {
   userMessage?: string;
   task?: Task;
   issue?: EnvironmentIssue;
+  recovery?: EnvironmentRecoveryState | null;
   running?: boolean;
   started?: boolean;
   fixed?: boolean;
@@ -26,11 +27,55 @@ interface TaskActionResponse {
   suggestion?: { command?: string; rationale?: string };
 }
 
+interface EnvironmentRecoverySuggestion {
+  canFixWithCommand?: boolean;
+  command?: string;
+  rationale?: string;
+  confidence?: 'low' | 'medium' | 'high';
+}
+
+interface EnvironmentRecoveryAttempt {
+  id: string;
+  createdAt: string;
+  status: 'running' | 'failed' | 'completed' | 'retry_failed' | 'stale';
+  command?: string;
+  commandSource?: string;
+  message: string;
+  error?: string;
+  stdout?: string;
+  stderr?: string;
+  suggestion?: EnvironmentRecoverySuggestion | null;
+  nextSuggestion?: EnvironmentRecoverySuggestion | null;
+}
+
+interface EnvironmentRecoveryState {
+  running: boolean;
+  runningFix?: { command: string; startedAt: string };
+  attempts: EnvironmentRecoveryAttempt[];
+  failedCommands: string[];
+  nextSuggestion?: EnvironmentRecoverySuggestion | null;
+}
+
 export function getTaskEnvironmentIssue(task: Task): EnvironmentIssue | null {
   return classifyEnvironmentIssueFromTexts([
     task.status_reason,
     task.planning_dispatch_error,
   ]);
+}
+
+function summarizeText(text: string | undefined, maxLength = 180): string | null {
+  if (!text) return null;
+  const line = text
+    .split(/\r?\n/)
+    .map(part => part.trim())
+    .find(Boolean);
+  if (!line) return null;
+  return line.length > maxLength ? `${line.slice(0, maxLength - 1)}...` : line;
+}
+
+function attemptStatusLabel(status: EnvironmentRecoveryAttempt['status']): string {
+  if (status === 'retry_failed') return 'Retry failed';
+  return status.charAt(0).toUpperCase() + status.slice(1);
 }
 
 export function EnvironmentIssuePanel({ task, compact = false, className = '' }: EnvironmentIssuePanelProps) {
@@ -44,12 +89,51 @@ export function EnvironmentIssuePanel({ task, compact = false, className = '' }:
   const [isConfirmingCommand, setIsConfirmingCommand] = useState(false);
   const [isEnteringCommand, setIsEnteringCommand] = useState(false);
   const [userCommand, setUserCommand] = useState('');
+  const [recovery, setRecovery] = useState<EnvironmentRecoveryState | null>(null);
+  const issueCode = issue?.code;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!issueCode) {
+      setRecovery(null);
+      return;
+    }
+
+    fetch(`/api/tasks/${task.id}/environment/fix`)
+      .then((res) => res.json())
+      .then((data: TaskActionResponse) => {
+        if (cancelled) return;
+        setRecovery(data.recovery || null);
+        if (data.task) updateTask(data.task);
+      })
+      .catch(() => {
+        if (!cancelled) setRecovery(null);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [issueCode, task.id, task.updated_at, updateTask]);
 
   if (!issue) return null;
 
   const fixStartedAt = task.updated_at ? new Date(task.updated_at).getTime() : NaN;
   const fixIsFresh = Number.isFinite(fixStartedAt) && Date.now() - fixStartedAt < 11 * 60 * 1000;
-  const fixIsRunning = (task.status_reason?.toLowerCase().startsWith('environment fix running:') ?? false) && fixIsFresh;
+  const fixIsRunning = Boolean(recovery?.running) || ((task.status_reason?.toLowerCase().startsWith('environment fix running:') ?? false) && fixIsFresh);
+  const suggestedCommand = recovery?.nextSuggestion?.command || issue.action.command;
+  const approvedCommand = userCommand.trim() || suggestedCommand || '';
+  const recentAttempts = recovery?.attempts.slice(0, 3) || [];
+  const approvedCommandSource = userCommand.trim()
+    ? recovery?.nextSuggestion?.command === userCommand.trim()
+      ? 'Recovery analysis'
+      : 'User input'
+    : recovery?.nextSuggestion?.command
+      ? 'Recovery analysis'
+      : issue.action.commandSource || 'Detected issue';
+  const approvedCommandRationale = recovery?.nextSuggestion?.command === approvedCommand
+    ? recovery.nextSuggestion.rationale
+    : undefined;
 
   const stop = (event: MouseEvent) => {
     event.stopPropagation();
@@ -57,16 +141,15 @@ export function EnvironmentIssuePanel({ task, compact = false, className = '' }:
 
   const applyResponse = (data: TaskActionResponse) => {
     if (data.task) updateTask(data.task);
+    if (data.recovery !== undefined) setRecovery(data.recovery);
   };
-
-  const approvedCommand = issue.action.command || userCommand.trim();
 
   const handleCopyCommand = async (event: MouseEvent) => {
     stop(event);
-    if (!issue.action.command) return;
+    if (!suggestedCommand) return;
 
     try {
-      await navigator.clipboard.writeText(issue.action.command);
+      await navigator.clipboard.writeText(suggestedCommand);
       setCopied(true);
       setMessage('Command copied.');
       setError(null);
@@ -128,7 +211,7 @@ export function EnvironmentIssuePanel({ task, compact = false, className = '' }:
           code: issue.code,
           retry: true,
           approvedCommand,
-          userProvidedCommand: !issue.action.command,
+          userProvidedCommand: approvedCommand !== issue.action.command,
         }),
       });
       const data = await res.json().catch(() => ({} as TaskActionResponse));
@@ -172,6 +255,7 @@ export function EnvironmentIssuePanel({ task, compact = false, className = '' }:
           code: issue.code,
           retry: true,
           autoSuggestCommand: true,
+          suggestOnly: true,
         }),
       });
       const data = await res.json().catch(() => ({} as TaskActionResponse));
@@ -186,12 +270,12 @@ export function EnvironmentIssuePanel({ task, compact = false, className = '' }:
         return;
       }
 
-      const ran = data.fix?.command ? ` Ran: ${data.fix.command}` : '';
-      if (data.running) {
-        const command = data.fix?.command ? ` Running: ${data.fix.command}` : '';
-        setMessage(`Environment fix started.${command} The agent will retry automatically if it succeeds.`);
+      if (data.suggestion?.command) {
+        setUserCommand(data.suggestion.command);
+        setIsConfirmingCommand(true);
+        setMessage('Review the suggested command before running it.');
       } else {
-        setMessage(data.retried ? `Fix ran and agent retry started.${ran}` : `Fix ran successfully.${ran}`);
+        setMessage('No command suggestion is available yet.');
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Auto fix failed.');
@@ -225,18 +309,61 @@ export function EnvironmentIssuePanel({ task, compact = false, className = '' }:
         </div>
       )}
 
-      {issue.action.command && !compact && (
+      {!compact && recovery?.nextSuggestion?.command && (
+        <div className="mt-3 rounded-md border border-white/15 bg-black/20 p-2.5">
+          <div className="text-[11px] font-semibold uppercase opacity-70">Next suggested action</div>
+          <code className="mt-1 block rounded border border-white/15 bg-black/30 px-2 py-1 text-[11px] break-all">
+            {recovery.nextSuggestion.command}
+          </code>
+          {recovery.nextSuggestion.rationale && (
+            <div className="mt-1 text-[11px] opacity-75">
+              {recovery.nextSuggestion.rationale}
+            </div>
+          )}
+        </div>
+      )}
+
+      {!compact && recentAttempts.length > 0 && (
+        <div className="mt-3 rounded-md border border-white/15 bg-black/15 p-2.5">
+          <div className="flex items-center gap-1.5 text-[11px] font-semibold uppercase opacity-70">
+            <History className="w-3.5 h-3.5" />
+            Recovery history
+          </div>
+          <div className="mt-2 space-y-2">
+            {recentAttempts.map((attempt) => {
+              const detail = summarizeText(attempt.error || attempt.stderr || attempt.stdout || attempt.message);
+              return (
+                <div key={attempt.id} className="border-t border-white/10 pt-2 first:border-t-0 first:pt-0">
+                  <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px]">
+                    <span className="font-semibold">{attemptStatusLabel(attempt.status)}</span>
+                    <span className="opacity-60">{new Date(attempt.createdAt).toLocaleTimeString()}</span>
+                  </div>
+                  {attempt.command && (
+                    <code className="mt-1 block break-all text-[10px] opacity-80">{attempt.command}</code>
+                  )}
+                  {detail && (
+                    <div className="mt-1 text-[10px] opacity-70">{detail}</div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {suggestedCommand && !compact && !recovery?.nextSuggestion?.command && (
         <code className="mt-2 block rounded border border-white/15 bg-black/20 px-2 py-1 text-[11px] break-all opacity-90">
-          {issue.action.command}
+          {suggestedCommand}
         </code>
       )}
 
       <div className={`mt-2 flex ${compact ? 'flex-col' : 'flex-wrap'} gap-2`}>
-        {issue.action.mode === 'command' && issue.action.command && (
+        {suggestedCommand && (
           <button
             type="button"
             onClick={(event) => {
               stop(event);
+              setUserCommand(suggestedCommand);
               setIsConfirmingCommand(true);
               setIsEnteringCommand(false);
               setError(null);
@@ -246,11 +373,11 @@ export function EnvironmentIssuePanel({ task, compact = false, className = '' }:
             className="inline-flex min-h-9 items-center justify-center gap-1.5 rounded border border-white/20 bg-white/10 px-2.5 text-[11px] font-medium hover:bg-white/20 disabled:opacity-50"
           >
             <Wrench className={`w-3.5 h-3.5 ${fixIsRunning || isFixing ? 'animate-spin' : ''}`} />
-            {fixIsRunning ? 'Fix running...' : isFixing ? 'Running command...' : issue.action.label}
+            {fixIsRunning ? 'Fix running...' : isFixing ? 'Running command...' : 'Review suggested fix'}
           </button>
         )}
 
-        {issue.action.mode === 'manual' && !issue.action.command && (
+        {issue.action.mode === 'manual' && !suggestedCommand && (
           <button
             type="button"
             onClick={handleAutoFix}
@@ -258,11 +385,11 @@ export function EnvironmentIssuePanel({ task, compact = false, className = '' }:
             className="inline-flex min-h-9 items-center justify-center gap-1.5 rounded border border-white/20 bg-white/10 px-2.5 text-[11px] font-medium hover:bg-white/20 disabled:opacity-50"
           >
             <Wrench className={`w-3.5 h-3.5 ${fixIsRunning || isFixing ? 'animate-spin' : ''}`} />
-            {fixIsRunning ? 'Fix running...' : isFixing ? 'Auto fixing...' : 'Auto fix & retry'}
+            {fixIsRunning ? 'Fix running...' : isFixing ? 'Finding command...' : 'Find fix command'}
           </button>
         )}
 
-        {issue.action.mode === 'manual' && !issue.action.command && (
+        {issue.action.mode === 'manual' && !suggestedCommand && (
           <button
             type="button"
             onClick={(event) => {
@@ -290,14 +417,14 @@ export function EnvironmentIssuePanel({ task, compact = false, className = '' }:
           </a>
         )}
 
-        {issue.action.command && (
+        {suggestedCommand && (
           <button
             type="button"
             onClick={handleCopyCommand}
             className="inline-flex min-h-9 items-center justify-center gap-1.5 rounded border border-white/15 px-2.5 text-[11px] hover:bg-white/10"
           >
             {copied ? <CheckCircle2 className="w-3.5 h-3.5" /> : <Clipboard className="w-3.5 h-3.5" />}
-            {copied ? 'Copied' : compact ? 'Copy fix' : issue.action.mode === 'manual' ? issue.action.label : 'Copy command'}
+            {copied ? 'Copied' : compact ? 'Copy fix' : 'Copy command'}
           </button>
         )}
 
@@ -318,7 +445,7 @@ export function EnvironmentIssuePanel({ task, compact = false, className = '' }:
         </div>
       )}
 
-      {isEnteringCommand && !issue.action.command && (
+      {isEnteringCommand && !suggestedCommand && (
         <div
           className="mt-3 rounded-md border border-white/20 bg-black/25 p-3"
           onClick={(event) => event.stopPropagation()}
@@ -380,8 +507,13 @@ export function EnvironmentIssuePanel({ task, compact = false, className = '' }:
             {approvedCommand}
           </code>
           <div className="mt-1 text-[10px] opacity-70">
-            Source: {issue.action.commandSource || 'User input'}
+            Source: {approvedCommandSource}
           </div>
+          {approvedCommandRationale && (
+            <div className="mt-1 text-[10px] opacity-70">
+              {approvedCommandRationale}
+            </div>
+          )}
           <div className="mt-3 flex gap-2">
             <button
               type="button"

--- a/src/components/EnvironmentIssuePanel.tsx
+++ b/src/components/EnvironmentIssuePanel.tsx
@@ -18,9 +18,11 @@ interface TaskActionResponse {
   userMessage?: string;
   task?: Task;
   issue?: EnvironmentIssue;
+  running?: boolean;
+  started?: boolean;
   fixed?: boolean;
   retried?: boolean;
-  fix?: { command?: string };
+  fix?: { command?: string; startedAt?: string };
   suggestion?: { command?: string; rationale?: string };
 }
 
@@ -44,6 +46,10 @@ export function EnvironmentIssuePanel({ task, compact = false, className = '' }:
   const [userCommand, setUserCommand] = useState('');
 
   if (!issue) return null;
+
+  const fixStartedAt = task.updated_at ? new Date(task.updated_at).getTime() : NaN;
+  const fixIsFresh = Number.isFinite(fixStartedAt) && Date.now() - fixStartedAt < 11 * 60 * 1000;
+  const fixIsRunning = (task.status_reason?.toLowerCase().startsWith('environment fix running:') ?? false) && fixIsFresh;
 
   const stop = (event: MouseEvent) => {
     event.stopPropagation();
@@ -72,6 +78,10 @@ export function EnvironmentIssuePanel({ task, compact = false, className = '' }:
 
   const handleRetry = async (event: MouseEvent) => {
     stop(event);
+    if (fixIsRunning) {
+      setMessage('Environment fix is still running. The agent will retry automatically if it succeeds.');
+      return;
+    }
     setIsRetrying(true);
     setError(null);
     setMessage(null);
@@ -96,6 +106,10 @@ export function EnvironmentIssuePanel({ task, compact = false, className = '' }:
 
   const handleRunFix = async (event: MouseEvent) => {
     stop(event);
+    if (fixIsRunning) {
+      setMessage('Environment fix is already running.');
+      return;
+    }
     if (!approvedCommand) {
       setError('Enter a command first.');
       return;
@@ -125,7 +139,12 @@ export function EnvironmentIssuePanel({ task, compact = false, className = '' }:
         return;
       }
 
-      setMessage(data.retried ? 'Fix ran and agent retry started.' : 'Fix ran successfully.');
+      if (data.running) {
+        const command = data.fix?.command ? ` Running: ${data.fix.command}` : '';
+        setMessage(`Environment fix started.${command} The agent will retry automatically if it succeeds.`);
+      } else {
+        setMessage(data.retried ? 'Fix ran and agent retry started.' : 'Fix ran successfully.');
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Environment fix failed.');
     } finally {
@@ -135,6 +154,10 @@ export function EnvironmentIssuePanel({ task, compact = false, className = '' }:
 
   const handleAutoFix = async (event: MouseEvent) => {
     stop(event);
+    if (fixIsRunning) {
+      setMessage('Environment fix is already running.');
+      return;
+    }
     setIsFixing(true);
     setIsConfirmingCommand(false);
     setIsEnteringCommand(false);
@@ -164,7 +187,12 @@ export function EnvironmentIssuePanel({ task, compact = false, className = '' }:
       }
 
       const ran = data.fix?.command ? ` Ran: ${data.fix.command}` : '';
-      setMessage(data.retried ? `Fix ran and agent retry started.${ran}` : `Fix ran successfully.${ran}`);
+      if (data.running) {
+        const command = data.fix?.command ? ` Running: ${data.fix.command}` : '';
+        setMessage(`Environment fix started.${command} The agent will retry automatically if it succeeds.`);
+      } else {
+        setMessage(data.retried ? `Fix ran and agent retry started.${ran}` : `Fix ran successfully.${ran}`);
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Auto fix failed.');
     } finally {
@@ -191,7 +219,9 @@ export function EnvironmentIssuePanel({ task, compact = false, className = '' }:
 
       {!compact && (
         <div className="mt-2 text-xs opacity-80">
-          {issue.userMessage}
+          {fixIsRunning
+            ? 'Mission Control is running the approved setup command. The assigned agent will retry automatically if it succeeds.'
+            : issue.userMessage}
         </div>
       )}
 
@@ -212,11 +242,11 @@ export function EnvironmentIssuePanel({ task, compact = false, className = '' }:
               setError(null);
               setMessage(null);
             }}
-            disabled={isFixing || isRetrying}
+            disabled={isFixing || isRetrying || fixIsRunning}
             className="inline-flex min-h-9 items-center justify-center gap-1.5 rounded border border-white/20 bg-white/10 px-2.5 text-[11px] font-medium hover:bg-white/20 disabled:opacity-50"
           >
-            <Wrench className="w-3.5 h-3.5" />
-            {isFixing ? 'Running command...' : issue.action.label}
+            <Wrench className={`w-3.5 h-3.5 ${fixIsRunning || isFixing ? 'animate-spin' : ''}`} />
+            {fixIsRunning ? 'Fix running...' : isFixing ? 'Running command...' : issue.action.label}
           </button>
         )}
 
@@ -224,11 +254,11 @@ export function EnvironmentIssuePanel({ task, compact = false, className = '' }:
           <button
             type="button"
             onClick={handleAutoFix}
-            disabled={isFixing || isRetrying}
+            disabled={isFixing || isRetrying || fixIsRunning}
             className="inline-flex min-h-9 items-center justify-center gap-1.5 rounded border border-white/20 bg-white/10 px-2.5 text-[11px] font-medium hover:bg-white/20 disabled:opacity-50"
           >
-            <Wrench className="w-3.5 h-3.5" />
-            {isFixing ? 'Auto fixing...' : 'Auto fix & retry'}
+            <Wrench className={`w-3.5 h-3.5 ${fixIsRunning || isFixing ? 'animate-spin' : ''}`} />
+            {fixIsRunning ? 'Fix running...' : isFixing ? 'Auto fixing...' : 'Auto fix & retry'}
           </button>
         )}
 
@@ -242,7 +272,7 @@ export function EnvironmentIssuePanel({ task, compact = false, className = '' }:
               setError(null);
               setMessage(null);
             }}
-            disabled={isFixing || isRetrying}
+            disabled={isFixing || isRetrying || fixIsRunning}
             className="inline-flex min-h-9 items-center justify-center rounded border border-white/15 px-2.5 text-[11px] hover:bg-white/10 disabled:opacity-50"
           >
             Enter command
@@ -274,7 +304,7 @@ export function EnvironmentIssuePanel({ task, compact = false, className = '' }:
         <button
           type="button"
           onClick={handleRetry}
-          disabled={isFixing || isRetrying}
+          disabled={isFixing || isRetrying || fixIsRunning}
           className="inline-flex min-h-9 items-center justify-center gap-1.5 rounded border border-white/15 px-2.5 text-[11px] hover:bg-white/10 disabled:opacity-50"
         >
           <RefreshCw className={`w-3.5 h-3.5 ${isRetrying ? 'animate-spin' : ''}`} />
@@ -317,7 +347,7 @@ export function EnvironmentIssuePanel({ task, compact = false, className = '' }:
                 setIsEnteringCommand(false);
                 setIsConfirmingCommand(true);
               }}
-              disabled={isFixing || isRetrying}
+              disabled={isFixing || isRetrying || fixIsRunning}
               className="inline-flex min-h-9 items-center justify-center gap-1.5 rounded bg-white/15 px-2.5 text-[11px] font-medium hover:bg-white/20 disabled:opacity-50"
             >
               <Wrench className="w-3.5 h-3.5" />
@@ -356,7 +386,7 @@ export function EnvironmentIssuePanel({ task, compact = false, className = '' }:
             <button
               type="button"
               onClick={handleRunFix}
-              disabled={isFixing || isRetrying}
+              disabled={isFixing || isRetrying || fixIsRunning}
               className="inline-flex min-h-9 items-center justify-center gap-1.5 rounded bg-white/15 px-2.5 text-[11px] font-medium hover:bg-white/20 disabled:opacity-50"
             >
               <Wrench className="w-3.5 h-3.5" />

--- a/src/components/EnvironmentIssuePanel.tsx
+++ b/src/components/EnvironmentIssuePanel.tsx
@@ -40,8 +40,11 @@ interface EnvironmentRecoveryAttempt {
   status: 'running' | 'failed' | 'completed' | 'retry_failed' | 'stale';
   command?: string;
   commandSource?: string;
+  generation: number;
   message: string;
   error?: string;
+  failureFingerprint?: string;
+  repeatedFailure?: boolean;
   stdout?: string;
   stderr?: string;
   suggestion?: EnvironmentRecoverySuggestion | null;
@@ -52,7 +55,9 @@ interface EnvironmentRecoveryState {
   running: boolean;
   runningFix?: { command: string; startedAt: string };
   attempts: EnvironmentRecoveryAttempt[];
+  generation: number;
   failedCommands: string[];
+  repeatedFailures: Array<{ command: string; generation: number; firstGeneration: number; failureFingerprint: string }>;
   nextSuggestion?: EnvironmentRecoverySuggestion | null;
 }
 
@@ -134,6 +139,7 @@ export function EnvironmentIssuePanel({ task, compact = false, className = '' }:
   const approvedCommandRationale = recovery?.nextSuggestion?.command === approvedCommand
     ? recovery.nextSuggestion.rationale
     : undefined;
+  const repeatedFailure = recovery?.repeatedFailures?.[0];
 
   const stop = (event: MouseEvent) => {
     event.stopPropagation();
@@ -323,6 +329,18 @@ export function EnvironmentIssuePanel({ task, compact = false, className = '' }:
         </div>
       )}
 
+      {!compact && repeatedFailure && !recovery?.nextSuggestion?.command && (
+        <div className="mt-3 rounded-md border border-red-400/25 bg-red-500/10 p-2.5">
+          <div className="text-[11px] font-semibold uppercase text-red-100/80">Manual intervention needed</div>
+          <div className="mt-1 text-[11px] opacity-80">
+            The same command failed with the same error after a successful recovery step. Mission Control will not keep suggesting it automatically.
+          </div>
+          <code className="mt-2 block rounded border border-white/15 bg-black/30 px-2 py-1 text-[11px] break-all">
+            {repeatedFailure.command}
+          </code>
+        </div>
+      )}
+
       {!compact && recentAttempts.length > 0 && (
         <div className="mt-3 rounded-md border border-white/15 bg-black/15 p-2.5">
           <div className="flex items-center gap-1.5 text-[11px] font-semibold uppercase opacity-70">
@@ -336,6 +354,8 @@ export function EnvironmentIssuePanel({ task, compact = false, className = '' }:
                 <div key={attempt.id} className="border-t border-white/10 pt-2 first:border-t-0 first:pt-0">
                   <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px]">
                     <span className="font-semibold">{attemptStatusLabel(attempt.status)}</span>
+                    <span className="opacity-60">Gen {attempt.generation}</span>
+                    {attempt.repeatedFailure && <span className="text-red-100/80">same error repeated</span>}
                     <span className="opacity-60">{new Date(attempt.createdAt).toLocaleTimeString()}</span>
                   </div>
                   {attempt.command && (

--- a/src/components/EnvironmentIssuePanel.tsx
+++ b/src/components/EnvironmentIssuePanel.tsx
@@ -1,0 +1,380 @@
+'use client';
+
+import { useState, type MouseEvent } from 'react';
+import { AlertTriangle, CheckCircle2, Clipboard, ExternalLink, RefreshCw, Wrench } from 'lucide-react';
+import { classifyEnvironmentIssueFromTexts, type EnvironmentIssue } from '@/lib/environment-issues';
+import { useMissionControl } from '@/lib/store';
+import type { Task } from '@/lib/types';
+
+interface EnvironmentIssuePanelProps {
+  task: Task;
+  compact?: boolean;
+  className?: string;
+}
+
+interface TaskActionResponse {
+  success?: boolean;
+  error?: string;
+  userMessage?: string;
+  task?: Task;
+  issue?: EnvironmentIssue;
+  fixed?: boolean;
+  retried?: boolean;
+  fix?: { command?: string };
+  suggestion?: { command?: string; rationale?: string };
+}
+
+export function getTaskEnvironmentIssue(task: Task): EnvironmentIssue | null {
+  return classifyEnvironmentIssueFromTexts([
+    task.status_reason,
+    task.planning_dispatch_error,
+  ]);
+}
+
+export function EnvironmentIssuePanel({ task, compact = false, className = '' }: EnvironmentIssuePanelProps) {
+  const updateTask = useMissionControl((state) => state.updateTask);
+  const issue = getTaskEnvironmentIssue(task);
+  const [isFixing, setIsFixing] = useState(false);
+  const [isRetrying, setIsRetrying] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [isConfirmingCommand, setIsConfirmingCommand] = useState(false);
+  const [isEnteringCommand, setIsEnteringCommand] = useState(false);
+  const [userCommand, setUserCommand] = useState('');
+
+  if (!issue) return null;
+
+  const stop = (event: MouseEvent) => {
+    event.stopPropagation();
+  };
+
+  const applyResponse = (data: TaskActionResponse) => {
+    if (data.task) updateTask(data.task);
+  };
+
+  const approvedCommand = issue.action.command || userCommand.trim();
+
+  const handleCopyCommand = async (event: MouseEvent) => {
+    stop(event);
+    if (!issue.action.command) return;
+
+    try {
+      await navigator.clipboard.writeText(issue.action.command);
+      setCopied(true);
+      setMessage('Command copied.');
+      setError(null);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setError('Could not copy command. Select it manually.');
+    }
+  };
+
+  const handleRetry = async (event: MouseEvent) => {
+    stop(event);
+    setIsRetrying(true);
+    setError(null);
+    setMessage(null);
+
+    try {
+      const res = await fetch(`/api/tasks/${task.id}/dispatch/retry`, { method: 'POST' });
+      const data = await res.json().catch(() => ({} as TaskActionResponse));
+      applyResponse(data);
+
+      if (!res.ok || !data.success) {
+        setError(data.userMessage || data.error || 'Retry failed.');
+        return;
+      }
+
+      setMessage('Agent retry started.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Retry failed.');
+    } finally {
+      setIsRetrying(false);
+    }
+  };
+
+  const handleRunFix = async (event: MouseEvent) => {
+    stop(event);
+    if (!approvedCommand) {
+      setError('Enter a command first.');
+      return;
+    }
+    setIsFixing(true);
+    setIsConfirmingCommand(false);
+    setIsEnteringCommand(false);
+    setError(null);
+    setMessage(null);
+
+    try {
+      const res = await fetch(`/api/tasks/${task.id}/environment/fix`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          code: issue.code,
+          retry: true,
+          approvedCommand,
+          userProvidedCommand: !issue.action.command,
+        }),
+      });
+      const data = await res.json().catch(() => ({} as TaskActionResponse));
+      applyResponse(data);
+
+      if (!res.ok || !data.success) {
+        setError(data.error || 'Environment fix failed.');
+        return;
+      }
+
+      setMessage(data.retried ? 'Fix ran and agent retry started.' : 'Fix ran successfully.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Environment fix failed.');
+    } finally {
+      setIsFixing(false);
+    }
+  };
+
+  const handleAutoFix = async (event: MouseEvent) => {
+    stop(event);
+    setIsFixing(true);
+    setIsConfirmingCommand(false);
+    setIsEnteringCommand(false);
+    setError(null);
+    setMessage(null);
+
+    try {
+      const res = await fetch(`/api/tasks/${task.id}/environment/fix`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          code: issue.code,
+          retry: true,
+          autoSuggestCommand: true,
+        }),
+      });
+      const data = await res.json().catch(() => ({} as TaskActionResponse));
+      applyResponse(data);
+
+      if (!res.ok || !data.success) {
+        if (data.suggestion?.command) {
+          setUserCommand(data.suggestion.command);
+          setIsConfirmingCommand(true);
+        }
+        setError(data.error || 'Auto fix failed.');
+        return;
+      }
+
+      const ran = data.fix?.command ? ` Ran: ${data.fix.command}` : '';
+      setMessage(data.retried ? `Fix ran and agent retry started.${ran}` : `Fix ran successfully.${ran}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Auto fix failed.');
+    } finally {
+      setIsFixing(false);
+    }
+  };
+
+  const tone = issue.severity === 'danger'
+    ? 'bg-red-500/10 border-red-500/30 text-red-200'
+    : 'bg-amber-500/10 border-amber-500/30 text-amber-100';
+  const iconTone = issue.severity === 'danger' ? 'text-red-300' : 'text-amber-300';
+
+  return (
+    <div className={`${compact ? 'p-2.5' : 'p-3'} rounded-md border ${tone} ${className}`}>
+      <div className="flex items-start gap-2">
+        <AlertTriangle className={`w-4 h-4 mt-0.5 flex-shrink-0 ${iconTone}`} />
+        <div className="min-w-0 flex-1">
+          <div className="text-xs font-semibold">Environment action required</div>
+          <div className={`${compact ? 'text-[11px] line-clamp-2' : 'text-xs'} mt-1 opacity-90`}>
+            {issue.summary} Mission Control paused the agent loop so this is not treated as a code bug.
+          </div>
+        </div>
+      </div>
+
+      {!compact && (
+        <div className="mt-2 text-xs opacity-80">
+          {issue.userMessage}
+        </div>
+      )}
+
+      {issue.action.command && !compact && (
+        <code className="mt-2 block rounded border border-white/15 bg-black/20 px-2 py-1 text-[11px] break-all opacity-90">
+          {issue.action.command}
+        </code>
+      )}
+
+      <div className={`mt-2 flex ${compact ? 'flex-col' : 'flex-wrap'} gap-2`}>
+        {issue.action.mode === 'command' && issue.action.command && (
+          <button
+            type="button"
+            onClick={(event) => {
+              stop(event);
+              setIsConfirmingCommand(true);
+              setIsEnteringCommand(false);
+              setError(null);
+              setMessage(null);
+            }}
+            disabled={isFixing || isRetrying}
+            className="inline-flex min-h-9 items-center justify-center gap-1.5 rounded border border-white/20 bg-white/10 px-2.5 text-[11px] font-medium hover:bg-white/20 disabled:opacity-50"
+          >
+            <Wrench className="w-3.5 h-3.5" />
+            {isFixing ? 'Running command...' : issue.action.label}
+          </button>
+        )}
+
+        {issue.action.mode === 'manual' && !issue.action.command && (
+          <button
+            type="button"
+            onClick={handleAutoFix}
+            disabled={isFixing || isRetrying}
+            className="inline-flex min-h-9 items-center justify-center gap-1.5 rounded border border-white/20 bg-white/10 px-2.5 text-[11px] font-medium hover:bg-white/20 disabled:opacity-50"
+          >
+            <Wrench className="w-3.5 h-3.5" />
+            {isFixing ? 'Auto fixing...' : 'Auto fix & retry'}
+          </button>
+        )}
+
+        {issue.action.mode === 'manual' && !issue.action.command && (
+          <button
+            type="button"
+            onClick={(event) => {
+              stop(event);
+              setIsEnteringCommand(true);
+              setIsConfirmingCommand(false);
+              setError(null);
+              setMessage(null);
+            }}
+            disabled={isFixing || isRetrying}
+            className="inline-flex min-h-9 items-center justify-center rounded border border-white/15 px-2.5 text-[11px] hover:bg-white/10 disabled:opacity-50"
+          >
+            Enter command
+          </button>
+        )}
+
+        {issue.action.mode === 'settings' && issue.action.settingsHref && (
+          <a
+            href={issue.action.settingsHref}
+            onClick={stop}
+            className="inline-flex min-h-9 items-center justify-center gap-1.5 rounded border border-white/20 bg-white/10 px-2.5 text-[11px] font-medium hover:bg-white/20"
+          >
+            <ExternalLink className="w-3.5 h-3.5" />
+            {issue.action.label}
+          </a>
+        )}
+
+        {issue.action.command && (
+          <button
+            type="button"
+            onClick={handleCopyCommand}
+            className="inline-flex min-h-9 items-center justify-center gap-1.5 rounded border border-white/15 px-2.5 text-[11px] hover:bg-white/10"
+          >
+            {copied ? <CheckCircle2 className="w-3.5 h-3.5" /> : <Clipboard className="w-3.5 h-3.5" />}
+            {copied ? 'Copied' : compact ? 'Copy fix' : issue.action.mode === 'manual' ? issue.action.label : 'Copy command'}
+          </button>
+        )}
+
+        <button
+          type="button"
+          onClick={handleRetry}
+          disabled={isFixing || isRetrying}
+          className="inline-flex min-h-9 items-center justify-center gap-1.5 rounded border border-white/15 px-2.5 text-[11px] hover:bg-white/10 disabled:opacity-50"
+        >
+          <RefreshCw className={`w-3.5 h-3.5 ${isRetrying ? 'animate-spin' : ''}`} />
+          {isRetrying ? 'Retrying...' : issue.retryLabel}
+        </button>
+      </div>
+
+      {(message || error) && (
+        <div className={`mt-2 text-[11px] ${error ? 'text-red-200' : 'text-green-200'}`}>
+          {error || message}
+        </div>
+      )}
+
+      {isEnteringCommand && !issue.action.command && (
+        <div
+          className="mt-3 rounded-md border border-white/20 bg-black/25 p-3"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <label className="text-xs font-semibold" htmlFor={`environment-command-${task.id}`}>
+            Setup command
+          </label>
+          <textarea
+            id={`environment-command-${task.id}`}
+            value={userCommand}
+            onChange={(event) => setUserCommand(event.target.value)}
+            rows={compact ? 2 : 3}
+            className="mt-2 w-full rounded border border-white/15 bg-black/30 px-2 py-1.5 text-[11px] text-white outline-none focus:border-white/35"
+            placeholder="Paste the command to run"
+          />
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={(event) => {
+                stop(event);
+                if (!userCommand.trim()) {
+                  setError('Enter a command first.');
+                  return;
+                }
+                setError(null);
+                setIsEnteringCommand(false);
+                setIsConfirmingCommand(true);
+              }}
+              disabled={isFixing || isRetrying}
+              className="inline-flex min-h-9 items-center justify-center gap-1.5 rounded bg-white/15 px-2.5 text-[11px] font-medium hover:bg-white/20 disabled:opacity-50"
+            >
+              <Wrench className="w-3.5 h-3.5" />
+              Review command
+            </button>
+            <button
+              type="button"
+              onClick={(event) => {
+                stop(event);
+                setIsEnteringCommand(false);
+              }}
+              className="inline-flex min-h-9 items-center justify-center rounded border border-white/15 px-2.5 text-[11px] hover:bg-white/10"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {isConfirmingCommand && approvedCommand && (
+        <div
+          className="mt-3 rounded-md border border-white/20 bg-black/25 p-3"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <div className="text-xs font-semibold">Approve command</div>
+          <div className="mt-1 text-[11px] opacity-80">
+            Mission Control will run this exact command on this machine, then retry the assigned agent.
+          </div>
+          <code className="mt-2 block rounded border border-white/15 bg-black/30 px-2 py-1 text-[11px] break-all">
+            {approvedCommand}
+          </code>
+          <div className="mt-1 text-[10px] opacity-70">
+            Source: {issue.action.commandSource || 'User input'}
+          </div>
+          <div className="mt-3 flex gap-2">
+            <button
+              type="button"
+              onClick={handleRunFix}
+              disabled={isFixing || isRetrying}
+              className="inline-flex min-h-9 items-center justify-center gap-1.5 rounded bg-white/15 px-2.5 text-[11px] font-medium hover:bg-white/20 disabled:opacity-50"
+            >
+              <Wrench className="w-3.5 h-3.5" />
+              Run command
+            </button>
+            <button
+              type="button"
+              onClick={(event) => {
+                stop(event);
+                setIsConfirmingCommand(false);
+              }}
+              className="inline-flex min-h-9 items-center justify-center rounded border border-white/15 px-2.5 text-[11px] hover:bg-white/10"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/MissionQueue.tsx
+++ b/src/components/MissionQueue.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Plus, ChevronRight, GripVertical, ArrowRightLeft, AlertTriangle, MessageSquare } from 'lucide-react';
+import { Plus, ChevronRight, GripVertical, ArrowRightLeft, AlertTriangle, MessageSquare, RefreshCw } from 'lucide-react';
 import { useMissionControl } from '@/lib/store';
 import { triggerAutoDispatch, shouldTriggerAutoDispatch } from '@/lib/auto-dispatch';
 import { getConfig } from '@/lib/config';
@@ -27,6 +27,27 @@ const COLUMNS: { id: TaskStatus; label: string; color: string }[] = [
   { id: 'verification', label: 'Verification', color: 'border-t-orange-500' },
   { id: 'done', label: 'Done', color: 'border-t-mc-accent-green' },
 ];
+
+interface DispatchRetryResponse {
+  success?: boolean;
+  error?: string;
+  userMessage?: string;
+  task?: Task;
+}
+
+function getDispatchErrorSummary(error: string): string {
+  const cleaned = error
+    .replace(/^Auto-nudge failed:\s*/i, '')
+    .replace(/^Auto-recovery failed:\s*/i, '')
+    .replace(/^Retry dispatch failed:\s*/i, '')
+    .trim();
+
+  if (cleaned.toLowerCase().includes('no active') && cleaned.toLowerCase().includes('session')) {
+    return 'Dispatch did not start a tracked runtime session.';
+  }
+
+  return cleaned || error;
+}
 
 export function MissionQueue({ workspaceId, mobileMode = false, isPortrait = true }: MissionQueueProps) {
   const { tasks, updateTaskStatus, addEvent } = useMissionControl();
@@ -335,27 +356,22 @@ export function MissionQueue({ workspaceId, mobileMode = false, isPortrait = tru
   );
 }
 
-function AssignedStatusBadge({ task, portraitMode }: { task: Task; portraitMode: boolean }) {
-  const [retrying, setRetrying] = useState(false);
+function AssignedStatusBadge({
+  task,
+  portraitMode,
+  retrying,
+  retryError,
+  onRetryDispatch,
+}: {
+  task: Task;
+  portraitMode: boolean;
+  retrying: boolean;
+  retryError: string | null;
+  onRetryDispatch: (e: React.MouseEvent) => void;
+}) {
   const updatedAt = new Date(task.updated_at).getTime();
   const staleMs = Date.now() - updatedAt;
   const isStale = staleMs > 2 * 60 * 1000; // 2 minutes
-
-  const handleRetryDispatch = async (e: React.MouseEvent) => {
-    e.stopPropagation(); // Don't open the task modal
-    setRetrying(true);
-    try {
-      const res = await fetch(`/api/tasks/${task.id}/dispatch`, { method: 'POST' });
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        console.error('Retry dispatch failed:', data.error);
-      }
-    } catch (err) {
-      console.error('Retry dispatch error:', err);
-    } finally {
-      setRetrying(false);
-    }
-  };
 
   if (isStale) {
     const staleMinutes = Math.floor(staleMs / 60000);
@@ -366,12 +382,18 @@ function AssignedStatusBadge({ task, portraitMode }: { task: Task; portraitMode:
           <span className="text-xs text-amber-200">Stuck in assigned for {staleMinutes}m</span>
         </div>
         <button
-          onClick={handleRetryDispatch}
+          onClick={onRetryDispatch}
           disabled={retrying}
-          className="text-[11px] px-2 py-1 bg-amber-500/20 hover:bg-amber-500/30 text-amber-300 rounded border border-amber-500/30 disabled:opacity-50"
+          className="inline-flex items-center gap-1.5 text-[11px] px-2 py-1 bg-amber-500/20 hover:bg-amber-500/30 text-amber-300 rounded border border-amber-500/30 disabled:opacity-50"
         >
-          {retrying ? 'Dispatching...' : '↻ Retry Dispatch'}
+          <RefreshCw className={`w-3 h-3 ${retrying ? 'animate-spin' : ''}`} />
+          {retrying ? 'Dispatching...' : 'Retry Dispatch'}
         </button>
+        {retryError && (
+          <div className="mt-1.5 text-[11px] text-red-300 line-clamp-2" title={retryError}>
+            {retryError}
+          </div>
+        )}
       </div>
     );
   }
@@ -396,6 +418,9 @@ interface TaskCardProps {
 }
 
 function TaskCard({ task, onDragStart, onClick, onMoveStatus, isDragging, mobileMode, portraitMode = true, unreadCount = 0 }: TaskCardProps) {
+  const updateTask = useMissionControl((state) => state.updateTask);
+  const [retryingDispatch, setRetryingDispatch] = useState(false);
+  const [retryDispatchError, setRetryDispatchError] = useState<string | null>(null);
   const priorityStyles = {
     low: 'text-mc-text-secondary',
     normal: 'text-mc-accent',
@@ -415,6 +440,34 @@ function TaskCard({ task, onDragStart, onClick, onMoveStatus, isDragging, mobile
   const isSubtask = !!task.is_subtask;
   const isAssigned = task.status === 'assigned';
   const dispatchError = task.planning_dispatch_error;
+
+  const handleRetryDispatch = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setRetryingDispatch(true);
+    setRetryDispatchError(null);
+
+    try {
+      const res = await fetch(`/api/tasks/${task.id}/dispatch/retry`, { method: 'POST' });
+      const data = await res.json().catch(() => ({} as DispatchRetryResponse));
+
+      if (!res.ok || !data.success) {
+        const message = data.userMessage || data.error || 'Dispatch retry failed';
+        setRetryDispatchError(message);
+        console.error('Retry dispatch failed:', data.error || message);
+        return;
+      }
+
+      if (data.task) {
+        updateTask(data.task);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Dispatch retry failed';
+      setRetryDispatchError(message);
+      console.error('Retry dispatch error:', err);
+    } finally {
+      setRetryingDispatch(false);
+    }
+  };
 
   return (
     <div
@@ -463,14 +516,40 @@ function TaskCard({ task, onDragStart, onClick, onMoveStatus, isDragging, mobile
         )}
 
         {isAssigned && dispatchError && (
-          <div className={`flex items-start gap-2 ${portraitMode ? 'mb-3 py-2 px-3' : 'mb-2 py-1.5 px-2.5'} bg-red-500/10 rounded-md border border-red-500/30`}>
-            <div className="w-2 h-2 bg-red-400 rounded-full mt-1 flex-shrink-0" />
-            <span className="text-xs text-red-300">Assigned, but blocked: {dispatchError}</span>
+          <div className={`${portraitMode ? 'mb-3 p-3' : 'mb-2 p-2.5'} bg-red-500/10 rounded-md border border-red-500/30`}>
+            <div className="flex items-start gap-2">
+              <AlertTriangle className="w-3.5 h-3.5 text-red-300 mt-0.5 flex-shrink-0" />
+              <div className="min-w-0 flex-1">
+                <div className="text-xs font-medium text-red-200">Dispatch blocked</div>
+                <div className="text-[11px] text-red-300/90 line-clamp-2" title={dispatchError}>
+                  {getDispatchErrorSummary(dispatchError)}
+                </div>
+              </div>
+            </div>
+            <button
+              onClick={handleRetryDispatch}
+              disabled={retryingDispatch}
+              className="mt-2 inline-flex items-center gap-1.5 text-[11px] px-2 py-1 bg-red-500/20 hover:bg-red-500/30 text-red-200 rounded border border-red-500/30 disabled:opacity-50"
+            >
+              <RefreshCw className={`w-3 h-3 ${retryingDispatch ? 'animate-spin' : ''}`} />
+              {retryingDispatch ? 'Retrying...' : 'Retry dispatch'}
+            </button>
+            {retryDispatchError && (
+              <div className="mt-1.5 text-[11px] text-red-300 line-clamp-2" title={retryDispatchError}>
+                {retryDispatchError}
+              </div>
+            )}
           </div>
         )}
 
         {isAssigned && !dispatchError && (
-          <AssignedStatusBadge task={task} portraitMode={portraitMode} />
+          <AssignedStatusBadge
+            task={task}
+            portraitMode={portraitMode}
+            retrying={retryingDispatch}
+            retryError={retryDispatchError}
+            onRetryDispatch={handleRetryDispatch}
+          />
         )}
 
         {task.status === 'inbox' && !task.assigned_agent_id && (

--- a/src/components/MissionQueue.tsx
+++ b/src/components/MissionQueue.tsx
@@ -8,6 +8,7 @@ import { getConfig } from '@/lib/config';
 import { useUnreadCounts } from '@/hooks/useUnreadCounts';
 import type { Task, TaskStatus } from '@/lib/types';
 import { TaskModal } from './TaskModal';
+import { EnvironmentIssuePanel, getTaskEnvironmentIssue } from './EnvironmentIssuePanel';
 import { formatDistanceToNow } from 'date-fns';
 
 interface MissionQueueProps {
@@ -440,6 +441,7 @@ function TaskCard({ task, onDragStart, onClick, onMoveStatus, isDragging, mobile
   const isSubtask = !!task.is_subtask;
   const isAssigned = task.status === 'assigned';
   const dispatchError = task.planning_dispatch_error;
+  const environmentIssue = getTaskEnvironmentIssue(task);
 
   const handleRetryDispatch = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -515,7 +517,15 @@ function TaskCard({ task, onDragStart, onClick, onMoveStatus, isDragging, mobile
           </div>
         )}
 
-        {isAssigned && dispatchError && (
+        {environmentIssue && (
+          <EnvironmentIssuePanel
+            task={task}
+            compact
+            className={portraitMode ? 'mb-3' : 'mb-2'}
+          />
+        )}
+
+        {isAssigned && dispatchError && !environmentIssue && (
           <div className={`${portraitMode ? 'mb-3 p-3' : 'mb-2 p-2.5'} bg-red-500/10 rounded-md border border-red-500/30`}>
             <div className="flex items-start gap-2">
               <AlertTriangle className="w-3.5 h-3.5 text-red-300 mt-0.5 flex-shrink-0" />
@@ -542,7 +552,7 @@ function TaskCard({ task, onDragStart, onClick, onMoveStatus, isDragging, mobile
           </div>
         )}
 
-        {isAssigned && !dispatchError && (
+        {isAssigned && !dispatchError && !environmentIssue && (
           <AssignedStatusBadge
             task={task}
             portraitMode={portraitMode}
@@ -559,7 +569,7 @@ function TaskCard({ task, onDragStart, onClick, onMoveStatus, isDragging, mobile
           </div>
         )}
 
-        {['testing', 'verification'].includes(task.status) && dispatchError && (
+        {['testing', 'verification'].includes(task.status) && dispatchError && !environmentIssue && (
           <div className={`flex items-start gap-2 ${portraitMode ? 'mb-3 py-2 px-3' : 'mb-2 py-1.5 px-2.5'} bg-red-500/10 rounded-md border border-red-500/30`}>
             <div className="w-2 h-2 bg-red-400 rounded-full mt-1 flex-shrink-0" />
             <span className="text-xs text-red-300">{dispatchError}</span>

--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -16,6 +16,7 @@ import { AgentLiveTab } from './AgentLiveTab';
 import { TaskChatTab } from './TaskChatTab';
 import { TaskFlightRecorder } from './TaskFlightRecorder';
 import { WorkspaceTab } from './WorkspaceTab';
+import { EnvironmentIssuePanel } from './EnvironmentIssuePanel';
 import type { Task, TaskPriority, TaskStatus } from '@/lib/types';
 
 type TabType = 'overview' | 'planning' | 'convoy' | 'team' | 'activity' | 'flight-recorder' | 'deliverables' | 'images' | 'sessions' | 'workspace' | 'agent-live' | 'chat';
@@ -250,6 +251,8 @@ export function TaskModal({ task, onClose, workspaceId }: TaskModalProps) {
           {/* Overview Tab */}
           {activeTab === 'overview' && (
             <form onSubmit={handleSubmit} className="space-y-4">
+          {task && <EnvironmentIssuePanel task={task} />}
+
           {/* Title */}
           <div>
             <label className="block text-sm font-medium mb-1">Title</label>

--- a/src/lib/agent-health.ts
+++ b/src/lib/agent-health.ts
@@ -3,6 +3,7 @@ import { queryOne, queryAll, run } from '@/lib/db';
 import { broadcast } from '@/lib/events';
 import { getMissionControlUrl } from '@/lib/config';
 import { buildCheckpointContext } from '@/lib/checkpoint';
+import { cancelCodexRunsForTask } from '@/lib/codex/dispatch';
 import type { Agent, AgentHealth, AgentHealthState, SemanticAgentHealthState, Task } from '@/lib/types';
 
 const RECENT_SIGNAL_MINUTES = 5;
@@ -35,9 +36,10 @@ interface NoteSignal extends TimedRow {
 
 interface SessionSignal {
   id: string;
+  runtime: 'openclaw' | 'codex';
+  session_id: string;
   status: string;
   session_type: string;
-  openclaw_session_id: string;
   created_at: string;
   updated_at: string;
 }
@@ -158,15 +160,37 @@ function getActiveTaskForAgent(agentId: string): Task | undefined {
   );
 }
 
-function getSignals(task: Task, agentId: string) {
-  const sessions = queryAll<SessionSignal>(
-    `SELECT * FROM openclaw_sessions
+function isActiveSession(session: SessionSignal): boolean {
+  return session.status === 'active' || session.status === 'running';
+}
+
+function formatSessionId(session: SessionSignal): string {
+  return `${session.runtime}:${session.session_id}`;
+}
+
+function getRuntimeSessions(agentId: string, taskId: string): SessionSignal[] {
+  return queryAll<SessionSignal>(
+    `SELECT id, 'openclaw' AS runtime, openclaw_session_id AS session_id, status, session_type, created_at, updated_at
+     FROM openclaw_sessions
      WHERE agent_id = ?
        AND (task_id = ? OR task_id IS NULL)
+     UNION ALL
+     SELECT id, 'codex' AS runtime, id AS session_id, status, 'codex' AS session_type, created_at, updated_at
+     FROM codex_sessions
+     WHERE agent_id = ?
+       AND task_id = ?
      ORDER BY created_at DESC`,
-    [agentId, task.id]
+    [agentId, taskId, agentId, taskId]
   );
-  const activeSession = sessions.find(s => s.status === 'active');
+}
+
+function getActiveRuntimeSessions(agentId: string, taskId: string): SessionSignal[] {
+  return getRuntimeSessions(agentId, taskId).filter(isActiveSession);
+}
+
+function getSignals(task: Task, agentId: string) {
+  const sessions = getRuntimeSessions(agentId, task.id);
+  const activeSession = sessions.find(isActiveSession);
 
   const activities = queryAll<ActivitySignal>(
     `SELECT id, activity_type, message, created_at
@@ -253,7 +277,7 @@ function buildEvaluation(
     signals: {
       task_status: activeTask?.status,
       has_active_session: Boolean(signals?.activeSession),
-      active_session_id: signals?.activeSession?.openclaw_session_id,
+      active_session_id: signals?.activeSession?.session_id,
       active_session_created_at: normalizeTimestamp(signals?.activeSession?.created_at),
       active_session_updated_at: normalizeTimestamp(signals?.activeSession?.updated_at),
       latest_activity_at: latestActivityAt,
@@ -320,7 +344,7 @@ export function evaluateAgentHealth(agentId: string): AgentHealthEvaluation {
       'no_heartbeat',
       'No active session',
       'danger',
-      'The task is active, but Mission Control has no active OpenClaw session recorded for the assigned agent.',
+      'The task is active, but Mission Control has no active runtime session recorded for the assigned agent.',
       0.9,
       activeTask,
       signals,
@@ -670,13 +694,7 @@ export async function nudgeAgent(agentId: string): Promise<{ success: boolean; e
 
   const now = new Date().toISOString();
   const missionControlUrl = getMissionControlUrl();
-  const activeSessionsBefore = queryAll<SessionSignal>(
-    `SELECT id, status, session_type, openclaw_session_id, created_at, updated_at
-     FROM openclaw_sessions
-     WHERE agent_id = ? AND task_id = ? AND status = 'active'
-     ORDER BY created_at DESC`,
-    [agentId, activeTask.id]
-  );
+  const activeSessionsBefore = getActiveRuntimeSessions(agentId, activeTask.id);
 
   console.warn('[Health][Nudge] Starting auto-nudge', JSON.stringify({
     agentId,
@@ -685,20 +703,23 @@ export async function nudgeAgent(agentId: string): Promise<{ success: boolean; e
     missionControlUrl,
     hasApiToken: Boolean(process.env.MC_API_TOKEN),
     activeSessionCountBefore: activeSessionsBefore.length,
-    activeSessionIdsBefore: activeSessionsBefore.map(s => s.openclaw_session_id),
+    activeSessionIdsBefore: activeSessionsBefore.map(formatSessionId),
   }));
 
   const recoveryStatus = activeTask.status === 'in_progress' ? 'assigned' : activeTask.status;
 
   // End only this task's current session before replacing it.
-  const endResult = run(
+  const openClawEndResult = run(
     `UPDATE openclaw_sessions SET status = 'ended', ended_at = ?, updated_at = ? WHERE agent_id = ? AND task_id = ? AND status = 'active'`,
     [now, now, agentId, activeTask.id]
   );
+  const cancelledCodexRuns = cancelCodexRunsForTask(activeTask.id, agentId);
   console.warn('[Health][Nudge] Ended active sessions before re-dispatch', JSON.stringify({
     agentId,
     taskId: activeTask.id,
-    endedSessionCount: endResult.changes,
+    endedSessionCount: openClawEndResult.changes + cancelledCodexRuns,
+    endedOpenClawSessionCount: openClawEndResult.changes,
+    cancelledCodexRunCount: cancelledCodexRuns,
     recoveryStatus,
   }));
 
@@ -751,13 +772,7 @@ export async function nudgeAgent(agentId: string): Promise<{ success: boolean; e
          WHERE id = ?`,
         [activeTask.id]
       );
-      const activeSessionsAfter = queryAll<SessionSignal>(
-        `SELECT id, status, session_type, openclaw_session_id, created_at, updated_at
-         FROM openclaw_sessions
-         WHERE agent_id = ? AND task_id = ? AND status = 'active'
-         ORDER BY created_at DESC`,
-        [agentId, activeTask.id]
-      );
+      const activeSessionsAfter = getActiveRuntimeSessions(agentId, activeTask.id);
 
       console.warn('[Health][Nudge] Post-dispatch state', JSON.stringify({
         agentId,
@@ -768,7 +783,7 @@ export async function nudgeAgent(agentId: string): Promise<{ success: boolean; e
         planningDispatchError: postDispatchTask?.planning_dispatch_error || null,
         statusReason: postDispatchTask?.status_reason || null,
         activeSessionCountAfter: activeSessionsAfter.length,
-        activeSessionIdsAfter: activeSessionsAfter.map(s => s.openclaw_session_id),
+        activeSessionIdsAfter: activeSessionsAfter.map(formatSessionId),
       }));
 
       if (res.ok && activeSessionsAfter.length > 0) {

--- a/src/lib/codex/dispatch.ts
+++ b/src/lib/codex/dispatch.ts
@@ -1,0 +1,307 @@
+import { spawn } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { v4 as uuidv4 } from 'uuid';
+import { queryAll, queryOne, run } from '@/lib/db';
+import { broadcast } from '@/lib/events';
+import { CODEX_COMMAND } from '@/lib/codex/status';
+import type { Agent, CodexSession, Task } from '@/lib/types';
+
+const CODEX_DISPATCH_SANDBOX = process.env.CODEX_DISPATCH_SANDBOX || 'danger-full-access';
+const CODEX_ENV_PASSTHROUGH = [
+  'HOME',
+  'USER',
+  'LOGNAME',
+  'SHELL',
+  'PATH',
+  'LANG',
+  'LC_ALL',
+  'LC_CTYPE',
+  'TERM',
+  'TMPDIR',
+  'SSH_AUTH_SOCK',
+  'CODEX_HOME',
+  'XDG_CONFIG_HOME',
+];
+
+interface StartCodexTaskRunInput {
+  task: Task;
+  agent: Agent;
+  prompt: string;
+  workingDirectory: string;
+  env?: Record<string, string | undefined>;
+}
+
+export interface StartedCodexTaskRun {
+  sessionId: string;
+  pid?: number;
+  command: string;
+  cwd: string;
+  logPath: string;
+}
+
+function expandPath(input: string): string {
+  if (input === '~') return os.homedir();
+  if (input.startsWith('~/')) return path.join(os.homedir(), input.slice(2));
+  return input;
+}
+
+function ensureDirectory(input: string): string {
+  const resolved = path.resolve(expandPath(input));
+  fs.mkdirSync(resolved, { recursive: true });
+  return resolved;
+}
+
+function createLogPath(taskId: string, sessionId: string): string {
+  const logDir = path.join(process.cwd(), '.codex-runs', taskId);
+  fs.mkdirSync(logDir, { recursive: true });
+  return path.join(logDir, `${sessionId}.log`);
+}
+
+function buildCodexEnvironment(extraEnv?: Record<string, string | undefined>): NodeJS.ProcessEnv {
+  const env: Record<string, string> = {
+    NODE_ENV: process.env.NODE_ENV || 'production',
+  };
+
+  for (const key of CODEX_ENV_PASSTHROUGH) {
+    if (process.env[key]) {
+      env[key] = process.env[key];
+    }
+  }
+
+  if (process.env.MC_API_TOKEN) {
+    env.MC_API_TOKEN = process.env.MC_API_TOKEN;
+  }
+
+  for (const [key, value] of Object.entries(extraEnv || {})) {
+    if (value !== undefined) {
+      env[key] = value;
+    }
+  }
+
+  env.NO_COLOR = '1';
+  return env as NodeJS.ProcessEnv;
+}
+
+function recordActivity(taskId: string, agentId: string, message: string, metadata?: Record<string, unknown>): void {
+  run(
+    `INSERT INTO task_activities (id, task_id, agent_id, activity_type, message, metadata, created_at)
+     VALUES (?, ?, ?, 'status_changed', ?, ?, ?)`,
+    [uuidv4(), taskId, agentId, message, metadata ? JSON.stringify(metadata) : null, new Date().toISOString()]
+  );
+}
+
+function updateTaskFailure(taskId: string, message: string): void {
+  const now = new Date().toISOString();
+  run(
+    `UPDATE tasks
+     SET status = CASE WHEN status = 'in_progress' THEN 'assigned' ELSE status END,
+         planning_dispatch_error = ?,
+         status_reason = ?,
+         updated_at = ?
+     WHERE id = ?
+       AND status != 'done'`,
+    [message, message, now, taskId]
+  );
+
+  const updatedTask = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
+  if (updatedTask) {
+    broadcast({ type: 'task_updated', payload: updatedTask });
+  }
+}
+
+function parseCodexEventLine(line: string): { threadId?: string; finalMessage?: string } | undefined {
+  try {
+    const event = JSON.parse(line) as {
+      type?: string;
+      thread_id?: string;
+      item?: { type?: string; text?: string };
+    };
+
+    if (event.type === 'thread.started' && event.thread_id) {
+      return { threadId: event.thread_id };
+    }
+
+    if (event.type === 'item.completed' && event.item?.type === 'agent_message' && event.item.text) {
+      return { finalMessage: event.item.text };
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+}
+
+function handleCodexStdout(sessionId: string, chunk: Buffer, state: { buffer: string; finalMessage?: string }): void {
+  state.buffer += chunk.toString('utf8');
+  const lines = state.buffer.split(/\r?\n/);
+  state.buffer = lines.pop() || '';
+
+  for (const line of lines) {
+    const parsed = parseCodexEventLine(line.trim());
+    if (!parsed) continue;
+
+    if (parsed.threadId) {
+      run('UPDATE codex_sessions SET codex_thread_id = ?, updated_at = ? WHERE id = ?', [
+        parsed.threadId,
+        new Date().toISOString(),
+        sessionId,
+      ]);
+    }
+
+    if (parsed.finalMessage) {
+      state.finalMessage = parsed.finalMessage;
+    }
+  }
+}
+
+export function startCodexTaskRun(input: StartCodexTaskRunInput): StartedCodexTaskRun {
+  const sessionId = uuidv4();
+  const cwd = ensureDirectory(input.workingDirectory);
+  const logPath = createLogPath(input.task.id, sessionId);
+  const args = ['exec', '--sandbox', CODEX_DISPATCH_SANDBOX, '--json', '--skip-git-repo-check', '--cd', cwd, '-'];
+  const command = `${CODEX_COMMAND} ${args.join(' ')}`;
+  const now = new Date().toISOString();
+
+  const child = spawn(CODEX_COMMAND, args, {
+    cwd,
+    env: buildCodexEnvironment(input.env),
+    stdio: ['pipe', 'pipe', 'pipe'],
+    windowsHide: true,
+  });
+
+  run(
+    `INSERT INTO codex_sessions (id, agent_id, task_id, pid, status, command, cwd, log_path, started_at, created_at, updated_at)
+     VALUES (?, ?, ?, ?, 'running', ?, ?, ?, ?, ?, ?)`,
+    [sessionId, input.agent.id, input.task.id, child.pid || null, command, cwd, logPath, now, now, now]
+  );
+
+  const logStream = fs.createWriteStream(logPath, { flags: 'a' });
+  const stdoutState: { buffer: string; finalMessage?: string } = { buffer: '' };
+  let stderrTail = '';
+
+  child.stdout.on('data', (chunk: Buffer) => {
+    logStream.write(chunk);
+    handleCodexStdout(sessionId, chunk, stdoutState);
+  });
+
+  child.stderr.on('data', (chunk: Buffer) => {
+    const text = chunk.toString('utf8');
+    logStream.write(chunk);
+    stderrTail = (stderrTail + text).slice(-4000);
+  });
+
+  child.on('error', (error) => {
+    const endedAt = new Date().toISOString();
+    const message = `Codex run failed to start: ${error.message}`;
+
+    run(
+      `UPDATE codex_sessions
+       SET status = 'failed', error = ?, ended_at = ?, updated_at = ?
+       WHERE id = ?`,
+      [message, endedAt, endedAt, sessionId]
+    );
+
+    recordActivity(input.task.id, input.agent.id, message, { runtime: 'codex', session_id: sessionId, log_path: logPath });
+    updateTaskFailure(input.task.id, message);
+    logStream.end();
+  });
+
+  child.on('close', (code, signal) => {
+    const endedAt = new Date().toISOString();
+    const failed = code !== 0 || Boolean(signal);
+    const status = failed ? 'failed' : 'completed';
+    const error = failed
+      ? `Codex run exited with ${signal ? `signal ${signal}` : `code ${code}`}${stderrTail.trim() ? `: ${stderrTail.trim()}` : ''}`
+      : null;
+
+    run(
+      `UPDATE codex_sessions
+       SET status = ?, exit_code = ?, signal = ?, error = ?, ended_at = ?, updated_at = ?
+       WHERE id = ?`,
+      [status, code, signal, error, endedAt, endedAt, sessionId]
+    );
+
+    recordActivity(
+      input.task.id,
+      input.agent.id,
+      failed ? `Codex run failed: ${error}` : 'Codex run completed',
+      {
+        runtime: 'codex',
+        session_id: sessionId,
+        log_path: logPath,
+        final_message: stdoutState.finalMessage,
+      }
+    );
+
+    if (failed && error) {
+      updateTaskFailure(input.task.id, error);
+    }
+
+    logStream.end();
+  });
+
+  child.stdin.end(input.prompt);
+
+  return {
+    sessionId,
+    pid: child.pid,
+    command,
+    cwd,
+    logPath,
+  };
+}
+
+export function getActiveCodexSessions(agentId: string, taskId: string): CodexSession[] {
+  return queryAll<CodexSession>(
+    `SELECT * FROM codex_sessions
+     WHERE agent_id = ?
+       AND task_id = ?
+       AND status = 'running'
+     ORDER BY created_at DESC`,
+    [agentId, taskId]
+  );
+}
+
+export function cancelCodexRunsForTask(taskId: string, agentId?: string): number {
+  const sessions = agentId
+    ? queryAll<CodexSession>(
+      `SELECT * FROM codex_sessions WHERE task_id = ? AND agent_id = ? AND status = 'running'`,
+      [taskId, agentId]
+    )
+    : queryAll<CodexSession>(
+      `SELECT * FROM codex_sessions WHERE task_id = ? AND status = 'running'`,
+      [taskId]
+    );
+
+  for (const session of sessions) {
+    if (session.pid) {
+      try {
+        process.kill(session.pid, 'SIGTERM');
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code !== 'ESRCH') {
+          console.warn('[Codex] Failed to terminate prior run:', error);
+        }
+      }
+    }
+  }
+
+  const now = new Date().toISOString();
+  const result = agentId
+    ? run(
+      `UPDATE codex_sessions
+       SET status = 'cancelled', error = ?, ended_at = ?, updated_at = ?
+       WHERE task_id = ? AND agent_id = ? AND status = 'running'`,
+      ['Cancelled before replacement dispatch', now, now, taskId, agentId]
+    )
+    : run(
+      `UPDATE codex_sessions
+       SET status = 'cancelled', error = ?, ended_at = ?, updated_at = ?
+       WHERE task_id = ? AND status = 'running'`,
+      ['Cancelled before replacement dispatch', now, now, taskId]
+    );
+
+  return result.changes;
+}

--- a/src/lib/codex/status.ts
+++ b/src/lib/codex/status.ts
@@ -1,0 +1,124 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+interface CommandError extends Error {
+  code?: string | number;
+  stdout?: string;
+  stderr?: string;
+  killed?: boolean;
+  signal?: NodeJS.Signals;
+}
+
+interface CommandResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+  code?: string | number;
+  error?: string;
+}
+
+export interface CodexCliStatus {
+  installed: boolean;
+  authenticated: boolean;
+  ready: boolean;
+  command: string;
+  version?: string;
+  authMethod?: string;
+  error?: string;
+  loginCommand: string;
+  checkedAt: string;
+}
+
+const CODEX_COMMAND = process.env.CODEX_CLI_PATH || 'codex';
+const LOGIN_COMMAND = `${CODEX_COMMAND} login --device-auth`;
+
+function cleanOutput(output: string): string {
+  return output
+    .replace(/\u001b\[[0-9;]*m/g, '')
+    .split(/\r?\n/)
+    .filter((line) => !line.startsWith('WARNING: proceeding, even though we could not update PATH:'))
+    .join('\n')
+    .trim();
+}
+
+function firstMeaningfulLine(output: string): string | undefined {
+  return cleanOutput(output)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean);
+}
+
+async function runCodex(args: string[], timeoutMs = 5000): Promise<CommandResult> {
+  try {
+    const { stdout, stderr } = await execFileAsync(CODEX_COMMAND, args, {
+      timeout: timeoutMs,
+      maxBuffer: 1024 * 1024,
+      env: {
+        ...process.env,
+        NO_COLOR: '1',
+      },
+      windowsHide: true,
+    });
+
+    return {
+      ok: true,
+      stdout: cleanOutput(stdout),
+      stderr: cleanOutput(stderr),
+    };
+  } catch (error) {
+    const commandError = error as CommandError;
+
+    return {
+      ok: false,
+      stdout: cleanOutput(commandError.stdout || ''),
+      stderr: cleanOutput(commandError.stderr || ''),
+      code: commandError.code,
+      error: commandError.message,
+    };
+  }
+}
+
+function parseAuthMethod(output: string): string | undefined {
+  const match = output.match(/Logged in using\s+(.+)$/im);
+  return match?.[1]?.trim();
+}
+
+export async function getCodexCliStatus(): Promise<CodexCliStatus> {
+  const checkedAt = new Date().toISOString();
+  const versionResult = await runCodex(['--version'], 5000);
+
+  if (!versionResult.ok) {
+    const error = versionResult.code === 'ENOENT'
+      ? 'Codex CLI was not found on the server PATH'
+      : versionResult.stderr || versionResult.stdout || versionResult.error || 'Failed to run Codex CLI';
+
+    return {
+      installed: false,
+      authenticated: false,
+      ready: false,
+      command: CODEX_COMMAND,
+      error,
+      loginCommand: LOGIN_COMMAND,
+      checkedAt,
+    };
+  }
+
+  const version = firstMeaningfulLine(versionResult.stdout || versionResult.stderr);
+  const loginResult = await runCodex(['login', 'status'], 5000);
+  const loginOutput = [loginResult.stdout, loginResult.stderr].filter(Boolean).join('\n');
+  const authenticated = loginResult.ok && /Logged in using/i.test(loginOutput);
+
+  return {
+    installed: true,
+    authenticated,
+    ready: authenticated,
+    command: CODEX_COMMAND,
+    version,
+    authMethod: parseAuthMethod(loginOutput),
+    error: authenticated ? undefined : loginOutput || loginResult.error || 'Codex CLI is not logged in',
+    loginCommand: LOGIN_COMMAND,
+    checkedAt,
+  };
+}

--- a/src/lib/codex/status.ts
+++ b/src/lib/codex/status.ts
@@ -31,7 +31,7 @@ export interface CodexCliStatus {
   checkedAt: string;
 }
 
-const CODEX_COMMAND = process.env.CODEX_CLI_PATH || 'codex';
+export const CODEX_COMMAND = process.env.CODEX_CLI_PATH || 'codex';
 const LOGIN_COMMAND = `${CODEX_COMMAND} login --device-auth`;
 
 function cleanOutput(output: string): string {

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -1625,6 +1625,21 @@ const migrations: Migration[] = [
 
       console.log('[Migration 029] repo_readiness_checks table created');
     }
+  },
+  {
+    id: '030',
+    name: 'add_app_settings',
+    up: (db) => {
+      console.log('[Migration 030] Adding app_settings table...');
+
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS app_settings (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL,
+          updated_at TEXT DEFAULT (datetime('now'))
+        )
+      `);
+    }
   }
 ];
 

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -1640,6 +1640,37 @@ const migrations: Migration[] = [
         )
       `);
     }
+  },
+  {
+    id: '031',
+    name: 'add_codex_sessions',
+    up: (db) => {
+      console.log('[Migration 031] Adding codex_sessions table...');
+
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS codex_sessions (
+          id TEXT PRIMARY KEY,
+          agent_id TEXT REFERENCES agents(id),
+          task_id TEXT REFERENCES tasks(id) ON DELETE CASCADE,
+          codex_thread_id TEXT,
+          pid INTEGER,
+          status TEXT NOT NULL DEFAULT 'running' CHECK (status IN ('running', 'completed', 'failed', 'cancelled')),
+          command TEXT NOT NULL,
+          cwd TEXT NOT NULL,
+          log_path TEXT,
+          exit_code INTEGER,
+          signal TEXT,
+          error TEXT,
+          started_at TEXT DEFAULT (datetime('now')),
+          ended_at TEXT,
+          created_at TEXT DEFAULT (datetime('now')),
+          updated_at TEXT DEFAULT (datetime('now'))
+        )
+      `);
+
+      db.exec('CREATE INDEX IF NOT EXISTS idx_codex_sessions_task ON codex_sessions(task_id, status)');
+      db.exec('CREATE INDEX IF NOT EXISTS idx_codex_sessions_agent ON codex_sessions(agent_id, status)');
+    }
   }
 ];
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -235,6 +235,13 @@ CREATE TABLE IF NOT EXISTS knowledge_entries (
   created_at TEXT DEFAULT (datetime('now'))
 );
 
+-- Application settings persisted for server-side workflows
+CREATE TABLE IF NOT EXISTS app_settings (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL,
+  updated_at TEXT DEFAULT (datetime('now'))
+);
+
 -- Task activities table (for real-time activity log)
 CREATE TABLE IF NOT EXISTS task_activities (
   id TEXT PRIMARY KEY,

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -198,6 +198,26 @@ CREATE TABLE IF NOT EXISTS openclaw_sessions (
   updated_at TEXT DEFAULT (datetime('now'))
 );
 
+-- Codex runtime session mapping
+CREATE TABLE IF NOT EXISTS codex_sessions (
+  id TEXT PRIMARY KEY,
+  agent_id TEXT REFERENCES agents(id),
+  task_id TEXT REFERENCES tasks(id) ON DELETE CASCADE,
+  codex_thread_id TEXT,
+  pid INTEGER,
+  status TEXT NOT NULL DEFAULT 'running' CHECK (status IN ('running', 'completed', 'failed', 'cancelled')),
+  command TEXT NOT NULL,
+  cwd TEXT NOT NULL,
+  log_path TEXT,
+  exit_code INTEGER,
+  signal TEXT,
+  error TEXT,
+  started_at TEXT DEFAULT (datetime('now')),
+  ended_at TEXT,
+  created_at TEXT DEFAULT (datetime('now')),
+  updated_at TEXT DEFAULT (datetime('now'))
+);
+
 -- Workflow templates (per-workspace workflow definitions)
 CREATE TABLE IF NOT EXISTS workflow_templates (
   id TEXT PRIMARY KEY,
@@ -824,4 +844,6 @@ CREATE INDEX IF NOT EXISTS idx_user_task_reads_user_task ON user_task_reads(user
 CREATE INDEX IF NOT EXISTS idx_product_skills_product ON product_skills(product_id, skill_type, status);
 CREATE INDEX IF NOT EXISTS idx_product_skills_confidence ON product_skills(confidence DESC);
 CREATE INDEX IF NOT EXISTS idx_skill_reports_skill ON skill_reports(skill_id);
+CREATE INDEX IF NOT EXISTS idx_codex_sessions_task ON codex_sessions(task_id, status);
+CREATE INDEX IF NOT EXISTS idx_codex_sessions_agent ON codex_sessions(agent_id, status);
 `;

--- a/src/lib/environment-command-suggestion.ts
+++ b/src/lib/environment-command-suggestion.ts
@@ -35,7 +35,14 @@ function cleanCommand(command: string | null | undefined): string | undefined {
     .map(line => line.trim())
     .find(Boolean);
 
-  return firstLine || undefined;
+  return firstLine
+    ?.replace(/^[$>]\s*/, '')
+    .replace(/[.;]\s*$/, '')
+    .trim() || undefined;
+}
+
+function normalizeCommand(command: string | undefined): string | undefined {
+  return command?.trim().replace(/\s+/g, ' ');
 }
 
 function safeJsonParse<T = unknown>(value: string | null | undefined): T | undefined {
@@ -95,7 +102,14 @@ export async function suggestEnvironmentFixCommand(input: {
   issue: EnvironmentIssue;
   activities: RecentActivity[];
   requestText?: string;
+  attemptedCommands?: string[];
 }): Promise<EnvironmentCommandSuggestion> {
+  const attemptedCommands = Array.from(new Set(
+    (input.attemptedCommands || [])
+      .map(command => normalizeCommand(cleanCommand(command)))
+      .filter((command): command is string => Boolean(command))
+  ));
+
   const prompt = `You are helping Mission Control recover an agent task blocked by a local environment issue.
 
 Return only JSON with this exact shape:
@@ -109,9 +123,11 @@ Return only JSON with this exact shape:
 Rules:
 - Use the task logs and error text as the source of truth.
 - Prefer an exact command already present in the logs.
+- Do not return a command that already appears in "Commands already attempted".
 - If no exact command is present, infer one only when the missing dependency/tool and host platform make the command clear.
 - The command must be one shell command line suitable for the server running Mission Control.
 - Do not include placeholders, secrets, tokens, or interactive explanation text in the command.
+- If the only clear command has already been attempted, return can_fix_with_command=false and command=null.
 - If a single concrete command is not clear, return can_fix_with_command=false and command=null.
 - Do not assume a specific OS, package manager, repository host, language, or framework unless the evidence below supports it.
 
@@ -136,6 +152,9 @@ ${input.requestText || ''}
 ${input.task.status_reason || ''}
 ${input.task.planning_dispatch_error || ''}
 
+Commands already attempted:
+${attemptedCommands.length > 0 ? attemptedCommands.map(command => `- ${command}`).join('\n') : '- (none)'}
+
 Recent activities and logs:
 ${formatActivities(input.activities)}`;
 
@@ -146,12 +165,18 @@ ${formatActivities(input.activities)}`;
   });
 
   const command = cleanCommand(result.data.command);
-  const canFixWithCommand = Boolean(result.data.can_fix_with_command && command);
+  const normalizedCommand = normalizeCommand(command);
+  const repeatsAttemptedCommand = Boolean(
+    normalizedCommand && attemptedCommands.includes(normalizedCommand)
+  );
+  const canFixWithCommand = Boolean(result.data.can_fix_with_command && command && !repeatsAttemptedCommand);
 
   return {
     canFixWithCommand,
     command: canFixWithCommand ? command : undefined,
     confidence: result.data.confidence,
-    rationale: result.data.rationale,
+    rationale: repeatsAttemptedCommand
+      ? 'The only suggested command has already been attempted for this task.'
+      : result.data.rationale,
   };
 }

--- a/src/lib/environment-command-suggestion.ts
+++ b/src/lib/environment-command-suggestion.ts
@@ -103,9 +103,10 @@ export async function suggestEnvironmentFixCommand(input: {
   activities: RecentActivity[];
   requestText?: string;
   attemptedCommands?: string[];
+  blockedCommands?: string[];
 }): Promise<EnvironmentCommandSuggestion> {
-  const attemptedCommands = Array.from(new Set(
-    (input.attemptedCommands || [])
+  const blockedCommands = Array.from(new Set(
+    (input.blockedCommands || input.attemptedCommands || [])
       .map(command => normalizeCommand(cleanCommand(command)))
       .filter((command): command is string => Boolean(command))
   ));
@@ -123,11 +124,11 @@ Return only JSON with this exact shape:
 Rules:
 - Use the task logs and error text as the source of truth.
 - Prefer an exact command already present in the logs.
-- Do not return a command that already appears in "Commands already attempted".
+- Do not return a command that appears in "Commands blocked in the current recovery generation".
 - If no exact command is present, infer one only when the missing dependency/tool and host platform make the command clear.
 - The command must be one shell command line suitable for the server running Mission Control.
 - Do not include placeholders, secrets, tokens, or interactive explanation text in the command.
-- If the only clear command has already been attempted, return can_fix_with_command=false and command=null.
+- If the only clear command is blocked in the current recovery generation, return can_fix_with_command=false and command=null.
 - If a single concrete command is not clear, return can_fix_with_command=false and command=null.
 - Do not assume a specific OS, package manager, repository host, language, or framework unless the evidence below supports it.
 
@@ -152,8 +153,8 @@ ${input.requestText || ''}
 ${input.task.status_reason || ''}
 ${input.task.planning_dispatch_error || ''}
 
-Commands already attempted:
-${attemptedCommands.length > 0 ? attemptedCommands.map(command => `- ${command}`).join('\n') : '- (none)'}
+Commands blocked in the current recovery generation:
+${blockedCommands.length > 0 ? blockedCommands.map(command => `- ${command}`).join('\n') : '- (none)'}
 
 Recent activities and logs:
 ${formatActivities(input.activities)}`;
@@ -166,17 +167,17 @@ ${formatActivities(input.activities)}`;
 
   const command = cleanCommand(result.data.command);
   const normalizedCommand = normalizeCommand(command);
-  const repeatsAttemptedCommand = Boolean(
-    normalizedCommand && attemptedCommands.includes(normalizedCommand)
+  const returnsBlockedCommand = Boolean(
+    normalizedCommand && blockedCommands.includes(normalizedCommand)
   );
-  const canFixWithCommand = Boolean(result.data.can_fix_with_command && command && !repeatsAttemptedCommand);
+  const canFixWithCommand = Boolean(result.data.can_fix_with_command && command && !returnsBlockedCommand);
 
   return {
     canFixWithCommand,
     command: canFixWithCommand ? command : undefined,
     confidence: result.data.confidence,
-    rationale: repeatsAttemptedCommand
-      ? 'The only suggested command has already been attempted for this task.'
+    rationale: returnsBlockedCommand
+      ? 'The only suggested command is blocked in the current recovery generation.'
       : result.data.rationale,
   };
 }

--- a/src/lib/environment-command-suggestion.ts
+++ b/src/lib/environment-command-suggestion.ts
@@ -1,0 +1,157 @@
+import fs from 'fs';
+import os from 'os';
+import { completeJSON } from '@/lib/autopilot/llm';
+import type { EnvironmentIssue } from '@/lib/environment-issues';
+import type { Task } from '@/lib/types';
+
+interface RecentActivity {
+  created_at?: string;
+  activity_type?: string;
+  message: string;
+  metadata?: string | null;
+}
+
+export interface EnvironmentCommandSuggestion {
+  canFixWithCommand: boolean;
+  command?: string;
+  rationale?: string;
+  confidence?: 'low' | 'medium' | 'high';
+}
+
+interface SuggestionResponse {
+  can_fix_with_command?: boolean;
+  command?: string | null;
+  rationale?: string;
+  confidence?: 'low' | 'medium' | 'high';
+}
+
+const MAX_LOG_CHARS = 12_000;
+const MAX_ACTIVITY_CHARS = 12_000;
+
+function cleanCommand(command: string | null | undefined): string | undefined {
+  if (!command) return undefined;
+  const firstLine = command
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .find(Boolean);
+
+  return firstLine || undefined;
+}
+
+function safeJsonParse<T = unknown>(value: string | null | undefined): T | undefined {
+  if (!value) return undefined;
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+function readLogTail(logPath: unknown): string | undefined {
+  if (!logPath || typeof logPath !== 'string') return undefined;
+
+  try {
+    const stat = fs.statSync(logPath);
+    if (!stat.isFile()) return undefined;
+    const start = Math.max(0, stat.size - MAX_LOG_CHARS);
+    const fd = fs.openSync(logPath, 'r');
+    try {
+      const buffer = Buffer.alloc(stat.size - start);
+      fs.readSync(fd, buffer, 0, buffer.length, start);
+      return buffer.toString('utf8').trim();
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    return undefined;
+  }
+}
+
+function formatActivities(activities: RecentActivity[]): string {
+  return activities
+    .map((activity) => {
+      const metadata = safeJsonParse<Record<string, unknown>>(activity.metadata || undefined);
+      const lines = [
+        `- ${activity.created_at || 'unknown time'} [${activity.activity_type || 'activity'}]: ${activity.message}`,
+      ];
+
+      if (metadata?.final_message) {
+        lines.push(`  Final message: ${String(metadata.final_message)}`);
+      }
+
+      const logTail = readLogTail(metadata?.log_path);
+      if (logTail) {
+        lines.push(`  Log tail:\n${logTail}`);
+      }
+
+      return lines.join('\n');
+    })
+    .join('\n\n')
+    .slice(-MAX_ACTIVITY_CHARS);
+}
+
+export async function suggestEnvironmentFixCommand(input: {
+  task: Task;
+  issue: EnvironmentIssue;
+  activities: RecentActivity[];
+  requestText?: string;
+}): Promise<EnvironmentCommandSuggestion> {
+  const prompt = `You are helping Mission Control recover an agent task blocked by a local environment issue.
+
+Return only JSON with this exact shape:
+{
+  "can_fix_with_command": true | false,
+  "command": "single shell command to run, or null",
+  "confidence": "low" | "medium" | "high",
+  "rationale": "one short sentence"
+}
+
+Rules:
+- Use the task logs and error text as the source of truth.
+- Prefer an exact command already present in the logs.
+- If no exact command is present, infer one only when the missing dependency/tool and host platform make the command clear.
+- The command must be one shell command line suitable for the server running Mission Control.
+- Do not include placeholders, secrets, tokens, or interactive explanation text in the command.
+- If a single concrete command is not clear, return can_fix_with_command=false and command=null.
+- Do not assume a specific OS, package manager, repository host, language, or framework unless the evidence below supports it.
+
+Server platform:
+- os.platform(): ${os.platform()}
+- os.release(): ${os.release()}
+- os.arch(): ${os.arch()}
+
+Task:
+- id: ${input.task.id}
+- title: ${input.task.title}
+- status: ${input.task.status}
+- workspace_path: ${input.task.workspace_path || '(none)'}
+- repo_url: ${input.task.repo_url || '(none)'}
+- repo_branch: ${input.task.repo_branch || '(none)'}
+
+Classified issue:
+${JSON.stringify(input.issue, null, 2)}
+
+Current error text:
+${input.requestText || ''}
+${input.task.status_reason || ''}
+${input.task.planning_dispatch_error || ''}
+
+Recent activities and logs:
+${formatActivities(input.activities)}`;
+
+  const result = await completeJSON<SuggestionResponse>(prompt, {
+    temperature: 0.1,
+    maxTokens: 700,
+    timeoutMs: 120_000,
+  });
+
+  const command = cleanCommand(result.data.command);
+  const canFixWithCommand = Boolean(result.data.can_fix_with_command && command);
+
+  return {
+    canFixWithCommand,
+    command: canFixWithCommand ? command : undefined,
+    confidence: result.data.confidence,
+    rationale: result.data.rationale,
+  };
+}

--- a/src/lib/environment-issues.test.ts
+++ b/src/lib/environment-issues.test.ts
@@ -1,0 +1,75 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  classifyEnvironmentIssue,
+  classifyEnvironmentIssueFromTexts,
+  hasEnvironmentIssueCommand,
+} from './environment-issues';
+
+test('classifies a missing executable with a suggested setup command', () => {
+  const issue = classifyEnvironmentIssue(
+    "build failed: cannot execute tool 'example-tool' due to missing dependency; use: package-manager install example-tool"
+  );
+
+  assert.equal(issue?.code, 'missing_dependency');
+  assert.equal(issue?.title, 'Missing example-tool');
+  assert.equal(issue?.action.mode, 'command');
+  assert.equal(issue?.action.command, 'package-manager install example-tool');
+  assert.equal(issue ? hasEnvironmentIssueCommand(issue) : false, true);
+});
+
+test('classifies command-not-found failures without inventing an install command', () => {
+  const issue = classifyEnvironmentIssue('example-tool: command not found');
+
+  assert.equal(issue?.code, 'missing_tool');
+  assert.equal(issue?.title, 'Missing example-tool');
+  assert.equal(issue?.action.mode, 'manual');
+  assert.equal(issue?.action.command, undefined);
+});
+
+test('classifies generic missing environment dependencies without hardcoded tooling', () => {
+  const issue = classifyEnvironmentIssue(
+    'Focused tests could not execute because the local build environment is missing the Example Compiler / helper binary. Fix it, then retry the assigned agent.'
+  );
+
+  assert.equal(issue?.code, 'missing_tool');
+  assert.equal(issue?.title, 'Missing Example Compiler');
+  assert.equal(issue?.action.mode, 'manual');
+  assert.equal(issue?.action.command, undefined);
+});
+
+test('classifies repository access failures without assuming a provider-specific command', () => {
+  const issue = classifyEnvironmentIssueFromTexts([
+    'fatal: repository not found',
+    'This may be a private repository access issue.',
+  ]);
+
+  assert.equal(issue?.code, 'repo_access');
+  assert.equal(issue?.action.mode, 'manual');
+  assert.equal(issue?.action.command, undefined);
+});
+
+test('extracts a repository access command when the log suggests one', () => {
+  const issue = classifyEnvironmentIssue(
+    'repository authentication failed; run `credential-helper login` before retrying'
+  );
+
+  assert.equal(issue?.code, 'repo_access');
+  assert.equal(issue?.action.mode, 'command');
+  assert.equal(issue?.action.command, 'credential-helper login');
+});
+
+test('extracts explicit setup command lines from agent failure reports', () => {
+  const issue = classifyEnvironmentIssue(
+    'Focused tests could not execute because the local build environment is missing a helper tool.\nSuggested setup command: package-manager install helper-tool'
+  );
+
+  assert.equal(issue?.code, 'missing_dependency');
+  assert.equal(issue?.action.mode, 'command');
+  assert.equal(issue?.action.command, 'package-manager install helper-tool');
+});
+
+test('ignores normal code failure text', () => {
+  const issue = classifyEnvironmentIssue('Unit test assertion failed: expected 2 to equal 3');
+  assert.equal(issue, null);
+});

--- a/src/lib/environment-issues.ts
+++ b/src/lib/environment-issues.ts
@@ -1,0 +1,226 @@
+export type EnvironmentIssueCode =
+  | 'missing_tool'
+  | 'missing_dependency'
+  | 'repo_access'
+  | 'runtime_auth';
+
+export type EnvironmentIssueFixMode = 'command' | 'manual' | 'settings';
+
+export interface EnvironmentIssueAction {
+  mode: EnvironmentIssueFixMode;
+  label: string;
+  description: string;
+  command?: string;
+  commandSource?: string;
+  settingsHref?: string;
+}
+
+export interface EnvironmentIssue {
+  code: EnvironmentIssueCode;
+  title: string;
+  summary: string;
+  userMessage: string;
+  severity: 'warning' | 'danger';
+  action: EnvironmentIssueAction;
+  retryLabel: string;
+}
+
+function normalizeText(parts: Array<string | null | undefined>): string {
+  return parts.filter(Boolean).join('\n').trim();
+}
+
+function cleanCommand(command: string | undefined): string | undefined {
+  if (!command) return undefined;
+  const firstLine = command
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .find(Boolean);
+  if (!firstLine) return undefined;
+
+  return firstLine
+    .replace(/^[$>]\s*/, '')
+    .replace(/[.;]\s*$/, '')
+    .trim();
+}
+
+function cleanMissingName(name: string | undefined): string | null {
+  if (!name) return null;
+  const cleaned = name
+    .replace(/^the\s+/i, '')
+    .replace(/[.;,/].*$/, '')
+    .trim();
+
+  if (!cleaned || ['the', 'a', 'an', 'or', 'and', 'required', 'local'].includes(cleaned.toLowerCase())) {
+    return null;
+  }
+
+  return cleaned;
+}
+
+function extractSuggestedCommand(text: string): { command: string; source: string } | null {
+  const patterns: Array<{ source: string; regex: RegExp }> = [
+    { source: 'suggested setup command', regex: /suggested\s+(?:setup\s+)?command:\s*([^\n]+)/i },
+    { source: 'error suggestion', regex: /\b(?:use|using):\s*([^\n]+)/i },
+    { source: 'quoted command suggestion', regex: /\b(?:run|try|execute|use)\b\s+[`'"]([^`'"\n]+)[`'"]/i },
+    { source: 'install suggestion', regex: /(?:install(?: it)? (?:with|using)|via)\s+[`'"]?([^`'"\n]+)/i },
+    { source: 'plain command suggestion', regex: /\b(?:run|try|execute|use)\b\s*:\s*([^\n]+)/i },
+  ];
+
+  for (const { source, regex } of patterns) {
+    const match = text.match(regex);
+    const command = cleanCommand(match?.[1]);
+    if (command) return { command, source };
+  }
+
+  return null;
+}
+
+function extractMissingName(text: string): string | null {
+  const patterns = [
+    /cannot execute tool\s+['"`]?([A-Za-z0-9_.+-]+)['"`]?/i,
+    /(?:command|tool|binary|executable)\s+['"`]?([A-Za-z0-9_.+-]+)['"`]?\s+(?:not found|is missing|missing)/i,
+    /['"`]([A-Za-z0-9_.+-]+)['"`]\s*:\s*command not found/i,
+    /\b([A-Za-z0-9_.+-]+):\s*command not found/i,
+    /missing\s+(?:the\s+)?[`'"]?([A-Za-z0-9_.+-]+(?:\s+[A-Za-z0-9_.+-]+){0,3})[`'"]?(?=\s*(?:;|,|\.|\/|$|\n))/i,
+    /missing\s+[`'"]?([A-Za-z0-9_.+-]+)[`'"]?(?:\s|;|,|$)/i,
+    /failed to find\s+[`'"]?([A-Za-z0-9_.+-]+)[`'"]?/i,
+    /No such file or directory.*?['"`]([A-Za-z0-9_.+-]+)['"`]/i,
+  ];
+
+  for (const pattern of patterns) {
+    const match = text.match(pattern);
+    const name = cleanMissingName(match?.[1]);
+    if (name) return name;
+  }
+
+  return null;
+}
+
+function classifySetupIssue(text: string): EnvironmentIssue | null {
+  const normalized = text.toLowerCase();
+  const hasGenericMissingEnvironmentSignal =
+    /\bmissing\s+(?:the\s+)?[A-Za-z0-9_.+-]/i.test(text) &&
+    (
+      normalized.includes('environment') ||
+      normalized.includes('build') ||
+      normalized.includes('test') ||
+      normalized.includes('compiler') ||
+      normalized.includes('dependency') ||
+      normalized.includes('package') ||
+      normalized.includes('tool') ||
+      normalized.includes('binary') ||
+      normalized.includes('executable')
+    );
+  const hasSetupSignal =
+    normalized.includes('command not found') ||
+    normalized.includes('tool not found') ||
+    normalized.includes('binary not found') ||
+    normalized.includes('executable not found') ||
+    normalized.includes('cannot execute tool') ||
+    normalized.includes('no such file or directory') ||
+    normalized.includes('missing dependency') ||
+    normalized.includes('missing package') ||
+    normalized.includes('required dependency') ||
+    normalized.includes('failed to find') ||
+    normalized.includes('not installed') ||
+    hasGenericMissingEnvironmentSignal;
+
+  if (!hasSetupSignal) return null;
+
+  const suggested = extractSuggestedCommand(text);
+  const missingName = extractMissingName(text);
+  const isDependency = normalized.includes('dependency') || normalized.includes('package');
+  const code: EnvironmentIssueCode = isDependency ? 'missing_dependency' : 'missing_tool';
+  const noun = missingName
+    ? `\`${missingName}\``
+    : isDependency
+      ? 'a required dependency'
+      : 'a required tool';
+
+  return {
+    code,
+    title: missingName ? `Missing ${missingName}` : isDependency ? 'Missing dependency' : 'Missing tool',
+    summary: `The local environment is missing ${noun}.`,
+    userMessage: suggested
+      ? 'Review the suggested setup command, approve it if it looks right, then retry the assigned agent.'
+      : 'Enter a setup command to run here, or fix the environment outside Mission Control and retry the assigned agent.',
+    severity: 'danger',
+    action: {
+      mode: suggested ? 'command' : 'manual',
+      label: suggested ? 'Approve command & retry' : 'Run setup command',
+      description: suggested
+        ? 'Runs the exact setup command shown here after user approval, then retries the assigned agent.'
+        : 'Mission Control could not infer a setup command from the logs.',
+      command: suggested?.command,
+      commandSource: suggested?.source,
+    },
+    retryLabel: 'Retry agent',
+  };
+}
+
+export function classifyEnvironmentIssue(text: string | null | undefined): EnvironmentIssue | null {
+  return classifyEnvironmentIssueFromTexts([text]);
+}
+
+export function classifyEnvironmentIssueFromTexts(parts: Array<string | null | undefined>): EnvironmentIssue | null {
+  const text = normalizeText(parts);
+  if (!text) return null;
+
+  const normalized = text.toLowerCase();
+
+  if (
+    normalized.includes('repository not found') ||
+    normalized.includes('could not read from remote repository') ||
+    normalized.includes('authentication failed') ||
+    normalized.includes('repo access') ||
+    normalized.includes('private repo')
+  ) {
+    const suggested = extractSuggestedCommand(text);
+    return {
+      code: 'repo_access',
+      title: 'Repository access needed',
+      summary: 'The agent cannot access the target repository from this machine.',
+      userMessage: suggested
+        ? 'Review the repository access command, approve it if it looks right, then retry the assigned agent.'
+        : 'Confirm repository authentication and access, then retry the assigned agent.',
+      severity: 'warning',
+      action: {
+        mode: suggested ? 'command' : 'manual',
+        label: suggested ? 'Approve command & retry' : 'Fix manually',
+        description: suggested
+          ? 'Runs the exact repository access command shown here after user approval.'
+          : 'Mission Control could not infer an authentication command from the logs.',
+        command: suggested?.command,
+        commandSource: suggested?.source,
+      },
+      retryLabel: 'Retry agent',
+    };
+  }
+
+  if (
+    normalized.includes('runtime is not ready') ||
+    normalized.includes('runtime connection') ||
+    normalized.includes('not authenticated')
+  ) {
+    return {
+      code: 'runtime_auth',
+      title: 'Agent runtime needs setup',
+      summary: 'The selected agent runtime is not connected or authenticated.',
+      userMessage: 'Fix the runtime connection in Settings, then retry the assigned agent.',
+      severity: 'warning',
+      action: {
+        mode: 'settings',
+        label: 'Open Settings',
+        description: 'Check runtime authentication and connection status.',
+        settingsHref: '/settings',
+      },
+      retryLabel: 'Retry agent',
+    };
+  }
+
+  return classifySetupIssue(text);
+}
+
+export function hasEnvironmentIssueCommand(issue: EnvironmentIssue): boolean {
+  return issue.action.mode === 'command' && Boolean(issue.action.command);
+}

--- a/src/lib/repo-preflight.ts
+++ b/src/lib/repo-preflight.ts
@@ -60,7 +60,7 @@ function parseHeadBranches(lsRemoteOutput: string): string[] {
 function authHintForGitError(errorText: string): string {
   const lower = errorText.toLowerCase();
   if (lower.includes('could not resolve host')) {
-    return 'Mission Control could not reach GitHub from the server process. Check network/DNS and retry.';
+    return 'Mission Control could not reach the repository host from the server process. Check network/DNS and retry.';
   }
   if (
     lower.includes('repository not found') ||
@@ -68,7 +68,7 @@ function authHintForGitError(errorText: string): string {
     lower.includes('could not read username') ||
     lower.includes('permission denied')
   ) {
-    return 'Authenticate git for the same user running Mission Control, for example with gh auth login, an SSH remote with a loaded key, or a Git credential helper token.';
+    return 'Authenticate git for the same user running Mission Control, using credentials that can access this repository.';
   }
   return 'Verify the repo URL and that the Mission Control server user can run git ls-remote against it.';
 }

--- a/src/lib/runtime-settings.ts
+++ b/src/lib/runtime-settings.ts
@@ -1,0 +1,100 @@
+import { queryOne, run } from '@/lib/db';
+
+export type AgentRuntimeProvider = 'openclaw' | 'codex';
+
+export interface AgentRuntimeSettings {
+  provider: AgentRuntimeProvider;
+  codexCloudEnvironmentId: string;
+  codexDefaultBranch: string;
+  envOverrides: {
+    provider: boolean;
+    codexCloudEnvironmentId: boolean;
+    codexDefaultBranch: boolean;
+  };
+}
+
+type RuntimeSettingsUpdate = Partial<Pick<AgentRuntimeSettings, 'provider' | 'codexCloudEnvironmentId' | 'codexDefaultBranch'>>;
+
+interface SettingRow {
+  value: string;
+}
+
+const SETTING_KEYS = {
+  provider: 'agent_runtime_provider',
+  codexCloudEnvironmentId: 'codex_cloud_environment_id',
+  codexDefaultBranch: 'codex_default_branch',
+} as const;
+
+function getSetting(key: string): string | undefined {
+  return queryOne<SettingRow>('SELECT value FROM app_settings WHERE key = ?', [key])?.value;
+}
+
+function setSetting(key: string, value: string): void {
+  run(
+    `INSERT INTO app_settings (key, value, updated_at)
+     VALUES (?, ?, datetime('now'))
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+    [key, value]
+  );
+}
+
+function normalizeProvider(value: string | undefined): AgentRuntimeProvider {
+  return value === 'codex' ? 'codex' : 'openclaw';
+}
+
+function normalizeOptionalText(value: string | undefined): string {
+  return (value || '').trim();
+}
+
+function validateSettingsUpdate(updates: RuntimeSettingsUpdate): void {
+  if (updates.provider !== undefined && updates.provider !== 'openclaw' && updates.provider !== 'codex') {
+    throw new Error('Invalid runtime provider');
+  }
+
+  if (updates.codexCloudEnvironmentId !== undefined && updates.codexCloudEnvironmentId.length > 200) {
+    throw new Error('Codex Cloud environment ID is too long');
+  }
+
+  if (updates.codexDefaultBranch !== undefined && updates.codexDefaultBranch.length > 200) {
+    throw new Error('Codex default branch is too long');
+  }
+}
+
+export function getAgentRuntimeSettings(): AgentRuntimeSettings {
+  const providerFromEnv = process.env.AGENT_RUNTIME_PROVIDER;
+  const codexCloudEnvironmentFromEnv = process.env.CODEX_CLOUD_ENV_ID;
+  const codexDefaultBranchFromEnv = process.env.CODEX_DEFAULT_BRANCH;
+
+  return {
+    provider: normalizeProvider(providerFromEnv || getSetting(SETTING_KEYS.provider)),
+    codexCloudEnvironmentId: normalizeOptionalText(
+      codexCloudEnvironmentFromEnv || getSetting(SETTING_KEYS.codexCloudEnvironmentId)
+    ),
+    codexDefaultBranch: normalizeOptionalText(
+      codexDefaultBranchFromEnv || getSetting(SETTING_KEYS.codexDefaultBranch)
+    ),
+    envOverrides: {
+      provider: Boolean(providerFromEnv),
+      codexCloudEnvironmentId: Boolean(codexCloudEnvironmentFromEnv),
+      codexDefaultBranch: Boolean(codexDefaultBranchFromEnv),
+    },
+  };
+}
+
+export function updateAgentRuntimeSettings(updates: RuntimeSettingsUpdate): AgentRuntimeSettings {
+  validateSettingsUpdate(updates);
+
+  if (updates.provider !== undefined) {
+    setSetting(SETTING_KEYS.provider, updates.provider);
+  }
+
+  if (updates.codexCloudEnvironmentId !== undefined) {
+    setSetting(SETTING_KEYS.codexCloudEnvironmentId, normalizeOptionalText(updates.codexCloudEnvironmentId));
+  }
+
+  if (updates.codexDefaultBranch !== undefined) {
+    setSetting(SETTING_KEYS.codexDefaultBranch, normalizeOptionalText(updates.codexDefaultBranch));
+  }
+
+  return getAgentRuntimeSettings();
+}

--- a/src/lib/task-dispatch-context.ts
+++ b/src/lib/task-dispatch-context.ts
@@ -638,6 +638,8 @@ If tests PASS:
 If tests FAIL:
 1. ${failEndpoint}
    Body: {"reason": "Detailed description of what failed and what needs fixing"}
+   If the failure is caused by a missing local tool/dependency or repository access issue, include this exact line in the reason when you can identify a concrete command:
+   Suggested setup command: <single command to run>
 
 Reply with: TEST_PASS: [summary] or TEST_FAIL: [what failed]`;
   }
@@ -654,6 +656,8 @@ If verification PASSES:
 If verification FAILS:
 1. ${failEndpoint}
    Body: {"reason": "Detailed description of what failed and what needs fixing"}
+   If the failure is caused by a missing local tool/dependency or repository access issue, include this exact line in the reason when you can identify a concrete command:
+   Suggested setup command: <single command to run>
 
 Reply with: VERIFY_PASS: [summary] or VERIFY_FAIL: [what failed]`;
   }

--- a/src/lib/task-dispatch-context.ts
+++ b/src/lib/task-dispatch-context.ts
@@ -1,0 +1,698 @@
+import { queryAll, queryOne } from '@/lib/db';
+import { getTaskWorkflow } from '@/lib/workflow-engine';
+import { formatMailForDispatch } from '@/lib/mailbox';
+import { getPendingNotesForDispatch } from '@/lib/task-notes';
+import { getMatchedSkills, formatSkillsForDispatch } from '@/lib/skills';
+import type {
+  Agent,
+  Idea,
+  KnowledgeEntry,
+  Product,
+  ResearchCycle,
+  Task,
+  TaskActivity,
+  TaskDeliverable,
+  TaskImage,
+  TaskStatus,
+  WorkCheckpoint,
+  WorkflowStage,
+} from '@/lib/types';
+
+export const DISPATCH_CONTEXT_VERSION = 'task-dispatch-context/v1';
+
+const SECTION_MAX_CHARS = 32_000;
+const RESEARCH_REPORT_MAX_CHARS = 40_000;
+const ACTIVITY_MESSAGE_MAX_CHARS = 700;
+const FINAL_MESSAGE_MAX_CHARS = 1_200;
+
+export interface DispatchContextSectionAudit {
+  key: string;
+  title: string;
+  included: boolean;
+  charCount: number;
+  truncated: boolean;
+}
+
+export interface DispatchContextAudit {
+  version: typeof DISPATCH_CONTEXT_VERSION;
+  generatedAt: string;
+  taskId: string;
+  agentId: string;
+  totalChars: number;
+  sections: DispatchContextSectionAudit[];
+}
+
+export interface DispatchContextInput {
+  task: Task;
+  agent: Agent;
+  missionControlUrl: string;
+  taskProjectDir: string;
+  workspaceIsolated: boolean;
+  workspaceBranchName?: string;
+  workspacePort?: number;
+}
+
+export interface DispatchContextResult {
+  message: string;
+  audit: DispatchContextAudit;
+  isBuilder: boolean;
+  nextStatus: TaskStatus;
+}
+
+interface SectionDraft {
+  key: string;
+  title: string;
+  body: string;
+  maxChars?: number;
+}
+
+type RuntimeSessionSummary = {
+  runtime: 'openclaw' | 'codex';
+  session_id: string;
+  status: string;
+  created_at: string;
+  updated_at?: string;
+  ended_at?: string;
+  error?: string;
+  log_path?: string;
+};
+
+function clipText(value: string, maxChars: number): { text: string; truncated: boolean } {
+  if (value.length <= maxChars) {
+    return { text: value, truncated: false };
+  }
+
+  const omitted = value.length - maxChars;
+  const headSize = Math.floor(maxChars * 0.65);
+  const tailSize = Math.max(0, maxChars - headSize - 120);
+  return {
+    text: `${value.slice(0, headSize)}\n\n[... ${omitted} characters omitted from the middle of this context section ...]\n\n${value.slice(-tailSize)}`,
+    truncated: true,
+  };
+}
+
+function compact(value: string | null | undefined): string {
+  return (value || '').trim();
+}
+
+function safeJsonParse<T = unknown>(value: string | null | undefined): T | undefined {
+  if (!value) return undefined;
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+function stringifyUnknown(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function formatJsonList(value: string | null | undefined): string {
+  const parsed = safeJsonParse<unknown>(value);
+  if (Array.isArray(parsed)) {
+    return parsed.map(item => `- ${stringifyUnknown(item)}`).join('\n');
+  }
+  if (parsed) return stringifyUnknown(parsed);
+  return compact(value);
+}
+
+function formatTimestamp(value?: string | null): string {
+  return value || 'unknown time';
+}
+
+function addSection(sections: SectionDraft[], key: string, title: string, body: string, maxChars = SECTION_MAX_CHARS): void {
+  sections.push({ key, title, body: compact(body), maxChars });
+}
+
+function renderSections(input: DispatchContextInput, drafts: SectionDraft[]): { message: string; audit: DispatchContextAudit } {
+  const auditSections: DispatchContextSectionAudit[] = [];
+  const rendered: string[] = [];
+
+  for (const section of drafts) {
+    const original = compact(section.body);
+    const { text, truncated } = clipText(original, section.maxChars || SECTION_MAX_CHARS);
+    auditSections.push({
+      key: section.key,
+      title: section.title,
+      included: original.length > 0,
+      charCount: original.length,
+      truncated,
+    });
+
+    if (original.length > 0) {
+      rendered.push(`---\n## ${section.title}\n${text}`);
+    }
+  }
+
+  const message = rendered.join('\n\n');
+  return {
+    message,
+    audit: {
+      version: DISPATCH_CONTEXT_VERSION,
+      generatedAt: new Date().toISOString(),
+      taskId: input.task.id,
+      agentId: input.agent.id,
+      totalChars: message.length,
+      sections: auditSections,
+    },
+  };
+}
+
+function resolveWorkflowStage(task: Task): { currentStage?: WorkflowStage; nextStage?: WorkflowStage } {
+  const workflow = getTaskWorkflow(task.id);
+  if (!workflow) return {};
+
+  let stageIndex = workflow.stages.findIndex(stage => stage.status === task.status);
+  if (stageIndex < 0 && (task.status === 'assigned' || task.status === 'inbox')) {
+    stageIndex = workflow.stages.findIndex(stage => stage.role === 'builder');
+  }
+
+  if (stageIndex < 0) return {};
+
+  return {
+    currentStage: workflow.stages[stageIndex],
+    nextStage: workflow.stages[stageIndex + 1],
+  };
+}
+
+function formatTaskSection(task: Task, agent: Agent, currentStage?: WorkflowStage): string {
+  const roleLabel = currentStage?.label || 'Task';
+  const lines = [
+    `Dispatch mode: ${!currentStage || currentStage.role === 'builder' || task.status === 'assigned' ? 'NEW TASK ASSIGNED' : `${roleLabel.toUpperCase()} STAGE`}`,
+    `Task ID: ${task.id}`,
+    `Title: ${task.title}`,
+    `Status at dispatch: ${task.status}`,
+    `Priority: ${task.priority.toUpperCase()}`,
+    `Assigned gateway: ${agent.name} (${agent.id})`,
+  ];
+
+  if (task.due_date) lines.push(`Due: ${task.due_date}`);
+  if (task.status_reason) lines.push(`Current status reason: ${task.status_reason}`);
+
+  if (task.description) {
+    lines.push('', 'Task description:', task.description);
+  }
+
+  return lines.join('\n');
+}
+
+function formatProductSection(task: Task): string {
+  if (!task.product_id) return 'No linked product record.';
+
+  const product = queryOne<Product>('SELECT * FROM products WHERE id = ?', [task.product_id]);
+  if (!product) return `Linked product ${task.product_id} was not found.`;
+
+  const lines = [
+    `Product: ${product.name} (${product.id})`,
+    `Status: ${product.status}`,
+    `Workspace: ${product.workspace_id}`,
+  ];
+
+  if (product.description) lines.push('', 'Description:', product.description);
+  if (product.product_program) lines.push('', 'Product program:', product.product_program);
+  if (product.live_url) lines.push(`Live URL: ${product.live_url}`);
+  if (product.repo_url) lines.push(`Repo URL: ${product.repo_url}`);
+  if (product.default_branch) lines.push(`Default branch: ${product.default_branch}`);
+  if (product.build_mode) lines.push(`Build mode: ${product.build_mode}`);
+  if (product.cost_cap_per_task !== undefined) lines.push(`Cost cap per task: ${product.cost_cap_per_task}`);
+  if (product.cost_cap_monthly !== undefined) lines.push(`Monthly cost cap: ${product.cost_cap_monthly}`);
+
+  return lines.join('\n');
+}
+
+function getLinkedIdea(task: Task): Idea | null {
+  if (task.idea_id) {
+    const byId = queryOne<Idea>('SELECT * FROM ideas WHERE id = ?', [task.idea_id]);
+    if (byId) return byId;
+  }
+
+  return queryOne<Idea>('SELECT * FROM ideas WHERE task_id = ? ORDER BY updated_at DESC LIMIT 1', [task.id]) || null;
+}
+
+function formatIdeaSection(task: Task): { body: string; idea: Idea | null } {
+  const idea = getLinkedIdea(task);
+  if (!idea) {
+    return { body: 'No linked Autopilot idea record.', idea: null };
+  }
+
+  const lines = [
+    `Idea: ${idea.title} (${idea.id})`,
+    `Category: ${idea.category}`,
+    `Source: ${idea.source}`,
+    `Status: ${idea.status}`,
+  ];
+
+  if (idea.description) lines.push('', 'Idea description:', idea.description);
+  if (idea.research_backing) lines.push('', 'Research backing:', idea.research_backing);
+  if (idea.technical_approach) lines.push('', 'Technical approach:', idea.technical_approach);
+  if (idea.competitive_analysis) lines.push('', 'Competitive analysis:', idea.competitive_analysis);
+  if (idea.target_user_segment) lines.push('', 'Target user segment:', idea.target_user_segment);
+  if (idea.revenue_potential) lines.push('', 'Revenue potential:', idea.revenue_potential);
+  if (idea.risks) lines.push('', 'Risks:', formatJsonList(idea.risks));
+  if (idea.tags) lines.push('', 'Tags:', formatJsonList(idea.tags));
+  if (idea.user_notes) lines.push('', 'User notes from approval:', idea.user_notes);
+  if (idea.similarity_flag) lines.push('', 'Similarity notes:', formatJsonList(idea.similarity_flag));
+  if (idea.impact_score !== undefined) lines.push(`Impact score: ${idea.impact_score}`);
+  if (idea.feasibility_score !== undefined) lines.push(`Feasibility score: ${idea.feasibility_score}`);
+  if (idea.complexity) lines.push(`Complexity: ${idea.complexity}`);
+  if (idea.estimated_effort_hours !== undefined) lines.push(`Estimated effort hours: ${idea.estimated_effort_hours}`);
+  if (idea.source_research) lines.push('', 'Source research excerpts:', formatJsonList(idea.source_research));
+
+  return { body: lines.join('\n'), idea };
+}
+
+function formatResearchSection(task: Task, idea: Idea | null): string {
+  const cycleId = idea?.cycle_id;
+  if (!cycleId) return 'No linked research cycle for this task.';
+
+  const cycle = queryOne<ResearchCycle>('SELECT * FROM research_cycles WHERE id = ?', [cycleId]);
+  if (!cycle) return `Linked research cycle ${cycleId} was not found.`;
+
+  const lines = [
+    `Research cycle: ${cycle.id}`,
+    `Status: ${cycle.status}`,
+    `Phase: ${cycle.current_phase || 'unknown'}`,
+    `Started: ${formatTimestamp(cycle.started_at)}`,
+    `Completed: ${formatTimestamp(cycle.completed_at)}`,
+    `Ideas generated: ${cycle.ideas_generated}`,
+  ];
+
+  if (cycle.error_message) lines.push(`Error: ${cycle.error_message}`);
+  if (cycle.phase_data) lines.push('', 'Phase data:', stringifyUnknown(safeJsonParse(cycle.phase_data) || cycle.phase_data));
+  if (cycle.report) {
+    const parsedReport = safeJsonParse(cycle.report);
+    lines.push('', 'Research report:', stringifyUnknown(parsedReport || cycle.report));
+  } else {
+    lines.push('', 'Research report: No report stored.');
+  }
+
+  return lines.join('\n');
+}
+
+function formatPlanningSection(task: Task, agent: Agent): string {
+  const lines: string[] = [];
+
+  if (task.planning_spec) {
+    const parsed = safeJsonParse<{ spec_markdown?: string } | string>(task.planning_spec);
+    lines.push('Planning specification:', typeof parsed === 'string' ? parsed : parsed?.spec_markdown || stringifyUnknown(parsed || task.planning_spec));
+  } else {
+    lines.push('Planning specification: none stored.');
+  }
+
+  if (task.planning_agents) {
+    const agents = safeJsonParse<Array<{ agent_id?: string; name?: string; role?: string; instructions?: string }>>(task.planning_agents);
+    if (Array.isArray(agents)) {
+      const ownInstructions = agents.find(item => item.agent_id === agent.id || item.name === agent.name);
+      if (ownInstructions?.instructions) {
+        lines.push('', 'Instructions for this gateway:', ownInstructions.instructions);
+      }
+
+      const allInstructions = agents
+        .filter(item => item.instructions)
+        .map(item => `- ${item.name || item.role || item.agent_id || 'Agent'}: ${item.instructions}`)
+        .join('\n');
+      if (allInstructions) lines.push('', 'All planned agent instructions:', allInstructions);
+    } else {
+      lines.push('', 'Planning agents:', task.planning_agents);
+    }
+  } else {
+    lines.push('Planning agents: none stored.');
+  }
+
+  if (task.planning_messages) {
+    lines.push('', 'Planning conversation/messages:', stringifyUnknown(safeJsonParse(task.planning_messages) || task.planning_messages));
+  } else {
+    lines.push('Planning messages: none stored.');
+  }
+
+  return lines.join('\n');
+}
+
+function formatKnowledgeSection(task: Task): string {
+  const entries = queryAll<KnowledgeEntry & { tags: string | null }>(
+    `SELECT *
+     FROM knowledge_entries
+     WHERE workspace_id = ?
+     ORDER BY CASE
+       WHEN task_id = ? THEN 0
+       WHEN task_id IS NULL THEN 1
+       ELSE 2
+     END, confidence DESC, created_at DESC
+     LIMIT 8`,
+    [task.workspace_id, task.id]
+  );
+
+  if (entries.length === 0) return 'No workspace lessons or task-specific knowledge entries found.';
+
+  return entries.map((entry, index) => {
+    const tags = formatJsonList(entry.tags || undefined);
+    return [
+      `${index + 1}. ${entry.title}`,
+      `   Category: ${entry.category}; confidence: ${Math.round(entry.confidence * 100)}%; created: ${entry.created_at}`,
+      tags ? `   Tags: ${tags.replace(/\n/g, '; ')}` : '',
+      `   Content: ${entry.content}`,
+    ].filter(Boolean).join('\n');
+  }).join('\n\n');
+}
+
+function formatSkillsSection(task: Task, agent: Agent): string {
+  if (!task.product_id) return 'No product linked, so no product skills were matched.';
+
+  const skills = getMatchedSkills(task.product_id, task.title, task.description || '', agent.role || agent.name);
+  const formatted = formatSkillsForDispatch(skills);
+  return formatted || 'No matching active product skills found.';
+}
+
+function formatImagesSection(task: Task, missionControlUrl: string): string {
+  if (!task.images) return 'No task reference images.';
+
+  const images = safeJsonParse<TaskImage[]>(task.images);
+  if (!Array.isArray(images) || images.length === 0) return 'No task reference images.';
+
+  return images
+    .map(img => `- ${img.original_name}: ${missionControlUrl}/api/task-images/${task.id}/${img.filename}`)
+    .join('\n');
+}
+
+function parseCheckpoint(row: WorkCheckpoint): WorkCheckpoint {
+  return {
+    ...row,
+    files_snapshot: typeof row.files_snapshot === 'string'
+      ? safeJsonParse<Array<{ path: string; hash: string; size: number }>>(row.files_snapshot)
+      : row.files_snapshot,
+    context_data: typeof row.context_data === 'string'
+      ? safeJsonParse<Record<string, unknown>>(row.context_data)
+      : row.context_data,
+  };
+}
+
+function formatCheckpoint(checkpoint: WorkCheckpoint): string {
+  const lines = [
+    `Checkpoint ${checkpoint.id} (${checkpoint.checkpoint_type}) at ${checkpoint.created_at}`,
+    `Summary: ${checkpoint.state_summary}`,
+  ];
+
+  if (checkpoint.files_snapshot && checkpoint.files_snapshot.length > 0) {
+    lines.push('Files snapshot:');
+    for (const file of checkpoint.files_snapshot) {
+      lines.push(`- ${file.path} (${file.size} bytes)`);
+    }
+  }
+
+  if (checkpoint.context_data) {
+    lines.push('Context data:', stringifyUnknown(checkpoint.context_data));
+  }
+
+  return lines.join('\n');
+}
+
+function getRecentRuntimeSessions(taskId: string): RuntimeSessionSummary[] {
+  return queryAll<RuntimeSessionSummary>(
+    `SELECT 'openclaw' AS runtime, openclaw_session_id AS session_id, status, created_at, updated_at, ended_at, NULL AS error, NULL AS log_path
+     FROM openclaw_sessions
+     WHERE task_id = ?
+     UNION ALL
+     SELECT 'codex' AS runtime, id AS session_id, status, created_at, updated_at, ended_at, error, log_path
+     FROM codex_sessions
+     WHERE task_id = ?
+     ORDER BY created_at DESC
+     LIMIT 8`,
+    [taskId, taskId]
+  );
+}
+
+function formatActivity(activity: TaskActivity & { agent_name?: string | null }): string {
+  const metadata = safeJsonParse<Record<string, unknown>>(activity.metadata);
+  const lines = [
+    `- ${activity.created_at} [${activity.activity_type}${activity.agent_name ? ` by ${activity.agent_name}` : ''}]: ${clipText(activity.message, ACTIVITY_MESSAGE_MAX_CHARS).text}`,
+  ];
+
+  if (metadata?.final_message) {
+    lines.push(`  Final message: ${clipText(String(metadata.final_message), FINAL_MESSAGE_MAX_CHARS).text}`);
+  }
+  if (metadata?.runtime || metadata?.codex_session_id || metadata?.session_id) {
+    lines.push(`  Metadata: ${stringifyUnknown({
+      runtime: metadata.runtime,
+      session_id: metadata.codex_session_id || metadata.session_id,
+      log_path: metadata.log_path,
+    })}`);
+  }
+
+  return lines.join('\n');
+}
+
+function formatPreviousWorkSection(task: Task): string {
+  const lines: string[] = [];
+
+  const deliverables = queryAll<TaskDeliverable>(
+    `SELECT *
+     FROM task_deliverables
+     WHERE task_id = ?
+     ORDER BY created_at DESC
+     LIMIT 12`,
+    [task.id]
+  );
+  lines.push('Registered deliverables:');
+  if (deliverables.length === 0) {
+    lines.push('- None registered.');
+  } else {
+    for (const deliverable of deliverables) {
+      lines.push(`- ${deliverable.created_at} [${deliverable.deliverable_type}] ${deliverable.title}${deliverable.path ? `: ${deliverable.path}` : ''}${deliverable.description ? ` - ${deliverable.description}` : ''}`);
+    }
+  }
+
+  const checkpoints = queryAll<WorkCheckpoint>(
+    `SELECT *
+     FROM work_checkpoints
+     WHERE task_id = ?
+     ORDER BY created_at DESC
+     LIMIT 3`,
+    [task.id]
+  ).map(parseCheckpoint);
+  lines.push('', 'Work checkpoints:');
+  if (checkpoints.length === 0) {
+    lines.push('- None stored.');
+  } else {
+    for (const checkpoint of checkpoints) {
+      lines.push(formatCheckpoint(checkpoint));
+    }
+    lines.push('Continue from the latest checkpoint. Do not redo completed work.');
+  }
+
+  const activities = queryAll<TaskActivity & { agent_name?: string | null }>(
+    `SELECT ta.*, a.name AS agent_name
+     FROM task_activities ta
+     LEFT JOIN agents a ON a.id = ta.agent_id
+     WHERE ta.task_id = ?
+       AND ta.message NOT LIKE 'Agent health:%'
+     ORDER BY ta.created_at DESC
+     LIMIT 15`,
+    [task.id]
+  );
+  lines.push('', 'Recent task activity:');
+  if (activities.length === 0) {
+    lines.push('- No non-health activity recorded.');
+  } else {
+    lines.push(...activities.map(formatActivity));
+  }
+
+  const sessions = getRecentRuntimeSessions(task.id);
+  lines.push('', 'Recent runtime sessions across gateways:');
+  if (sessions.length === 0) {
+    lines.push('- No runtime sessions recorded.');
+  } else {
+    for (const session of sessions) {
+      lines.push(`- ${session.created_at} ${session.runtime}:${session.session_id} status=${session.status}${session.ended_at ? ` ended=${session.ended_at}` : ''}${session.error ? ` error=${clipText(session.error, 700).text}` : ''}${session.log_path ? ` log=${session.log_path}` : ''}`);
+    }
+  }
+
+  if (task.pr_url || task.pr_status || task.merge_pr_url || task.merge_status) {
+    lines.push('', 'PR and merge state:');
+    if (task.pr_url) lines.push(`- PR URL: ${task.pr_url}`);
+    if (task.pr_status) lines.push(`- PR status: ${task.pr_status}`);
+    if (task.merge_pr_url) lines.push(`- Merge PR URL: ${task.merge_pr_url}`);
+    if (task.merge_status) lines.push(`- Merge status: ${task.merge_status}`);
+  }
+
+  return lines.join('\n');
+}
+
+function formatNotesSection(task: Task, agent: Agent): string {
+  const recentNotes = queryAll<{ role: string; mode: string; status: string; content: string; created_at: string; delivered_at?: string | null }>(
+    `SELECT role, mode, status, content, created_at, delivered_at
+     FROM task_notes
+     WHERE task_id = ?
+     ORDER BY created_at DESC
+     LIMIT 12`,
+    [task.id]
+  );
+
+  const lines: string[] = [];
+  if (recentNotes.length > 0) {
+    lines.push('Recent operator/agent notes:');
+    for (const note of recentNotes) {
+      lines.push(`- ${note.created_at} [${note.role}/${note.mode}/${note.status}]: ${note.content}`);
+    }
+  } else {
+    lines.push('Recent operator/agent notes: none.');
+  }
+
+  const { formatted: pendingNotes } = getPendingNotesForDispatch(task.id);
+  if (pendingNotes) {
+    lines.push('', pendingNotes);
+  }
+
+  const mail = formatMailForDispatch(agent.id);
+  if (mail) {
+    lines.push('', mail);
+  } else {
+    lines.push('', 'Unread gateway mail: none.');
+  }
+
+  return lines.join('\n');
+}
+
+function formatRepoSection(task: Task, missionControlUrl: string, isBuilder: boolean): string {
+  if (!task.repo_url) return 'No repository attached to this task.';
+
+  const repoBranch = task.repo_branch || 'main';
+  const branchName = `autopilot/${task.title.toLowerCase().replace(/[^a-z0-9]+/g, '-').slice(0, 50)}`;
+  const lines = [
+    `Repo: ${task.repo_url}`,
+    `Base branch: ${repoBranch}`,
+    `Feature branch: ${branchName}`,
+  ];
+
+  if (isBuilder) {
+    lines.push(
+      '',
+      'Git workflow:',
+      `1. First, verify git access: git ls-remote ${task.repo_url}`,
+      '   If this fails, report the error immediately via Mission Control and stop.',
+      '2. Clone the repo or use the existing local checkout.',
+      `3. Create or continue branch ${branchName} from ${repoBranch}.`,
+      `4. Implement the task. Commit with clear messages that reference task ${task.id}.`,
+      '5. Push the branch and create/update a Pull Request.',
+      '',
+      'PR requirements:',
+      `- Title: "Autopilot: ${task.title}"`,
+      '- Body must include what was built, research backing, technical approach, risks/tradeoffs, and the task ID.',
+      `- Target branch: ${repoBranch}`,
+      `- After creating PR, PATCH ${missionControlUrl}/api/tasks/${task.id} with {"pr_url":"<github PR url>","pr_status":"open"}.`
+    );
+  }
+
+  return lines.join('\n');
+}
+
+function formatWorkspaceSection(input: DispatchContextInput, isBuilder: boolean): string {
+  if (isBuilder && input.workspaceIsolated) {
+    return [
+      `Output/workspace directory: ${input.taskProjectDir}`,
+      `Port: ${input.workspacePort || 'default'} (use this for any dev server, not the default app port)`,
+      input.workspaceBranchName ? `Workspace branch: ${input.workspaceBranchName}` : '',
+      `Do not modify files outside this workspace directory: ${input.taskProjectDir}`,
+      'Create this directory if needed and save all task deliverables there.',
+    ].filter(Boolean).join('\n');
+  }
+
+  return [
+    `Output directory: ${input.taskProjectDir}`,
+    'Create this directory if needed and save all task deliverables there.',
+  ].join('\n');
+}
+
+function formatCompletionSection(input: DispatchContextInput, isBuilder: boolean, isTester: boolean, isVerifier: boolean, nextStatus: TaskStatus): string {
+  const { task, missionControlUrl, taskProjectDir } = input;
+  const failEndpoint = `POST ${missionControlUrl}/api/tasks/${task.id}/fail`;
+
+  if (isBuilder) {
+    return `After completing work, you MUST call these APIs:
+1. Log activity: POST ${missionControlUrl}/api/tasks/${task.id}/activities
+   Body: {"activity_type": "completed", "message": "Description of what was done"}
+2. Register deliverable: POST ${missionControlUrl}/api/tasks/${task.id}/deliverables
+   Body: {"deliverable_type": "file", "title": "File name", "path": "${taskProjectDir}/filename.html"}
+3. Update status: PATCH ${missionControlUrl}/api/tasks/${task.id}
+   Body: {"status": "${nextStatus}"}
+
+When complete, reply with:
+TASK_COMPLETE: [brief summary of what you did]`;
+  }
+
+  if (isTester) {
+    return `YOUR ROLE: TESTER. Test the deliverables for this task.
+
+If tests PASS:
+1. Log activity: POST ${missionControlUrl}/api/tasks/${task.id}/activities
+   Body: {"activity_type": "completed", "message": "Tests passed: [summary]"}
+2. Update status: PATCH ${missionControlUrl}/api/tasks/${task.id}
+   Body: {"status": "${nextStatus}"}
+
+If tests FAIL:
+1. ${failEndpoint}
+   Body: {"reason": "Detailed description of what failed and what needs fixing"}
+
+Reply with: TEST_PASS: [summary] or TEST_FAIL: [what failed]`;
+  }
+
+  if (isVerifier) {
+    return `YOUR ROLE: VERIFIER. Verify that all work meets quality standards.
+
+If verification PASSES:
+1. Log activity: POST ${missionControlUrl}/api/tasks/${task.id}/activities
+   Body: {"activity_type": "completed", "message": "Verification passed: [summary]"}
+2. Update status: PATCH ${missionControlUrl}/api/tasks/${task.id}
+   Body: {"status": "${nextStatus}"}
+
+If verification FAILS:
+1. ${failEndpoint}
+   Body: {"reason": "Detailed description of what failed and what needs fixing"}
+
+Reply with: VERIFY_PASS: [summary] or VERIFY_FAIL: [what failed]`;
+  }
+
+  return `After completing work:
+1. Update status: PATCH ${missionControlUrl}/api/tasks/${task.id}
+   Body: {"status": "${nextStatus}"}`;
+}
+
+export function buildTaskDispatchContext(input: DispatchContextInput): DispatchContextResult {
+  const { task, agent, missionControlUrl } = input;
+  const { currentStage, nextStage } = resolveWorkflowStage(task);
+  const isBuilder = !currentStage || currentStage.role === 'builder' || task.status === 'assigned';
+  const isTester = currentStage?.role === 'tester';
+  const isVerifier = currentStage?.role === 'verifier' || currentStage?.role === 'reviewer';
+  const nextStatus = (nextStage?.status || 'review') as TaskStatus;
+
+  const { body: ideaBody, idea } = formatIdeaSection(task);
+
+  const sections: SectionDraft[] = [];
+  addSection(sections, 'task', 'Task', formatTaskSection(task, agent, currentStage));
+  addSection(sections, 'product', 'Product Context', formatProductSection(task));
+  addSection(sections, 'idea', 'Research Idea Context', ideaBody);
+  addSection(sections, 'research', 'Research Cycle Context', formatResearchSection(task, idea), RESEARCH_REPORT_MAX_CHARS);
+  addSection(sections, 'planning', 'Planning Context', formatPlanningSection(task, agent), SECTION_MAX_CHARS);
+  addSection(sections, 'knowledge', 'Memory and Lessons', formatKnowledgeSection(task), SECTION_MAX_CHARS);
+  addSection(sections, 'skills', 'Reusable Product Skills', formatSkillsSection(task, agent), SECTION_MAX_CHARS);
+  addSection(sections, 'previous_work', 'Previous Work and Continuation Memory', formatPreviousWorkSection(task), SECTION_MAX_CHARS);
+  addSection(sections, 'notes_mail', 'Operator Notes and Gateway Mail', formatNotesSection(task, agent), SECTION_MAX_CHARS);
+  addSection(sections, 'images', 'Reference Images', formatImagesSection(task, missionControlUrl), SECTION_MAX_CHARS);
+  addSection(sections, 'repo', 'Repository and PR Workflow', formatRepoSection(task, missionControlUrl, isBuilder), SECTION_MAX_CHARS);
+  addSection(sections, 'workspace', 'Workspace and Deliverable Location', formatWorkspaceSection(input, isBuilder), SECTION_MAX_CHARS);
+  addSection(sections, 'completion', 'Completion Contract', formatCompletionSection(input, isBuilder, Boolean(isTester), Boolean(isVerifier), nextStatus), SECTION_MAX_CHARS);
+  addSection(sections, 'support', 'Support', 'If you need help or clarification, ask the orchestrator through Mission Control.');
+
+  const rendered = renderSections(input, sections);
+  return {
+    ...rendered,
+    isBuilder,
+    nextStatus,
+  };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -73,6 +73,9 @@ export interface Task {
   planning_complete?: number;
   planning_dispatch_error?: string;
   planning_session_key?: string;
+  planning_messages?: string;
+  planning_spec?: string;
+  planning_agents?: string;
   images?: string; // JSON array of TaskImage objects
   convoy_id?: string;
   is_subtask?: number;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -235,6 +235,25 @@ export interface OpenClawSession {
   updated_at: string;
 }
 
+export interface CodexSession {
+  id: string;
+  agent_id: string;
+  task_id: string;
+  codex_thread_id?: string;
+  pid?: number;
+  status: 'running' | 'completed' | 'failed' | 'cancelled';
+  command: string;
+  cwd: string;
+  log_path?: string;
+  exit_code?: number;
+  signal?: string;
+  error?: string;
+  started_at: string;
+  ended_at?: string;
+  created_at: string;
+  updated_at: string;
+}
+
 export type ActivityType = 'spawned' | 'updated' | 'completed' | 'file_created' | 'status_changed';
 
 export type SemanticAgentHealthState =


### PR DESCRIPTION
## Summary
- Adds environment-recovery actions and guided recovery flow for tasks blocked by environment issues
- Tracks recovery generations and surfaces them in the UI
- Centralizes gateway dispatch context and adds retry recovery for `assigned`-stage dispatches
- Routes task dispatch through the Codex runtime
- Fixes task deletion regression where `ideas.task_id` / `content_inventory.task_id` FK references blocked `DELETE FROM tasks` with `SQLITE_CONSTRAINT_FOREIGNKEY`

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Production build succeeds (`npm run build`)
- [x] Verified task deletion now works in `/workspace/default` (was blocked for 56/60 tasks)
- [ ] Exercise environment recovery actions end-to-end on a real failing task