### PR TITLE
fix(agents): nullify task_roles.agent_id on agent delete

### DIFF
--- a/src/app/api/agents/[id]/route.ts
+++ b/src/app/api/agents/[id]/route.ts
@@ -134,6 +134,7 @@ export async function DELETE(
     run('UPDATE tasks SET assigned_agent_id = NULL WHERE assigned_agent_id = ?', [id]);
     run('UPDATE tasks SET created_by_agent_id = NULL WHERE created_by_agent_id = ?', [id]);
     run('UPDATE task_activities SET agent_id = NULL WHERE agent_id = ?', [id]);
+    run('UPDATE task_roles SET agent_id = NULL WHERE agent_id = ?', [id]);
 
     // Now delete the agent
     run('DELETE FROM agents WHERE id = ?', [id]);


### PR DESCRIPTION
## Summary

`DELETE /api/agents/[id]` fails with `FOREIGN KEY constraint failed` when the agent has rows in `task_roles` (auto-populated by the Workflow on task creation).

## Changes

One line added to the cleanup block in `src/app/api/agents/[id]/route.ts`:

```ts
run('UPDATE task_roles SET agent_id = NULL WHERE agent_id = ?', [id]);
```

Matches the existing pattern used for `tasks` / `task_activities`. Nullify rather than DELETE because `task_roles` captures the role assignment intent per task and we want to preserve task history.

## Test plan

- [ ] Create a fresh workspace
- [ ] Create a task assigned to a seed agent — verify `task_roles` row exists
- [ ] `DELETE /api/agents/[id]` — should return 200 instead of 500
- [ ] Verify `task_roles.agent_id` is NULL for the deleted agent
- [ ] Verify task still exists and `assigned_agent_id` is NULL

## Related

Issue: #153