### PR TITLE
Fix chat tab not working in planning and in-flight task states

### DIFF
--- a/src/app/api/tasks/[id]/chat/route.ts
+++ b/src/app/api/tasks/[id]/chat/route.ts
@@ -3,7 +3,7 @@ import { createNote, getTaskNotes, getActiveSessionForTask, markNotesDelivered }
 import { getOpenClawClient } from '@/lib/openclaw/client';
 import { getMissionControlUrl } from '@/lib/config';
 import { attachChatListener, expectReply } from '@/lib/chat-listener';
-import { queryOne } from '@/lib/db';
+import { queryOne, run } from '@/lib/db';
 import { broadcast } from '@/lib/events';
 import type { Task } from '@/lib/types';
 
@@ -92,10 +92,20 @@ export async function POST(
       }
     }
 
-    // Fall back to dispatch only if:
-    // 1. Message wasn't delivered via chat.send
-    // 2. Task is in a state where dispatch makes sense (not done, not already in_progress)
-    if (!delivered && ['assigned', 'inbox', 'testing', 'review', 'verification'].includes(task.status)) {
+    // Fall back to dispatch if the message wasn't delivered via chat.send.
+    // Skip dispatch for: convoy_active (parent has no direct agent), pending_dispatch
+    // (a dispatch is already in flight), and done (work finished).
+    const dispatchableStatuses = ['planning', 'inbox', 'assigned', 'in_progress', 'testing', 'review', 'verification', 'review_fix'];
+    if (!delivered && dispatchableStatuses.includes(task.status)) {
+      // Planning-state tasks have no agent yet — transition to assigned so dispatch
+      // can pick a builder and move the task to in_progress like any other build.
+      if (task.status === 'planning') {
+        run(
+          `UPDATE tasks SET status = 'assigned', planning_complete = 1, planning_dispatch_error = NULL, status_reason = NULL, updated_at = datetime('now') WHERE id = ?`,
+          [taskId]
+        );
+      }
+
       try {
         const missionControlUrl = getMissionControlUrl();
         const headers: Record<string, string> = { 'Content-Type': 'application/json' };


### PR DESCRIPTION
## Problem
Sending a chat message on a task in \`planning\` or \`in_progress\` state did nothing — the message would show as \"Sending\" in the UI but never deliver. The note got stored as \`pending\` indefinitely with no agent to receive it.

## Root cause
\`/api/tasks/[id]/chat\` only triggered the dispatch fallback when status was in \`['assigned', 'inbox', 'testing', 'review', 'verification']\`. Both \`planning\` (no agent yet) and \`in_progress\` (would-be active agent, but if the session was lost there was no recovery) fell through to a no-op.

## Fix
Expand the dispatch fallback whitelist to: \`planning, inbox, assigned, in_progress, testing, review, verification, review_fix\`. Still skip \`convoy_active\` (parent has no direct agent), \`pending_dispatch\` (dispatch already in flight), and \`done\`.

For \`planning\` specifically: transition the task to \`assigned\` + mark planning complete before dispatching, so the dispatch route can pick a builder and the task properly moves to \`in_progress\`.

## Test plan
- [x] Verified against a real planning-state task (`ae2bf672`) with two stuck pending notes. After chat send: status moved planning → in_progress, agent assigned, note flipped to delivered, and the prior stuck notes also got picked up by the dispatch and delivered.
- [x] Production build succeeds.