### PR TITLE
Autopilot: SQLite WAL Mode and PRAGMA Performance Tuning

### DIFF
--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import fs from 'fs';
 import { schema } from './schema';
 import { runMigrations } from './migrations';
+import { applyDatabasePragmas } from './pragmas';
 import { ensureCatalogSyncScheduled } from '@/lib/agent-catalog-sync';
 
 const DB_PATH = process.env.DATABASE_PATH || path.join(process.cwd(), 'mission-control.db');
@@ -14,8 +15,7 @@ export function getDb(): Database.Database {
     const isNewDb = !fs.existsSync(DB_PATH);
     
     db = new Database(DB_PATH);
-    db.pragma('journal_mode = WAL');
-    db.pragma('foreign_keys = ON');
+    applyDatabasePragmas(db);
 
     // Initialize base schema (creates tables if they don't exist)
     db.exec(schema);

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -12,11 +12,13 @@ import Database from 'better-sqlite3';
 import fs from 'fs';
 import path from 'path';
 import { bootstrapCoreAgentsRaw } from '@/lib/bootstrap-agents';
+import { applyDatabasePragmas, verifyDatabasePragmas } from './pragmas';
 
 interface Migration {
   id: string;
   name: string;
   up: (db: Database.Database) => void;
+  transaction?: boolean;
 }
 
 // All migrations in order - NEVER remove or reorder existing migrations
@@ -1820,6 +1822,19 @@ const migrations: Migration[] = [
 
       console.log('[Migration 037] Created jira_sync table with indexes');
     }
+  },
+  {
+    id: '038',
+    name: 'configure_sqlite_wal_pragmas',
+    transaction: false,
+    up: (db) => {
+      console.log('[Migration 038] Verifying SQLite WAL and performance PRAGMAs...');
+
+      const pragmas = applyDatabasePragmas(db);
+      verifyDatabasePragmas(db, pragmas);
+
+      console.log('[Migration 038] SQLite PRAGMAs configured:', pragmas);
+    }
   }
 ];
 
