### PR TITLE
feat: Jira Cloud two-way sync integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,16 @@ MC_API_TOKEN=
 WEBHOOK_SECRET=
 
 # ====================================
+# Jira Cloud Integration (Optional)
+# ====================================
+# JIRA_SYNC=false
+# JIRA_URL=https://yourorg.atlassian.net
+# JIRA_EMAIL=
+# JIRA_API_TOKEN=
+# JIRA_PROJECT_KEY=
+# JIRA_WEBHOOK_SECRET=
+
+# ====================================
 # Security Notes
 # ====================================
 #

--- a/src/app/api/jira/status/route.ts
+++ b/src/app/api/jira/status/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { getJiraConfig, isJiraConfigured } from '@/lib/jira/config';
+
+export const dynamic = 'force-dynamic';
+
+// GET /api/jira/status — returns Jira integration status
+export async function GET() {
+  const config = getJiraConfig();
+  return NextResponse.json({
+    enabled: config.enabled,
+    configured: isJiraConfigured(),
+    ...(isJiraConfigured() && {
+      url: config.url,
+      projectKey: config.projectKey,
+    }),
+  });
+}

--- a/src/app/api/tasks/[id]/jira/route.ts
+++ b/src/app/api/tasks/[id]/jira/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getJiraSyncForTask, createJiraLink, unlinkJiraIssue } from '@/lib/jira/sync';
+import { isJiraConfigured } from '@/lib/jira/config';
+
+export const dynamic = 'force-dynamic';
+
+// GET /api/tasks/[id]/jira — get Jira sync info for a task
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const sync = getJiraSyncForTask(id);
+  if (!sync) {
+    return NextResponse.json({ linked: false }, { status: 200 });
+  }
+  return NextResponse.json({ linked: true, ...sync });
+}
+
+// POST /api/tasks/[id]/jira — create a Jira issue and link it to this task
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  if (!isJiraConfigured()) {
+    return NextResponse.json(
+      { error: 'Jira integration is not configured' },
+      { status: 400 }
+    );
+  }
+
+  const existing = getJiraSyncForTask(id);
+  if (existing) {
+    return NextResponse.json(
+      { error: 'Task is already linked to Jira', ...existing },
+      { status: 409 }
+    );
+  }
+
+  try {
+    const record = await createJiraLink(id);
+    if (!record) {
+      return NextResponse.json({ error: 'Task not found' }, { status: 404 });
+    }
+    return NextResponse.json({ linked: true, ...record }, { status: 201 });
+  } catch (error) {
+    console.error('[Jira] Failed to create link:', error);
+    return NextResponse.json(
+      { error: 'Failed to create Jira issue' },
+      { status: 500 }
+    );
+  }
+}
+
+// DELETE /api/tasks/[id]/jira — unlink Jira issue (does NOT delete the Jira issue)
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  await unlinkJiraIssue(id);
+  return NextResponse.json({ linked: false });
+}

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -11,6 +11,7 @@ import { triggerWorkspaceMerge } from '@/lib/workspace-isolation';
 import { cancelCodexRunsForTask } from '@/lib/codex/dispatch';
 import { UpdateTaskSchema } from '@/lib/validation';
 import { classifyEnvironmentIssueFromTexts } from '@/lib/environment-issues';
+import { syncTaskToJira } from '@/lib/jira/sync';
 import type { Task, UpdateTaskRequest, Agent, TaskDeliverable } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -58,9 +59,12 @@ export async function GET(
             AND ta.activity_type IN ('environment_blocked', 'status_changed')
           ORDER BY ta.created_at DESC
           LIMIT 1
-        ) as latest_activity_context
+        ) as latest_activity_context,
+        js.jira_issue_key,
+        js.jira_issue_url
        FROM tasks t
        LEFT JOIN agents aa ON t.assigned_agent_id = aa.id
+       LEFT JOIN jira_sync js ON js.task_id = t.id
        WHERE t.id = ?`,
       [id]
     );
@@ -520,6 +524,11 @@ export async function PATCH(
         );
       }
     }
+
+    // Fire-and-forget Jira sync (same pattern as auto-dispatch)
+    syncTaskToJira(id).catch(err => {
+      console.error('[Jira Sync] Failed to sync updated task:', err);
+    });
 
     return NextResponse.json(task);
   } catch (error) {

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -6,6 +6,7 @@ import { CreateTaskSchema } from '@/lib/validation';
 import { populateTaskRolesFromAgents } from '@/lib/workflow-engine';
 import { dispatchTaskFromServer } from '@/lib/server-dispatch';
 import { classifyEnvironmentIssueFromTexts } from '@/lib/environment-issues';
+import { syncTaskToJira } from '@/lib/jira/sync';
 import type { Task, CreateTaskRequest, Agent } from '@/lib/types';
 
 // GET /api/tasks - List all tasks with optional filters
@@ -32,10 +33,13 @@ export async function GET(request: NextRequest) {
             AND ta.activity_type IN ('environment_blocked', 'status_changed')
           ORDER BY ta.created_at DESC
           LIMIT 1
-        ) as latest_activity_context
+        ) as latest_activity_context,
+        js.jira_issue_key,
+        js.jira_issue_url
       FROM tasks t
       LEFT JOIN agents aa ON t.assigned_agent_id = aa.id
       LEFT JOIN agents ca ON t.created_by_agent_id = ca.id
+      LEFT JOIN jira_sync js ON js.task_id = t.id
       WHERE 1=1
     `;
     const params: unknown[] = [];
