### PR TITLE
Autopilot: Publish Mission Control rework branch

### DIFF
--- a/src/lib/task-dispatch-context.test.ts
+++ b/src/lib/task-dispatch-context.test.ts
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resolveSourceArtifactPath, rewriteSourceArtifactPath } from './task-dispatch-context';
+
+test('rewriteSourceArtifactPath rewrites Mission Control host artifact paths to sandbox paths', () => {
+  const host = '/opt/openclaw/mission-control/data/task-artifacts/task-1/export-1/report.docx';
+
+  assert.equal(
+    rewriteSourceArtifactPath(host),
+    '/workspace/mission-control-artifacts/task-1/export-1/report.docx'
+  );
+});
+
+test('rewriteSourceArtifactPath preserves non-artifact paths', () => {
+  assert.equal(rewriteSourceArtifactPath('/workspace/project/README.md'), '/workspace/project/README.md');
+  assert.equal(rewriteSourceArtifactPath('relative/path/report.md'), 'relative/path/report.md');
+});
+
+test('rewriteSourceArtifactPath handles missing paths', () => {
+  assert.equal(rewriteSourceArtifactPath(null), '');
+  assert.equal(rewriteSourceArtifactPath(undefined), '');
+  assert.equal(rewriteSourceArtifactPath(''), '');
+});
+
+test('resolveSourceArtifactPath prefers absolute path and rewrites it over relative storage path', () => {
+  assert.equal(
+    resolveSourceArtifactPath(
+      '/opt/openclaw/mission-control/data/task-artifacts/task-2/export-2/report.md',
+      'task-2/export-2/report.md'
+    ),
+    '/workspace/mission-control-artifacts/task-2/export-2/report.md'
+  );
+});
+
+test('resolveSourceArtifactPath prefixes relative storage fallback with sandbox artifact root', () => {
+  assert.equal(
+    resolveSourceArtifactPath(null, 'task-3/export-3/report.docx'),
+    '/workspace/mission-control-artifacts/task-3/export-3/report.docx'
+  );
+});

--- a/src/lib/task-dispatch-context.ts
+++ b/src/lib/task-dispatch-context.ts
@@ -26,6 +26,31 @@ const RESEARCH_REPORT_MAX_CHARS = 40_000;
 const ACTIVITY_MESSAGE_MAX_CHARS = 700;
 const FINAL_MESSAGE_MAX_CHARS = 1_200;
 
+/**
+ * Sandbox-stable artifact root used as the canonical base for source deliverable
+ * paths advertised to sandboxed QA/review workers. Must be reachable inside
+ * OpenClaw sandboxes and must not be a host-only Mission Control data path.
+ */
+export const SANDBOX_ARTIFACT_ROOT: string =
+  process.env.MISSION_CONTROL_SANDBOX_ARTIFACT_ROOT || '/workspace/mission-control-artifacts';
+
+const HOST_ARTIFACT_ROOT = '/opt/openclaw/mission-control/data/task-artifacts';
+
+export function rewriteSourceArtifactPath(hostPath: string | null | undefined): string {
+  if (!hostPath) return hostPath ?? '';
+  if (!hostPath.startsWith(HOST_ARTIFACT_ROOT)) return hostPath;
+  return SANDBOX_ARTIFACT_ROOT + hostPath.slice(HOST_ARTIFACT_ROOT.length);
+}
+
+export function resolveSourceArtifactPath(path: string | null | undefined, storagePath?: string | null): string {
+  const rewrittenPath = rewriteSourceArtifactPath(path);
+  if (rewrittenPath) return rewrittenPath;
+
+  if (!storagePath) return '';
+  if (storagePath.startsWith('/')) return rewriteSourceArtifactPath(storagePath);
+  return `${SANDBOX_ARTIFACT_ROOT}/${storagePath.replace(/^\/+/, '')}`;
+}
+
 export interface DispatchContextSectionAudit {
   key: string;
   title: string;
@@ -465,7 +490,9 @@ function formatPreviousWorkSection(task: Task): string {
     lines.push('- None registered.');
   } else {
     for (const deliverable of deliverables) {
-      lines.push(`- ${deliverable.created_at} [${deliverable.deliverable_type}] ${deliverable.title}${deliverable.path ? `: ${deliverable.path}` : ''}${deliverable.description ? ` - ${deliverable.description}` : ''}`);
+      const kind = deliverable.artifact_format || deliverable.deliverable_type;
+      const location = resolveSourceArtifactPath(deliverable.path, deliverable.storage_path);
+      lines.push(`- ${deliverable.created_at} [${kind}] ${deliverable.title}${location ? `: ${location}` : ''}${deliverable.description ? ` - ${deliverable.description}` : ''}`);
     }
   }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -297,8 +297,10 @@ export interface TaskDeliverable {
   id: string;
   task_id: string;
   deliverable_type: DeliverableType;
+  artifact_format?: string;
   title: string;
   path?: string;
+  storage_path?: string;
   description?: string;
   created_at: string;
 }


### PR DESCRIPTION
## What was built
Published commit `3e4a7cec3994180743c8ad945681c064d9453ea2` from `autopilot/rework-fix-in-mission-control-repository` for the Mission Control artifact-path resolver fix.

## Research backing
The task was created after technical verification passed locally, but canonical publication was blocked by missing upstream write access.

## Technical approach
Created a real GitHub fork `Broedkrummen/mission-control-crshdn-fork`, pushed the verified branch there, and opened this PR against `crshdn/mission-control:main`.

## Risks / tradeoffs
Direct push and merge permissions for `Broedkrummen` on `crshdn/mission-control` are still absent (`push: false`, `maintain: false`, `admin: false`), so final merge may require an upstream maintainer.

Task ID: `5f01483d-bbf8-4115-8547-d26308f9b0c5`
