### PR TITLE
fix(mc-bridge): verify task creation

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -14,6 +14,12 @@ http://localhost:4000
 
 Or use the `MISSION_CONTROL_URL` environment variable.
 
+## Bridge Helper
+
+Use `scripts/mc-bridge.py` when an agent runtime needs a small command-line wrapper around the Mission Control API. It supports exact agent names and unambiguous agent-name prefixes. For example, `Builder` resolves to `Builder Agent` when that is the only matching agent.
+
+`agent-start` verifies the created task can be read back from `/api/tasks/{id}` before printing the task ID, so callers should treat any non-zero exit code as failure.
+
 ## Task Lifecycle
 
 ```

--- a/scripts/mc-bridge.py
+++ b/scripts/mc-bridge.py
@@ -108,25 +108,45 @@ def resolve_agent_name(label: str) -> str | None:
 
 
 def find_agent(name: str) -> dict | None:
-    """Find an agent by name (case-insensitive) in Mission Control."""
+    """Find an agent by name in Mission Control.
+
+    Resolution order:
+    1. Exact case-insensitive name match.
+    2. Case-insensitive prefix match (e.g. "Builder" → "Builder Agent").
+
+    Prefix matches must be unambiguous so callers do not accidentally assign
+    work to the wrong agent.
+    """
     agents = get_agents()
-    name_lower = name.lower()
+    name_lower = name.lower().strip()
+
     for a in agents:
         if a.get("name", "").lower() == name_lower:
             return a
+
+    prefix_matches = [a for a in agents if a.get("name", "").lower().startswith(name_lower)]
+    if len(prefix_matches) == 1:
+        return prefix_matches[0]
+    if len(prefix_matches) > 1:
+        names = ", ".join(a.get("name", "?") for a in prefix_matches)
+        print(f"❌ Ambiguous agent name '{name}'. Matches: {names}", file=sys.stderr)
+        return None
+
     return None
 
 
 def find_agent_by_name_or_label(name_or_label: str) -> dict | None:
-    """Try to find agent by exact name first, then by label prefix mapping."""
-    # Direct name match
+    """Try to find agent by exact/prefix name first, then by label prefix mapping."""
     agent = find_agent(name_or_label)
     if agent:
         return agent
+
     # Try label mapping
     mapped_name = resolve_agent_name(name_or_label)
     if mapped_name:
-        return find_agent(mapped_name)
+        agent = find_agent(mapped_name)
+        if agent:
+            return agent
     return None
 
 # ---------------------------------------------------------------------------
@@ -172,7 +192,16 @@ def cmd_agent_start(args):
         print("❌ Failed to create task", file=sys.stderr)
         sys.exit(1)
 
-    task_id = task["id"]
+    task_id = task.get("id") if isinstance(task, dict) else None
+    if not task_id:
+        print("❌ Task creation returned no id", file=sys.stderr)
+        print(f"   Response: {task}", file=sys.stderr)
+        sys.exit(1)
+
+    verified = api_get(f"/api/tasks/{task_id}", quiet=True)
+    if not verified or (isinstance(verified, dict) and verified.get("id") != task_id):
+        print(f"❌ Task {task_id} created but not queryable", file=sys.stderr)
+        sys.exit(1)
 
     # 2. Set agent status to working
     api_patch(f"/api/agents/{agent_id}", {"status": "working"})

--- a/scripts/mc-bridge.sh
+++ b/scripts/mc-bridge.sh
@@ -12,7 +12,7 @@
 
 set -euo pipefail
 
-MC_URL="${MC_URL:-http://localhost:3000}"
+MC_URL="${MC_URL:-http://localhost:4000}"
 
 # Colors
 RED='\033[0;31m'


### PR DESCRIPTION
## Summary

Hardens the Mission Control bridge helper used by agent runtimes.

Changes:

- Resolve agents by exact case-insensitive name first.
- Support unambiguous case-insensitive prefix matching, such as `Builder` resolving to `Builder Agent`.
- Reject ambiguous prefixes instead of silently choosing an agent.
- Verify `agent-start` task creation by reading `GET /api/tasks/{id}` before printing the task ID.
- Align the bash bridge default URL with the app default port, `http://localhost:4000`.
- Document the bridge behavior in `ORCHESTRATION.md`.

## Why

Callers treat the task ID printed by `mc-bridge.py agent-start` as proof that Mission Control has a usable task. The bridge should therefore only print that ID after the task can be read back.

Prefix support also makes the bridge more forgiving for common agent names while still failing safely when multiple agents match.

## Verification

- `python3 -m py_compile scripts/mc-bridge.py`
- `bash -n scripts/mc-bridge.sh`
- `git diff --check`
- `npm run build`

Notes:

- `npm run build` passes with existing unrelated lint warnings in React components.
- `npm test` showed visible passing tests, then the test runner did not exit; I terminated the hung test processes and did not count that as a full test pass.