@@ -1944,10 +1959,15 @@ export function runMigrations(db: Database.Database): void {
       // Prevent ALTER TABLE RENAME from rewriting FK references in other tables.
       db.pragma('legacy_alter_table = ON');
 
-      db.transaction(() => {
+      if (migration.transaction === false) {
         migration.up(db);
         db.prepare('INSERT INTO _migrations (id, name) VALUES (?, ?)').run(migration.id, migration.name);
-      })();
+      } else {
+        db.transaction(() => {
+          migration.up(db);
+          db.prepare('INSERT INTO _migrations (id, name) VALUES (?, ?)').run(migration.id, migration.name);
+        })();
+      }
 
       // Re-enable FK checks and legacy alter table
       db.pragma('legacy_alter_table = OFF');

--- a/src/lib/db/pragmas.test.ts
+++ b/src/lib/db/pragmas.test.ts
@@ -1,0 +1,76 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import Database from 'better-sqlite3';
+import { applyDatabasePragmas, readDatabasePragmas, verifyDatabasePragmas } from './pragmas';
+
+function cleanupDb(dbPath: string): void {
+  for (const suffix of ['', '-wal', '-shm']) {
+    fs.rmSync(`${dbPath}${suffix}`, { force: true });
+  }
+}
+
+test('applyDatabasePragmas sets the SQLite WAL performance profile', () => {
+  const tmpDir = path.join(process.cwd(), '.tmp');
+  fs.mkdirSync(tmpDir, { recursive: true });
+  const dbPath = path.join(tmpDir, 'pragma-test.db');
+  cleanupDb(dbPath);
+
+  const db = new Database(dbPath);
+  try {
+    const pragmas = applyDatabasePragmas(db);
+
+    assert.equal(pragmas.journalMode, 'wal');
+    assert.equal(pragmas.synchronous, 1);
+    assert.equal(pragmas.cacheSize, -64000);
+    assert.equal(pragmas.busyTimeout, 5000);
+    assert.equal(pragmas.foreignKeys, 1);
+    assert.doesNotThrow(() => verifyDatabasePragmas(db, pragmas));
+  } finally {
+    db.close();
+  }
+
+  const reopened = new Database(dbPath);
+  try {
+    assert.equal(readDatabasePragmas(reopened).journalMode, 'wal');
+  } finally {
+    reopened.close();
+    cleanupDb(dbPath);
+  }
+});
+
+test('WAL profile allows a writer to commit while another connection is reading', () => {
+  const tmpDir = path.join(process.cwd(), '.tmp');
+  fs.mkdirSync(tmpDir, { recursive: true });
+  const dbPath = path.join(tmpDir, 'pragma-concurrency-test.db');
+  cleanupDb(dbPath);
+
+  const writer = new Database(dbPath);
+  const reader = new Database(dbPath);
+  const countRows = () => (reader.prepare('SELECT COUNT(*) AS count FROM items').get() as { count: number }).count;
+
+  try {
+    applyDatabasePragmas(writer);
+    applyDatabasePragmas(reader);
+
+    writer.exec('CREATE TABLE items (id INTEGER PRIMARY KEY, label TEXT NOT NULL)');
+    writer.prepare('INSERT INTO items (label) VALUES (?)').run('initial');
+
+    const commitWrite = writer.transaction(() => {
+      writer.prepare('INSERT INTO items (label) VALUES (?)').run('during-read');
+    });
+
+    reader.transaction(() => {
+      assert.equal(countRows(), 1);
+      assert.doesNotThrow(() => commitWrite());
+      assert.equal(countRows(), 1);
+    })();
+
+    assert.equal(countRows(), 2);
+  } finally {
+    reader.close();
+    writer.close();
+    cleanupDb(dbPath);
+  }
+});

--- a/src/lib/db/pragmas.ts
+++ b/src/lib/db/pragmas.ts
@@ -1,0 +1,83 @@
+import Database from 'better-sqlite3';
+
+export const SQLITE_PRAGMA_TARGETS = {
+  journalMode: 'wal',
+  synchronous: 1, // NORMAL
+  cacheSize: -64000,
+  busyTimeout: 5000,
+  foreignKeys: 1,
+} as const;
+
+export interface AppliedSqlitePragmas {
+  journalMode: string;
+  synchronous: number;
+  cacheSize: number;
+  busyTimeout: number;
+  foreignKeys: number;
+}
+
+function readPragma<T>(db: Database.Database, pragma: string): T {
+  return db.pragma(pragma, { simple: true }) as T;
+}
+
+function supportsWal(db: Database.Database): boolean {
+  return Boolean(db.name && db.name !== ':memory:');
+}
+
+/**
+ * SQLite connection tuning:
+ * - journal_mode=WAL allows readers and one writer to proceed concurrently,
+ *   which prevents UI reads from blocking autopilot writes.
+ * - synchronous=NORMAL preserves durability for normal process crashes while
+ *   reducing fsync overhead; the tradeoff is a small OS-crash data-loss window.
+ * - cache_size=-64000 gives SQLite about 64 MB of page cache per connection
+ *   using SQLite's negative-KiB form for read-heavy dashboard workloads.
+ * - busy_timeout=5000 waits briefly for transient writer locks instead of
+ *   immediately throwing SQLITE_BUSY under concurrent activity.
+ * - foreign_keys=ON enforces declared relational integrity on every connection.
+ */
+export function applyDatabasePragmas(db: Database.Database): AppliedSqlitePragmas {
+  readPragma<number>(db, 'busy_timeout = 5000');
+
+  const journalMode = supportsWal(db)
+    ? String(readPragma<string>(db, 'journal_mode = WAL')).toLowerCase()
+    : String(readPragma<string>(db, 'journal_mode')).toLowerCase();
+
+  readPragma<number>(db, 'synchronous = NORMAL');
+  readPragma<number>(db, 'cache_size = -64000');
+  readPragma<number>(db, 'foreign_keys = ON');
+
+  return readDatabasePragmas(db, journalMode);
+}
+
+export function readDatabasePragmas(db: Database.Database, journalModeOverride?: string): AppliedSqlitePragmas {
+  return {
+    journalMode: (journalModeOverride || String(readPragma<string>(db, 'journal_mode'))).toLowerCase(),
+    synchronous: Number(readPragma<number>(db, 'synchronous')),
+    cacheSize: Number(readPragma<number>(db, 'cache_size')),
+    busyTimeout: Number(readPragma<number>(db, 'busy_timeout')),
+    foreignKeys: Number(readPragma<number>(db, 'foreign_keys')),
+  };
+}
+
+export function verifyDatabasePragmas(db: Database.Database, pragmas = readDatabasePragmas(db)): void {
+  if (supportsWal(db) && pragmas.journalMode !== SQLITE_PRAGMA_TARGETS.journalMode) {
+    throw new Error(`Expected SQLite journal_mode=${SQLITE_PRAGMA_TARGETS.journalMode}, got ${pragmas.journalMode}`);
+  }
+
+  if (pragmas.synchronous !== SQLITE_PRAGMA_TARGETS.synchronous) {
+    throw new Error(`Expected SQLite synchronous=NORMAL (${SQLITE_PRAGMA_TARGETS.synchronous}), got ${pragmas.synchronous}`);
+  }
+
+  if (pragmas.cacheSize !== SQLITE_PRAGMA_TARGETS.cacheSize) {
+    throw new Error(`Expected SQLite cache_size=${SQLITE_PRAGMA_TARGETS.cacheSize}, got ${pragmas.cacheSize}`);
+  }
+
+  if (pragmas.busyTimeout !== SQLITE_PRAGMA_TARGETS.busyTimeout) {
+    throw new Error(`Expected SQLite busy_timeout=${SQLITE_PRAGMA_TARGETS.busyTimeout}, got ${pragmas.busyTimeout}`);
+  }
+
+  if (pragmas.foreignKeys !== SQLITE_PRAGMA_TARGETS.foreignKeys) {
+    throw new Error(`Expected SQLite foreign_keys=ON (${SQLITE_PRAGMA_TARGETS.foreignKeys}), got ${pragmas.foreignKeys}`);
+  }
+}


### PR DESCRIPTION
## What was built
- Added a shared SQLite PRAGMA initializer that enables WAL mode and applies synchronous=NORMAL, cache_size=-64000, busy_timeout=5000, and foreign_keys=ON immediately after opening the database.
- Added migration 038 to verify and persist the WAL/performance profile once for existing databases.
- Added focused tests for PRAGMA values, WAL persistence, and read/write concurrency across two SQLite connections.

## Research backing
Research recommended enabling WAL mode, increasing cache size, and setting synchronous=NORMAL to reduce lock contention during concurrent autopilot research and UI reads while improving read-heavy query throughput.

## Technical approach
The startup path now calls applyDatabasePragmas(db) before schema setup and migrations. Migration 038 runs outside the migration transaction because journal_mode changes cannot be applied inside a transaction, then verifies the effective PRAGMA values.

## Risks and tradeoffs
- WAL creates -wal and -shm sidecar files next to the database, so filesystem backup scripts should account for SQLite WAL behavior or checkpoint first.
- synchronous=NORMAL reduces fsync overhead with a small theoretical data-loss window on OS crash, while still being safe for normal process crashes.

Task ID: ae2bf672-adbe-4226-839b-0740de71ed43