### PR TITLE
fix(agents): make delete cleanup transactional

### DIFF
--- a/src/app/api/agents/[id]/route.ts
+++ b/src/app/api/agents/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { v4 as uuidv4 } from 'uuid';
-import { queryOne, run } from '@/lib/db';
+import { queryOne, run, transaction } from '@/lib/db';
 import type { Agent, UpdateAgentRequest } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -126,17 +126,20 @@ export async function DELETE(
       return NextResponse.json({ error: 'Agent not found' }, { status: 404 });
     }
 
-    // Delete or nullify related records first (foreign key constraints)
-    run('DELETE FROM openclaw_sessions WHERE agent_id = ?', [id]);
-    run('DELETE FROM events WHERE agent_id = ?', [id]);
-    run('DELETE FROM messages WHERE sender_agent_id = ?', [id]);
-    run('DELETE FROM conversation_participants WHERE agent_id = ?', [id]);
-    run('UPDATE tasks SET assigned_agent_id = NULL WHERE assigned_agent_id = ?', [id]);
-    run('UPDATE tasks SET created_by_agent_id = NULL WHERE created_by_agent_id = ?', [id]);
-    run('UPDATE task_activities SET agent_id = NULL WHERE agent_id = ?', [id]);
+    // Delete or nullify related records first (foreign key constraints).
+    // Keep the cleanup atomic so a failed delete cannot leave partial state.
+    transaction(() => {
+      run('DELETE FROM openclaw_sessions WHERE agent_id = ?', [id]);
+      run('DELETE FROM events WHERE agent_id = ?', [id]);
+      run('DELETE FROM messages WHERE sender_agent_id = ?', [id]);
+      run('DELETE FROM conversation_participants WHERE agent_id = ?', [id]);
+      run('UPDATE tasks SET assigned_agent_id = NULL WHERE assigned_agent_id = ?', [id]);
+      run('UPDATE tasks SET created_by_agent_id = NULL WHERE created_by_agent_id = ?', [id]);
+      run('UPDATE task_activities SET agent_id = NULL WHERE agent_id = ?', [id]);
 
-    // Now delete the agent
-    run('DELETE FROM agents WHERE id = ?', [id]);
+      // Now delete the agent
+      run('DELETE FROM agents WHERE id = ?', [id]);
+    });
 
     return NextResponse.json({ success: true });
   } catch (error) {


### PR DESCRIPTION
## Summary

Makes the agent DELETE route cleanup atomic by wrapping related-row cleanup and final agent deletion in the existing database `transaction` helper.

## Why

Deleting an agent touches several related tables before removing the agent row:

- `openclaw_sessions`
- `events`
- `messages`
- `conversation_participants`
- `tasks`
- `task_activities`
- `agents`

Those mutations should succeed or fail as a unit. Without a transaction, a failed intermediate statement can leave partial cleanup state behind.

## Verification

- `git diff --check`
- `npm run build`

Notes:

- `npm run build` passes with existing unrelated lint warnings in React components.
- `npm test` showed visible passing tests, then the test runner did not exit; I terminated the hung test processes and did not count that as a full test pass.
