### PR TITLE
support for openclaw protocol v4

### DIFF
--- a/src/lib/openclaw/client.ts
+++ b/src/lib/openclaw/client.ts
@@ -2,7 +2,12 @@
 
 import { EventEmitter } from 'events';
 import type { OpenClawMessage, OpenClawSessionInfo } from '../types';
-import { loadOrCreateDeviceIdentity, signDevicePayload, buildDeviceAuthPayload, publicKeyRawBase64Url } from './device-identity';
+import {
+  loadOrCreateDeviceIdentity,
+  signDevicePayload,
+  buildDeviceAuthPayloadV3,
+  publicKeyRawBase64Url,
+} from './device-identity';
 import { createHash } from 'crypto';
 
 // Types for gateway model discovery (matches OpenClaw models.list response)
@@ -29,6 +34,8 @@ export interface GatewayConfigSnapshot {
 
 const GATEWAY_URL = process.env.OPENCLAW_GATEWAY_URL || 'ws://127.0.0.1:18789';
 const GATEWAY_TOKEN = process.env.OPENCLAW_GATEWAY_TOKEN || '';
+const PROTOCOL_VERSION = 4;
+const MIN_CLIENT_PROTOCOL_VERSION = 4;
 
 // Global deduplication cache that persists across module reloads in Next.js dev
 // Use globalThis to ensure it's shared across all instances
@@ -298,7 +305,7 @@ export class OpenClawClient extends EventEmitter {
               const clientId = 'cli';
               let device: Record<string, unknown> | undefined;
               if (this.deviceIdentity) {
-                const payload = buildDeviceAuthPayload({
+                const payload = buildDeviceAuthPayloadV3({
                   deviceId: this.deviceIdentity.deviceId,
                   clientId,
                   clientMode: 'ui',
@@ -307,6 +314,7 @@ export class OpenClawClient extends EventEmitter {
                   signedAtMs,
                   token: this.token || null,
                   nonce,
+                  platform: process.platform || 'web',
                 });
                 const signature = signDevicePayload(this.deviceIdentity.privateKeyPem, payload);
                 device = {
@@ -323,20 +331,21 @@ export class OpenClawClient extends EventEmitter {
                 });
               }
 
+              const auth = this.token ? { token: this.token } : undefined;
               const response = {
                 type: 'req',
                 id: requestId,
                 method: 'connect',
                 params: {
-                  minProtocol: 3,
-                  maxProtocol: 3,
+                  minProtocol: MIN_CLIENT_PROTOCOL_VERSION,
+                  maxProtocol: PROTOCOL_VERSION,
                   client: {
                     id: clientId,
                     version: '1.0.1',
                     platform: process.platform || 'web',
                     mode: 'ui',
                   },
-                  auth: { token: this.token },
+                  auth,
                   role,
                   scopes,
                   device,
@@ -465,19 +474,44 @@ export class OpenClawClient extends EventEmitter {
 
   // Session management methods
   async listSessions(): Promise<OpenClawSessionInfo[]> {
-    return this.call<OpenClawSessionInfo[]>('sessions.list');
+    const result = await this.call<{ sessions?: OpenClawSessionInfo[] } | OpenClawSessionInfo[]>('sessions.list', {});
+    if (Array.isArray(result)) {
+      return result;
+    }
+    if (result && typeof result === 'object' && Array.isArray((result as { sessions?: OpenClawSessionInfo[] }).sessions)) {
+      return (result as { sessions?: OpenClawSessionInfo[] }).sessions ?? [];
+    }
+    return [];
   }
 
   async getSessionHistory(sessionId: string): Promise<unknown[]> {
-    return this.call<unknown[]>('sessions.history', { session_id: sessionId });
+    const result = await this.call<{ messages?: unknown[] } | unknown[]>('chat.history', {
+      sessionKey: sessionId,
+      limit: 100,
+    });
+    if (Array.isArray(result)) {
+      return result;
+    }
+    if (result && typeof result === 'object' && Array.isArray((result as { messages?: unknown[] }).messages)) {
+      return (result as { messages?: unknown[] }).messages ?? [];
+    }
+    return [];
   }
 
   async sendMessage(sessionId: string, content: string): Promise<void> {
-    await this.call('sessions.send', { session_id: sessionId, content });
+    await this.call('chat.send', {
+      sessionKey: sessionId,
+      message: content,
+      idempotencyKey: `session-send-${sessionId}-${Date.now()}`,
+    });
   }
 
   async createSession(channel: string, peer?: string): Promise<OpenClawSessionInfo> {
-    return this.call<OpenClawSessionInfo>('sessions.create', { channel, peer });
+    const result = await this.call<{ session?: OpenClawSessionInfo } | OpenClawSessionInfo>('sessions.create', { channel, peer });
+    if (result && typeof result === 'object' && !Array.isArray(result) && 'session' in result) {
+      return (result as { session?: OpenClawSessionInfo }).session as OpenClawSessionInfo;
+    }
+    return result as OpenClawSessionInfo;
   }
 
   // Agent methods

--- a/src/lib/openclaw/client.ts
+++ b/src/lib/openclaw/client.ts
@@ -449,6 +449,27 @@ export class OpenClawClient extends EventEmitter {
     }, 10000); // 10 seconds between reconnect attempts
   }
 
+  private unwrapArrayResponse<T>(result: T[] | Record<string, unknown>, key: string): T[] {
+    if (Array.isArray(result)) {
+      return result;
+    }
+
+    if (result && typeof result === 'object' && Array.isArray(result[key])) {
+      return result[key] as T[];
+    }
+
+    return [];
+  }
+
+  private unwrapObjectResponse<T>(result: T | Record<string, unknown>, key: string): T {
+    if (result && typeof result === 'object' && !Array.isArray(result) && key in result) {
+      const record = result as Record<string, unknown>;
+      return record[key] as T;
+    }
+
+    return result as T;
+  }
+
   async call<T = unknown>(method: string, params?: Record<string, unknown>): Promise<T> {
     if (!this.ws || !this.connected || !this.authenticated) {
       throw new Error('Not connected to OpenClaw Gateway');
@@ -475,13 +496,7 @@ export class OpenClawClient extends EventEmitter {
   // Session management methods
   async listSessions(): Promise<OpenClawSessionInfo[]> {
     const result = await this.call<{ sessions?: OpenClawSessionInfo[] } | OpenClawSessionInfo[]>('sessions.list', {});
-    if (Array.isArray(result)) {
-      return result;
-    }
-    if (result && typeof result === 'object' && Array.isArray((result as { sessions?: OpenClawSessionInfo[] }).sessions)) {
-      return (result as { sessions?: OpenClawSessionInfo[] }).sessions ?? [];
-    }
-    return [];
+    return this.unwrapArrayResponse<OpenClawSessionInfo>(result, 'sessions');
   }
 
   async getSessionHistory(sessionId: string): Promise<unknown[]> {
@@ -489,13 +504,7 @@ export class OpenClawClient extends EventEmitter {
       sessionKey: sessionId,
       limit: 100,
     });
-    if (Array.isArray(result)) {
-      return result;
-    }
-    if (result && typeof result === 'object' && Array.isArray((result as { messages?: unknown[] }).messages)) {
-      return (result as { messages?: unknown[] }).messages ?? [];
-    }
-    return [];
+    return this.unwrapArrayResponse<unknown>(result, 'messages');
   }
 
   async sendMessage(sessionId: string, content: string): Promise<void> {
@@ -508,24 +517,14 @@ export class OpenClawClient extends EventEmitter {
 
   async createSession(channel: string, peer?: string): Promise<OpenClawSessionInfo> {
     const result = await this.call<{ session?: OpenClawSessionInfo } | OpenClawSessionInfo>('sessions.create', { channel, peer });
-    if (result && typeof result === 'object' && !Array.isArray(result) && 'session' in result) {
-      return (result as { session?: OpenClawSessionInfo }).session as OpenClawSessionInfo;
-    }
-    return result as OpenClawSessionInfo;
+    return this.unwrapObjectResponse<OpenClawSessionInfo>(result, 'session');
   }
 
   // Agent methods
   async listAgents(): Promise<unknown[]> {
     const result = await this.call<{ agents?: unknown[] }>('agents.list');
     // Gateway returns { requester, allowAny, agents: [...] }
-    if (result && typeof result === 'object' && Array.isArray((result as Record<string, unknown>).agents)) {
-      return (result as Record<string, unknown>).agents as unknown[];
-    }
-    // Fallback: if the response is already an array
-    if (Array.isArray(result)) {
-      return result;
-    }
-    return [];
+    return this.unwrapArrayResponse<unknown>(result, 'agents');
   }
 
   // Node methods (device capabilities)

--- a/src/lib/openclaw/client.ts
+++ b/src/lib/openclaw/client.ts
@@ -449,25 +449,54 @@ export class OpenClawClient extends EventEmitter {
     }, 10000); // 10 seconds between reconnect attempts
   }
 
-  private unwrapArrayResponse<T>(result: T[] | Record<string, unknown>, key: string): T[] {
+  private describeResponseShape(result: unknown): string {
     if (Array.isArray(result)) {
-      return result;
+      return `array(length=${result.length})`;
     }
 
-    if (result && typeof result === 'object' && Array.isArray(result[key])) {
-      return result[key] as T[];
+    if (result === null) {
+      return 'null';
     }
 
-    return [];
+    if (typeof result === 'object') {
+      const keys = Object.keys(result as Record<string, unknown>);
+      return `object(keys=${keys.length > 0 ? keys.join(',') : '<none>'})`;
+    }
+
+    return typeof result;
   }
 
-  private unwrapObjectResponse<T>(result: T | Record<string, unknown>, key: string): T {
-    if (result && typeof result === 'object' && !Array.isArray(result) && key in result) {
-      const record = result as Record<string, unknown>;
-      return record[key] as T;
+  private unexpectedResponseShape(method: string, expected: string, result: unknown): never {
+    const actual = this.describeResponseShape(result);
+    console.error(`[OpenClaw] Unexpected response shape for ${method}: expected ${expected}, got ${actual}`);
+    throw new Error(`Unexpected OpenClaw response shape for ${method}: expected ${expected}, got ${actual}`);
+  }
+
+  private unwrapArrayResponse<T>(result: unknown, method: string, key: string): T[] {
+    if (Array.isArray(result)) {
+      return result as T[];
     }
 
-    return result as T;
+    if (result && typeof result === 'object') {
+      const record = result as Record<string, unknown>;
+      if (Array.isArray(record[key])) {
+        return record[key] as T[];
+      }
+    }
+
+    return this.unexpectedResponseShape(method, `array or object with "${key}" array`, result);
+  }
+
+  private unwrapObjectResponse<T>(result: unknown, method: string, key: string): T {
+    if (result && typeof result === 'object' && !Array.isArray(result)) {
+      const record = result as Record<string, unknown>;
+      if (key in record) {
+        return record[key] as T;
+      }
+      return result as T;
+    }
+
+    return this.unexpectedResponseShape(method, `object or object with "${key}" property`, result);
   }
 
   async call<T = unknown>(method: string, params?: Record<string, unknown>): Promise<T> {
@@ -496,7 +525,7 @@ export class OpenClawClient extends EventEmitter {
   // Session management methods
   async listSessions(): Promise<OpenClawSessionInfo[]> {
     const result = await this.call<{ sessions?: OpenClawSessionInfo[] } | OpenClawSessionInfo[]>('sessions.list', {});
-    return this.unwrapArrayResponse<OpenClawSessionInfo>(result, 'sessions');
+    return this.unwrapArrayResponse<OpenClawSessionInfo>(result, 'sessions.list', 'sessions');
   }
 
   async getSessionHistory(sessionId: string): Promise<unknown[]> {
@@ -504,7 +533,7 @@ export class OpenClawClient extends EventEmitter {
       sessionKey: sessionId,
       limit: 100,
     });
-    return this.unwrapArrayResponse<unknown>(result, 'messages');
+    return this.unwrapArrayResponse<unknown>(result, 'chat.history', 'messages');
   }
 
   async sendMessage(sessionId: string, content: string): Promise<void> {
@@ -517,14 +546,14 @@ export class OpenClawClient extends EventEmitter {
 
   async createSession(channel: string, peer?: string): Promise<OpenClawSessionInfo> {
     const result = await this.call<{ session?: OpenClawSessionInfo } | OpenClawSessionInfo>('sessions.create', { channel, peer });
-    return this.unwrapObjectResponse<OpenClawSessionInfo>(result, 'session');
+    return this.unwrapObjectResponse<OpenClawSessionInfo>(result, 'sessions.create', 'session');
   }
 
   // Agent methods
   async listAgents(): Promise<unknown[]> {
     const result = await this.call<{ agents?: unknown[] }>('agents.list');
     // Gateway returns { requester, allowAny, agents: [...] }
-    return this.unwrapArrayResponse<unknown>(result, 'agents');
+    return this.unwrapArrayResponse<unknown>(result, 'agents.list', 'agents');
   }
 
   // Node methods (device capabilities)
@@ -538,11 +567,8 @@ export class OpenClawClient extends EventEmitter {
 
   // Model discovery methods (queries remote gateway via RPC)
   async listModels(): Promise<GatewayModelChoice[]> {
-    const result = await this.call<{ models?: GatewayModelChoice[] }>('models.list', {});
-    if (result && typeof result === 'object' && Array.isArray((result as Record<string, unknown>).models)) {
-      return (result as Record<string, unknown>).models as GatewayModelChoice[];
-    }
-    return [];
+    const result = await this.call<{ models?: GatewayModelChoice[] } | GatewayModelChoice[]>('models.list', {});
+    return this.unwrapArrayResponse<GatewayModelChoice>(result, 'models.list', 'models');
   }
 
   async getConfig(): Promise<GatewayConfigSnapshot> {
@@ -550,7 +576,7 @@ export class OpenClawClient extends EventEmitter {
     if (result && typeof result === 'object') {
       return result as GatewayConfigSnapshot;
     }
-    return {};
+    return this.unexpectedResponseShape('config.get', 'object', result);
   }
 
   /**

--- a/src/lib/openclaw/device-identity.test.ts
+++ b/src/lib/openclaw/device-identity.test.ts
@@ -22,3 +22,51 @@ test('buildDeviceAuthPayloadV3 normalizes platform and deviceFamily for protocol
     'v3|device-1|cli|ui|operator|operator.admin|1737264000000|secret-token|nonce-123|win32|desktop'
   );
 });
+
+test('buildDeviceAuthPayloadV3 serializes nullish and whitespace device metadata as empty fields', () => {
+  const cases = [
+    { platform: null, deviceFamily: undefined },
+    { platform: undefined, deviceFamily: null },
+    { platform: '   ', deviceFamily: '\t  ' },
+  ];
+
+  for (const input of cases) {
+    const payload = buildDeviceAuthPayloadV3({
+      deviceId: 'device-1',
+      clientId: 'cli',
+      clientMode: 'ui',
+      role: 'operator',
+      scopes: ['operator.admin'],
+      signedAtMs: 1737264000000,
+      token: 'secret-token',
+      nonce: 'nonce-123',
+      platform: input.platform,
+      deviceFamily: input.deviceFamily,
+    });
+
+    assert.equal(
+      payload,
+      'v3|device-1|cli|ui|operator|operator.admin|1737264000000|secret-token|nonce-123||'
+    );
+  }
+});
+
+test('buildDeviceAuthPayloadV3 serializes a null token as an empty token field', () => {
+  const payload = buildDeviceAuthPayloadV3({
+    deviceId: 'device-1',
+    clientId: 'cli',
+    clientMode: 'ui',
+    role: 'operator',
+    scopes: ['operator.admin'],
+    signedAtMs: 1737264000000,
+    token: null,
+    nonce: 'nonce-123',
+    platform: 'win32',
+    deviceFamily: 'desktop',
+  });
+
+  assert.equal(
+    payload,
+    'v3|device-1|cli|ui|operator|operator.admin|1737264000000||nonce-123|win32|desktop'
+  );
+});

--- a/src/lib/openclaw/device-identity.test.ts
+++ b/src/lib/openclaw/device-identity.test.ts
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildDeviceAuthPayloadV3 } from './device-identity';
+
+test('buildDeviceAuthPayloadV3 normalizes platform and deviceFamily for protocol v4 device auth', () => {
+  const payload = buildDeviceAuthPayloadV3({
+    deviceId: 'device-1',
+    clientId: 'cli',
+    clientMode: 'ui',
+    role: 'operator',
+    scopes: ['operator.admin'],
+    signedAtMs: 1737264000000,
+    token: 'secret-token',
+    nonce: 'nonce-123',
+    platform: 'Win32 ',
+    deviceFamily: ' Desktop',
+  });
+
+  assert.equal(
+    payload,
+    'v3|device-1|cli|ui|operator|operator.admin|1737264000000|secret-token|nonce-123|win32|desktop'
+  );
+});

--- a/src/lib/openclaw/device-identity.ts
+++ b/src/lib/openclaw/device-identity.ts
@@ -94,6 +94,15 @@ export function signDevicePayload(privateKeyPem: string, payload: string): strin
   return base64UrlEncode(crypto.sign(null, Buffer.from(payload, 'utf8'), key));
 }
 
+function normalizeDeviceMetadataForAuth(value?: string | null): string {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  const trimmed = value.trim();
+  return trimmed ? trimmed.toLowerCase() : '';
+}
+
 // Build the canonical payload string for signing
 export function buildDeviceAuthPayload(params: {
   deviceId: string;
@@ -111,4 +120,36 @@ export function buildDeviceAuthPayload(params: {
   const base = [version, params.deviceId, params.clientId, params.clientMode, params.role, scopeStr, String(params.signedAtMs), token];
   if (version === 'v2') base.push(params.nonce ?? '');
   return base.join('|');
+}
+
+export function buildDeviceAuthPayloadV3(params: {
+  deviceId: string;
+  clientId: string;
+  clientMode: string;
+  role: string;
+  scopes: string[];
+  signedAtMs: number;
+  token: string | null;
+  nonce: string;
+  platform?: string | null;
+  deviceFamily?: string | null;
+}): string {
+  const scopeStr = params.scopes.join(',');
+  const token = params.token ?? '';
+  const platform = normalizeDeviceMetadataForAuth(params.platform);
+  const deviceFamily = normalizeDeviceMetadataForAuth(params.deviceFamily);
+
+  return [
+    'v3',
+    params.deviceId,
+    params.clientId,
+    params.clientMode,
+    params.role,
+    scopeStr,
+    String(params.signedAtMs),
+    token,
+    params.nonce,
+    platform,
+    deviceFamily,
+  ].join('|');
 }


### PR DESCRIPTION
The meaningful changes are:

 - handshake now advertises protocol 4 instead of 3
 - device auth now signs the newer v3 device payload used by current v4 gateways, including normalized platform metadata
 - session helpers were moved off the older session_id-style calls to the current chat/session request shapes and now normalize v4 response envelopes
 - added a focused test for the new device-auth payload builder in src\lib\openclaw\device-identity.test.ts

The code itself is in src\lib\openclaw\client.ts; I also updated the coupled helper in src\lib\openclaw\device-identity.ts because the v4 handshake depends on that signature format. TypeScript and the new targeted test passed. Full repo validation is still blocked by existing repository/environment issues on Windows: npm test uses rm, and npm run build fails on an unrelated EPERM scandir against C:\Users\camer\Application Data.

 This update now advertises minProtocol: 4 and maxProtocol: 4, so it expects a v4 gateway handshake and v4-era request shapes. A protocol v3-only client or gateway would not negotiate successfully.

  There is one easy point of confusion: the device-auth signature payload is now v3, but that is not the same as OpenClaw Protocol v3. That signature format is part of the Protocol v4 handshake path.

This addresses #137 

--------------------

Per copilot suggestion now fails loudly on unexpected protocol envelopes instead of silently treating them as empty results.

I added:

 - describeResponseShape(...) to summarize the actual payload shape
 - unexpectedResponseShape(...) to log a descriptive error and throw
 - updated listSessions, getSessionHistory, createSession, listAgents, listModels, and getConfig to use that stricter handling

So if the gateway returns the wrong shape in production, you’ll now get a clear error like “unexpected response shape for sessions.list” rather than a misleading “no sessions” outcome. TypeScript passes.