@@ -220,6 +224,11 @@ export async function POST(request: NextRequest) {
         payload: transformedTask,
       });
     }
+
+    // Fire-and-forget Jira sync (same pattern as auto-dispatch)
+    syncTaskToJira(id).catch(err => {
+      console.error('[Jira Sync] Failed to sync new task:', err);
+    });
 
     return NextResponse.json(transformedTask, { status: 201 });
   } catch (error) {

--- a/src/app/api/webhooks/jira/route.ts
+++ b/src/app/api/webhooks/jira/route.ts
@@ -1,0 +1,136 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createHmac, timingSafeEqual } from 'crypto';
+import { getJiraConfig, isJiraConfigured } from '@/lib/jira/config';
+import { syncJiraToTask } from '@/lib/jira/sync';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Verify the Jira Cloud webhook HMAC-SHA256 signature.
+ *
+ * Jira Cloud sends the header `X-Hub-Signature` in the format `sha256=<hex>`.
+ * See: https://developer.atlassian.com/cloud/jira/software/webhooks/
+ */
+function verifySignature(secret: string, signature: string, body: string): boolean {
+  // Jira sends "sha256=<hex>" — strip the prefix to get the raw hex digest
+  const parts = signature.split('=');
+  const algorithm = parts[0]; // e.g. "sha256"
+  const receivedHex = parts.slice(1).join('='); // the hex digest
+
+  if (algorithm !== 'sha256' || !receivedHex) {
+    return false;
+  }
+
+  const expectedHex = createHmac('sha256', secret)
+    .update(body, 'utf8')
+    .digest('hex');
+
+  // Constant-time comparison to prevent timing attacks
+  try {
+    return timingSafeEqual(
+      Buffer.from(receivedHex, 'hex'),
+      Buffer.from(expectedHex, 'hex')
+    );
+  } catch {
+    // If buffers are different lengths (malformed signature), fail closed
+    return false;
+  }
+}
+
+/**
+ * POST /api/webhooks/jira
+ *
+ * Receives Jira Cloud webhook events and syncs them to MC tasks.
+ *
+ * Jira Cloud webhookEvent values:
+ *   - jira:issue_created
+ *   - jira:issue_updated
+ *   - jira:issue_deleted
+ */
+export async function POST(request: NextRequest) {
+  if (!isJiraConfigured()) {
+    return NextResponse.json(
+      { error: 'Jira integration not configured' },
+      { status: 503 }
+    );
+  }
+
+  const config = getJiraConfig();
+  const body = await request.text();
+
+  // HMAC signature validation (if webhook secret is configured)
+  if (config.webhookSecret) {
+    const signature = request.headers.get('x-hub-signature') || '';
+
+    if (!signature || !verifySignature(config.webhookSecret, signature, body)) {
+      console.warn('[Jira Webhook] Invalid signature');
+      return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
+    }
+  }
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(body);
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const eventType = payload.webhookEvent as string | undefined;
+  const issue = payload.issue as {
+    id: string;
+    key: string;
+    fields: {
+      summary: string;
+      project?: { key: string };
+      status?: { name: string; statusCategory?: { key: string } };
+      priority?: { name: string };
+    };
+  } | undefined;
+
+  if (!issue) {
+    return NextResponse.json({ ok: true, skipped: 'no issue in payload' });
+  }
+
+  // Only process issues from our configured project
+  if (issue.fields?.project?.key !== config.projectKey) {
+    return NextResponse.json({ ok: true, skipped: 'different project' });
+  }
+
+  try {
+    if (eventType === 'jira:issue_deleted') {
+      // For now, log deletions but don't delete MC tasks.
+      // Future: optionally mark MC task as done or archive it.
+      console.log('[Jira Webhook] Issue deleted:', issue.key);
+      return NextResponse.json({ ok: true, action: 'noted_deletion' });
+    }
+
+    // For created and updated events, sync to MC
+    syncJiraToTask(issue.id, issue.key, {
+      summary: issue.fields.summary,
+      statusName: issue.fields.status?.name || 'To Do',
+      statusCategoryKey: issue.fields.status?.statusCategory?.key || 'new',
+      priorityName: issue.fields.priority?.name || 'Medium',
+    });
+
+    const action = eventType === 'jira:issue_created' ? 'created' : 'updated';
+    return NextResponse.json({ ok: true, action });
+  } catch (error) {
+    console.error('[Jira Webhook] Error processing event:', error);
+    return NextResponse.json(
+      { error: 'Processing failed' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * GET /api/webhooks/jira
+ *
+ * Health/status check for the Jira webhook endpoint.
+ */
+export async function GET() {
+  return NextResponse.json({
+    status: isJiraConfigured() ? 'active' : 'not_configured',
+    info: 'POST Jira Cloud webhook events to this endpoint',
+  });
+}

--- a/src/components/MissionQueue.tsx
+++ b/src/components/MissionQueue.tsx
@@ -614,6 +614,11 @@ function TaskCard({ task, onDragStart, onClick, onMoveStatus, isDragging, mobile
           <div className="flex items-center gap-1.5">
             <div className={`w-1.5 h-1.5 rounded-full ${priorityDots[task.priority]}`} />
             <span className={`text-xs capitalize ${priorityStyles[task.priority]}`}>{task.priority}</span>
+            {task.jira_issue_key && (
+              <span className="text-[10px] font-medium text-blue-400" title={`Linked: ${task.jira_issue_key}`}>
+                JIRA
+              </span>
+            )}
           </div>
           <span className="text-[10px] text-mc-text-secondary/60">{formatDistanceToNow(new Date(task.created_at), { addSuffix: true })}</span>
         </div>

--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState, useCallback } from 'react';
-import { X, Save, Trash2, Activity, Package, Bot, ClipboardList, Plus, Users, ImageIcon, Truck, Radio, MessageSquare, ExternalLink, HardDrive, Route, BarChart3 } from 'lucide-react';
+import { useState, useCallback, useEffect } from 'react';
+import { X, Save, Trash2, Activity, Package, Bot, ClipboardList, Plus, Users, ImageIcon, Truck, Radio, MessageSquare, ExternalLink, HardDrive, Route, BarChart3, Unlink, Loader2 } from 'lucide-react';
 import { useMissionControl } from '@/lib/store';
 import { triggerAutoDispatch, shouldTriggerAutoDispatch } from '@/lib/auto-dispatch';
 import { ActivityLog } from './ActivityLog';
@@ -42,6 +42,66 @@ export function TaskModal({ task, onClose, workspaceId }: TaskModalProps) {
   const handleSpecLocked = useCallback(() => {
     window.location.reload();
   }, []);
+
+  // Jira integration state
+  const [jiraConfigured, setJiraConfigured] = useState(false);
+  const [jiraLinking, setJiraLinking] = useState(false);
+  const [jiraUnlinking, setJiraUnlinking] = useState(false);
+  const [taskJiraKey, setTaskJiraKey] = useState(task?.jira_issue_key || '');
+  const [taskJiraUrl, setTaskJiraUrl] = useState(task?.jira_issue_url || '');
+
+  // Check Jira config on mount
+  useEffect(() => {
+    fetch('/api/jira/status')
+      .then((res) => res.json())
+      .then((data) => setJiraConfigured(data.configured === true))
+      .catch(() => setJiraConfigured(false));
+  }, []);
+
+  const handleJiraLink = async () => {
+    if (!task) return;
+    setJiraLinking(true);
+    try {
+      const res = await fetch(`/api/tasks/${task.id}/jira`, { method: 'POST' });
+      if (res.ok) {
+        const data = await res.json();
+        setTaskJiraKey(data.jira_issue_key || '');
+        setTaskJiraUrl(data.jira_issue_url || '');
+        // Refresh the task in the store
+        const taskRes = await fetch(`/api/tasks/${task.id}`);
+        if (taskRes.ok) {
+          const updatedTask = await taskRes.json();
+          updateTask(updatedTask);
+        }
+      }
+    } catch (error) {
+      console.error('Failed to link Jira issue:', error);
+    } finally {
+      setJiraLinking(false);
+    }
+  };
+
+  const handleJiraUnlink = async () => {
+    if (!task) return;
+    setJiraUnlinking(true);
+    try {
+      const res = await fetch(`/api/tasks/${task.id}/jira`, { method: 'DELETE' });
+      if (res.ok) {
+        setTaskJiraKey('');
+        setTaskJiraUrl('');
+        // Refresh the task in the store
+        const taskRes = await fetch(`/api/tasks/${task.id}`);
+        if (taskRes.ok) {
+          const updatedTask = await taskRes.json();
+          updateTask(updatedTask);
+        }
+      }
+    } catch (error) {
+      console.error('Failed to unlink Jira issue:', error);
+    } finally {
+      setJiraUnlinking(false);
+    }
+  };
 
   const [form, setForm] = useState({
     title: task?.title || '',
@@ -407,6 +467,61 @@ export function TaskModal({ task, onClose, workspaceId }: TaskModalProps) {
           {saveError && (
             <div className="p-3 bg-red-500/10 border border-red-500/30 rounded-md">
               <span className="text-sm text-red-400">{saveError}</span>
+            </div>
+          )}
+
+          {/* Jira Integration */}
+          {task && jiraConfigured && (
+            <div className="p-3 bg-mc-bg rounded-lg border border-mc-border">
+              <label className="block text-sm font-medium mb-2">Jira</label>
+              {taskJiraKey ? (
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <svg className="w-4 h-4 text-blue-400 flex-shrink-0" viewBox="0 0 24 24" fill="currentColor">
+                      <path d="M11.53 2c0 2.4 1.97 4.35 4.35 4.35h1.78v1.7c0 2.4 1.94 4.34 4.34 4.35V2.84a.84.84 0 0 0-.84-.84H11.53zM6.77 6.8a4.36 4.36 0 0 0 4.34 4.34h1.8v1.72a4.36 4.36 0 0 0 4.34 4.34V7.63a.84.84 0 0 0-.83-.83H6.77zM2 11.6a4.35 4.35 0 0 0 4.34 4.34h1.8v1.72A4.35 4.35 0 0 0 12.48 22v-9.57a.84.84 0 0 0-.84-.84H2z"/>
+                    </svg>
+                    <a
+                      href={taskJiraUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sm text-blue-400 hover:text-blue-300 hover:underline flex items-center gap-1 truncate"
+                    >
+                      {taskJiraKey}
+                      <ExternalLink className="w-3 h-3 flex-shrink-0" />
+                    </a>
+                    <span className="text-xs text-mc-text-secondary">Synced</span>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={handleJiraUnlink}
+                    disabled={jiraUnlinking}
+                    className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-mc-text-secondary hover:text-mc-accent-red hover:bg-mc-accent-red/10 rounded transition-colors disabled:opacity-50"
+                  >
+                    {jiraUnlinking ? (
+                      <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                    ) : (
+                      <Unlink className="w-3.5 h-3.5" />
+                    )}
+                    Unlink
+                  </button>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={handleJiraLink}
+                  disabled={jiraLinking}
+                  className="flex items-center gap-2 px-3 py-2 text-sm bg-mc-bg-tertiary border border-mc-border rounded hover:border-blue-400/40 hover:text-blue-400 transition-colors disabled:opacity-50"
+                >
+                  {jiraLinking ? (
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                  ) : (
+                    <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                      <path d="M11.53 2c0 2.4 1.97 4.35 4.35 4.35h1.78v1.7c0 2.4 1.94 4.34 4.34 4.35V2.84a.84.84 0 0 0-.84-.84H11.53zM6.77 6.8a4.36 4.36 0 0 0 4.34 4.34h1.8v1.72a4.36 4.36 0 0 0 4.34 4.34V7.63a.84.84 0 0 0-.83-.83H6.77zM2 11.6a4.35 4.35 0 0 0 4.34 4.34h1.8v1.72A4.35 4.35 0 0 0 12.48 22v-9.57a.84.84 0 0 0-.84-.84H2z"/>
+                    </svg>
+                  )}
+                  Link to Jira
+                </button>
+              )}
             </div>
           )}
             </form>

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -1794,6 +1794,32 @@ const migrations: Migration[] = [
 
       console.log('[Migration 036] codebase_snapshots table created');
     }
+  },
+  {
+    id: '037',
+    name: 'add_jira_sync',
+    up: (db) => {
+      console.log('[Migration 037] Adding jira_sync table...');
+
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS jira_sync (
+          id TEXT PRIMARY KEY,
+          task_id TEXT NOT NULL UNIQUE REFERENCES tasks(id) ON DELETE CASCADE,
+          jira_issue_id TEXT NOT NULL,
+          jira_issue_key TEXT NOT NULL,
+          jira_issue_url TEXT NOT NULL,
+          sync_enabled INTEGER DEFAULT 1,
+          last_synced_at TEXT,
+          last_sync_direction TEXT,
+          created_at TEXT DEFAULT (datetime('now'))
+        )
+      `);
+      db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_jira_sync_task ON jira_sync(task_id)`);
+      db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_jira_sync_jira_id ON jira_sync(jira_issue_id)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_jira_sync_key ON jira_sync(jira_issue_key)`);
+
+      console.log('[Migration 037] Created jira_sync table with indexes');
+    }
   }
 ];
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -800,6 +800,19 @@ CREATE TABLE IF NOT EXISTS codebase_snapshots (
   UNIQUE(product_id, commit_sha)
 );
 
+-- Jira Cloud sync mapping
+CREATE TABLE IF NOT EXISTS jira_sync (
+  id TEXT PRIMARY KEY,
+  task_id TEXT NOT NULL UNIQUE REFERENCES tasks(id) ON DELETE CASCADE,
+  jira_issue_id TEXT NOT NULL,
+  jira_issue_key TEXT NOT NULL,
+  jira_issue_url TEXT NOT NULL,
+  sync_enabled INTEGER DEFAULT 1,
+  last_synced_at TEXT,
+  last_sync_direction TEXT,
+  created_at TEXT DEFAULT (datetime('now'))
+);
+
 -- Indexes for performance
 CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_tasks_assigned ON tasks(assigned_agent_id);
@@ -866,4 +879,7 @@ CREATE INDEX IF NOT EXISTS idx_product_skills_confidence ON product_skills(confi
 CREATE INDEX IF NOT EXISTS idx_skill_reports_skill ON skill_reports(skill_id);
 CREATE INDEX IF NOT EXISTS idx_codex_sessions_task ON codex_sessions(task_id, status);
 CREATE INDEX IF NOT EXISTS idx_codex_sessions_agent ON codex_sessions(agent_id, status);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_jira_sync_task ON jira_sync(task_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_jira_sync_jira_id ON jira_sync(jira_issue_id);
+CREATE INDEX IF NOT EXISTS idx_jira_sync_key ON jira_sync(jira_issue_key);
 `;

--- a/src/lib/jira/client.ts
+++ b/src/lib/jira/client.ts
@@ -1,0 +1,186 @@
+import { getJiraConfig } from './config';
+
+// ── Internal helpers ──────────────────────────────────────────────────
+
+async function jiraFetch(path: string, options: RequestInit = {}): Promise<Response> {
+  const config = getJiraConfig();
+  const auth = Buffer.from(`${config.email}:${config.apiToken}`).toString('base64');
+
+  const url = `${config.url}${path}`;
+  const res = await fetch(url, {
+    ...options,
+    headers: {
+      'Authorization': `Basic ${auth}`,
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '(no body)');
+    throw new Error(`Jira API ${options.method || 'GET'} ${path} failed (${res.status}): ${body}`);
+  }
+
+  return res;
+}
+
+/**
+ * Convert plain text to a simple Atlassian Document Format (ADF) document.
+ * Jira REST API v3 requires description in ADF rather than plain text.
+ */
+function textToAdf(text: string): object {
+  return {
+    type: 'doc',
+    version: 1,
+    content: [
+      {
+        type: 'paragraph',
+        content: [
+          {
+            type: 'text',
+            text,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+// ── Public API ────────────────────────────────────────────────────────
+
+/**
+ * Create a new Jira issue.
+ */
+export async function createJiraIssue(params: {
+  summary: string;
+  description?: string;
+  priorityName?: string;
+  issueTypeName?: string;
+}): Promise<{ id: string; key: string; self: string }> {
+  const config = getJiraConfig();
+
+  const fields: Record<string, unknown> = {
+    project: { key: config.projectKey },
+    summary: params.summary,
+    issuetype: { name: params.issueTypeName || 'Task' },
+  };
+
+  if (params.description) {
+    fields.description = textToAdf(params.description);
+  }
+
+  if (params.priorityName) {
+    fields.priority = { name: params.priorityName };
+  }
+
+  const res = await jiraFetch('/rest/api/3/issue', {
+    method: 'POST',
+    body: JSON.stringify({ fields }),
+  });
+
+  return res.json() as Promise<{ id: string; key: string; self: string }>;
+}
+
+/**
+ * Update an existing Jira issue.
+ */
+export async function updateJiraIssue(
+  issueIdOrKey: string,
+  params: {
+    summary?: string;
+    description?: string;
+    priorityName?: string;
+  },
+): Promise<void> {
+  const fields: Record<string, unknown> = {};
+
+  if (params.summary !== undefined) {
+    fields.summary = params.summary;
+  }
+
+  if (params.description !== undefined) {
+    fields.description = textToAdf(params.description);
+  }
+
+  if (params.priorityName !== undefined) {
+    fields.priority = { name: params.priorityName };
+  }
+
+  await jiraFetch(`/rest/api/3/issue/${issueIdOrKey}`, {
+    method: 'PUT',
+    body: JSON.stringify({ fields }),
+  });
+}
+
+/**
+ * Transition a Jira issue to a target status.
+ *
+ * Jira does not allow setting status directly -- you must find the
+ * available transition that leads to the desired status and invoke it.
+ *
+ * Returns true if transitioned, false if no matching transition was found.
+ */
+export async function transitionJiraIssue(
+  issueIdOrKey: string,
+  targetStatusName: string,
+): Promise<boolean> {
+  // Step 1: Get available transitions
+  const res = await jiraFetch(`/rest/api/3/issue/${issueIdOrKey}/transitions`);
+  const data = (await res.json()) as {
+    transitions: { id: string; name: string; to: { name: string } }[];
+  };
+
+  // Step 2: Find a transition whose target status matches (case-insensitive)
+  const target = targetStatusName.toLowerCase();
+  const match = data.transitions.find(
+    (t) => t.to.name.toLowerCase() === target || t.name.toLowerCase() === target,
+  );
+
+  if (!match) {
+    return false;
+  }
+
+  // Step 3: Perform the transition
+  await jiraFetch(`/rest/api/3/issue/${issueIdOrKey}/transitions`, {
+    method: 'POST',
+    body: JSON.stringify({ transition: { id: match.id } }),
+  });
+
+  return true;
+}
+
+/**
+ * Get a Jira issue by ID or key.
+ */
+export async function getJiraIssue(issueIdOrKey: string): Promise<{
+  id: string;
+  key: string;
+  fields: {
+    summary: string;
+    description: unknown;
+    status: { name: string; statusCategory: { key: string } };
+    priority: { name: string };
+  };
+}> {
+  const res = await jiraFetch(`/rest/api/3/issue/${issueIdOrKey}`);
+  return res.json() as Promise<{
+    id: string;
+    key: string;
+    fields: {
+      summary: string;
+      description: unknown;
+      status: { name: string; statusCategory: { key: string } };
+      priority: { name: string };
+    };
+  }>;
+}
+
+/**
+ * Delete a Jira issue.
+ */
+export async function deleteJiraIssue(issueIdOrKey: string): Promise<void> {
+  await jiraFetch(`/rest/api/3/issue/${issueIdOrKey}`, {
+    method: 'DELETE',
+  });
+}

--- a/src/lib/jira/config.ts
+++ b/src/lib/jira/config.ts
@@ -1,0 +1,24 @@
+export interface JiraConfig {
+  enabled: boolean;
+  url: string;
+  email: string;
+  apiToken: string;
+  projectKey: string;
+  webhookSecret: string;
+}
+
+export function getJiraConfig(): JiraConfig {
+  return {
+    enabled: process.env.JIRA_SYNC === 'true',
+    url: (process.env.JIRA_URL || '').replace(/\/$/, ''),
+    email: process.env.JIRA_EMAIL || '',
+    apiToken: process.env.JIRA_API_TOKEN || '',
+    projectKey: process.env.JIRA_PROJECT_KEY || '',
+    webhookSecret: process.env.JIRA_WEBHOOK_SECRET || '',
+  };
+}
+
+export function isJiraConfigured(): boolean {
+  const config = getJiraConfig();
+  return config.enabled && !!config.url && !!config.email && !!config.apiToken && !!config.projectKey;
+}

--- a/src/lib/jira/mappings.ts
+++ b/src/lib/jira/mappings.ts
@@ -1,0 +1,75 @@
+import type { TaskStatus, TaskPriority } from '../types';
+
+// ── MC Status → Jira Status Name ──────────────────────────────────────
+const statusToJira: Record<TaskStatus, string> = {
+  inbox: 'To Do',
+  planning: 'To Do',
+  assigned: 'To Do',
+  pending_dispatch: 'To Do',
+  in_progress: 'In Progress',
+  convoy_active: 'In Progress',
+  testing: 'In Review',
+  review: 'In Review',
+  verification: 'In Review',
+  review_fix: 'In Progress',
+  done: 'Done',
+};
+
+export function mcStatusToJira(status: TaskStatus): string {
+  return statusToJira[status] || 'To Do';
+}
+
+// ── Jira Status → MC Status ──────────────────────────────────────────
+// First try exact status name, then fall back to Jira status category.
+const jiraStatusNameToMc: Record<string, TaskStatus> = {
+  'to do': 'inbox',
+  'in progress': 'in_progress',
+  'in review': 'review',
+  'done': 'done',
+};
+
+// Jira status categories: 'new' | 'indeterminate' | 'done'
+const jiraCategoryToMc: Record<string, TaskStatus> = {
+  new: 'inbox',
+  indeterminate: 'in_progress',
+  done: 'done',
+};
+
+export function jiraStatusToMc(
+  statusName: string,
+  statusCategoryKey?: string,
+): TaskStatus {
+  const byName = jiraStatusNameToMc[statusName.toLowerCase()];
+  if (byName) return byName;
+
+  if (statusCategoryKey) {
+    const byCat = jiraCategoryToMc[statusCategoryKey.toLowerCase()];
+    if (byCat) return byCat;
+  }
+
+  return 'inbox';
+}
+
+// ── Priority mappings ─────────────────────────────────────────────────
+const priorityToJira: Record<TaskPriority, string> = {
+  low: 'Low',
+  normal: 'Medium',
+  high: 'High',
+  urgent: 'Highest',
+};
+
+export function mcPriorityToJira(priority: TaskPriority): string {
+  return priorityToJira[priority] || 'Medium';
+}
+
+const jiraPriorityMap: Record<string, TaskPriority> = {
+  lowest: 'low',
+  low: 'low',
+  medium: 'normal',
+  high: 'high',
+  highest: 'urgent',
+};
+
+export function jiraPriorityToMc(priorityName: string): TaskPriority {
+  return jiraPriorityMap[priorityName.toLowerCase()] || 'normal';
+}

--- a/src/lib/jira/sync.ts
+++ b/src/lib/jira/sync.ts
@@ -1,0 +1,181 @@
+import { v4 as uuidv4 } from 'uuid';
+import { isJiraConfigured, getJiraConfig } from './config';
+import { createJiraIssue, updateJiraIssue, transitionJiraIssue } from './client';
+import { mcStatusToJira, mcPriorityToJira, jiraStatusToMc, jiraPriorityToMc } from './mappings';
+import { queryOne, run } from '../db';
+import { broadcast } from '../events';
+import type { Task } from '../types';
+
+export interface JiraSyncRecord {
+  id: string;
+  task_id: string;
+  jira_issue_id: string;
+  jira_issue_key: string;
+  jira_issue_url: string;
+  sync_enabled: number;
+  last_synced_at: string | null;
+  last_sync_direction: string | null;
+  created_at: string;
+}
+
+/**
+ * Main outbound sync: push an MC task to Jira.
+ * Creates a new Jira issue if no link exists, updates if linked.
+ * Never throws — failures are logged but never break task operations.
+ */
+export async function syncTaskToJira(taskId: string): Promise<void> {
+  if (!isJiraConfigured()) return;
+
+  try {
+    const task = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
+    if (!task) return;
+
+    const syncRecord = queryOne<JiraSyncRecord>(
+      'SELECT * FROM jira_sync WHERE task_id = ?',
+      [taskId]
+    );
+
+    // Loop prevention: skip if recently synced FROM Jira
+    if (syncRecord?.last_synced_at && syncRecord.last_sync_direction === 'from_jira') {
+      const lastSync = new Date(syncRecord.last_synced_at).getTime();
+      if (Date.now() - lastSync < 5000) return;
+    }
+
+    if (!syncRecord) {
+      // No link yet — create Jira issue and link it
+      await createJiraLink(taskId);
+    } else if (syncRecord.sync_enabled) {
+      // Linked — push updates to existing Jira issue
+      const jiraStatus = mcStatusToJira(task.status);
+      const jiraPriority = mcPriorityToJira(task.priority);
+
+      await updateJiraIssue(syncRecord.jira_issue_key, {
+        summary: task.title,
+        description: task.description || '',
+        priorityName: jiraPriority,
+      });
+
+      await transitionJiraIssue(syncRecord.jira_issue_key, jiraStatus);
+
+      run(
+        "UPDATE jira_sync SET last_synced_at = datetime('now'), last_sync_direction = ? WHERE id = ?",
+        ['to_jira', syncRecord.id]
+      );
+    }
+  } catch (error) {
+    console.error('[Jira Sync] Outbound sync failed for task', taskId, error);
+    // Never break task operations
+  }
+}
+
+/**
+ * Create a Jira issue and link it to an MC task.
+ * Returns the sync record on success, null on failure.
+ */
+export async function createJiraLink(taskId: string): Promise<JiraSyncRecord | null> {
+  if (!isJiraConfigured()) return null;
+
+  const task = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [taskId]);
+  if (!task) return null;
+
+  const config = getJiraConfig();
+  const jiraPriority = mcPriorityToJira(task.priority);
+
+  const result = await createJiraIssue({
+    summary: task.title,
+    description: task.description || '',
+    priorityName: jiraPriority,
+  });
+
+  const jiraUrl = `${config.url}/browse/${result.key}`;
+  const id = uuidv4();
+
+  run(
+    `INSERT INTO jira_sync (id, task_id, jira_issue_id, jira_issue_key, jira_issue_url, last_synced_at, last_sync_direction)
+     VALUES (?, ?, ?, ?, ?, datetime('now'), 'to_jira')`,
+    [id, taskId, result.id, result.key, jiraUrl]
+  );
+
+  return queryOne<JiraSyncRecord>('SELECT * FROM jira_sync WHERE id = ?', [id]) || null;
+}
+
+/**
+ * Unlink a Jira issue from an MC task.
+ * Does NOT delete the Jira issue — only removes the sync record.
+ */
+export async function unlinkJiraIssue(taskId: string): Promise<void> {
+  run('DELETE FROM jira_sync WHERE task_id = ?', [taskId]);
+}
+
+/**
+ * Get the Jira sync record for a given task.
+ */
+export function getJiraSyncForTask(taskId: string): JiraSyncRecord | undefined {
+  return queryOne<JiraSyncRecord>('SELECT * FROM jira_sync WHERE task_id = ?', [taskId]);
+}
+
+/**
+ * Inbound sync: Jira webhook → MC task.
+ * Creates a new MC task if no link exists, updates if linked.
+ * Never throws — failures are logged but never break webhook processing.
+ */
+export function syncJiraToTask(jiraIssueId: string, jiraIssueKey: string, fields: {
+  summary: string;
+  statusName: string;
+  statusCategoryKey: string;
+  priorityName: string;
+}): void {
+  const syncRecord = queryOne<JiraSyncRecord>(
+    'SELECT * FROM jira_sync WHERE jira_issue_id = ?',
+    [jiraIssueId]
+  );
+
+  if (!syncRecord) {
+    // No link yet — create a new MC task from the Jira issue
+    const mcPriority = jiraPriorityToMc(fields.priorityName);
+    const mcStatus = jiraStatusToMc(fields.statusName, fields.statusCategoryKey);
+    const id = uuidv4();
+
+    run(
+      `INSERT INTO tasks (id, title, status, priority, workspace_id, business_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, 'default', 'default', datetime('now'), datetime('now'))`,
+      [id, fields.summary, mcStatus, mcPriority]
+    );
+
+    const config = getJiraConfig();
+    const jiraUrl = `${config.url}/browse/${jiraIssueKey}`;
+    const syncId = uuidv4();
+
+    run(
+      `INSERT INTO jira_sync (id, task_id, jira_issue_id, jira_issue_key, jira_issue_url, last_synced_at, last_sync_direction)
+       VALUES (?, ?, ?, ?, ?, datetime('now'), 'from_jira')`,
+      [syncId, id, jiraIssueId, jiraIssueKey, jiraUrl]
+    );
+
+    // Broadcast SSE event so the UI updates in real time
+    const task = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [id]);
+    if (task) {
+      broadcast({ type: 'task_created', payload: task });
+    }
+  } else {
+    // Linked — update existing MC task
+    const mcPriority = jiraPriorityToMc(fields.priorityName);
+    const mcStatus = jiraStatusToMc(fields.statusName, fields.statusCategoryKey);
+
+    run(
+      `UPDATE tasks SET title = ?, status = ?, priority = ?, updated_at = datetime('now') WHERE id = ?`,
+      [fields.summary, mcStatus, mcPriority, syncRecord.task_id]
+    );
+
+    run(
+      `UPDATE jira_sync SET last_synced_at = datetime('now'), last_sync_direction = 'from_jira' WHERE id = ?`,
+      [syncRecord.id]
+    );
+
+    // Broadcast SSE event so the UI updates in real time
+    const task = queryOne<Task>('SELECT * FROM tasks WHERE id = ?', [syncRecord.task_id]);
+    if (task) {
+      broadcast({ type: 'task_updated', payload: task });
+    }
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -97,6 +97,8 @@ export interface Task {
   browser_test_url?: string;
   review_fix_count?: number;
   review_fix_max?: number;
+  jira_issue_key?: string;
+  jira_issue_url?: string;
   created_at: string;
   updated_at: string;
   // Joined fields


### PR DESCRIPTION
Rebased and revived from a stale branch. Adds Jira Cloud two-way sync between Mission Control tasks and Jira issues — link tasks, sync status/priority bidirectionally, webhook handler for Jira-side changes.

## What's included
- Jira API client (\`src/lib/jira/client.ts\`)
- Status/priority bidirectional mappings (\`src/lib/jira/mappings.ts\`)
- Sync engine + config (\`src/lib/jira/sync.ts\`, \`src/lib/jira/config.ts\`)
- POST/DELETE endpoints to link/unlink a task to a Jira issue (\`/api/tasks/[id]/jira\`)
- Webhook receiver for Jira-side updates (\`/api/webhooks/jira\`)
- Auto-sync on task create + update (fire-and-forget)
- Link/Unlink UI in TaskModal
- New \`jira_sync\` table (migration 037) joining task_id ↔ jira_issue_id
- New optional task columns: \`jira_issue_key\`, \`jira_issue_url\`

## Test plan
- [x] Type-check passes
- [x] Production build succeeds
- [ ] Configure Jira credentials via env and link a real task
- [ ] Verify webhook arrives on Jira-side status change