### PR TITLE
Fix: bump gateway client to protocol v4

### DIFF
--- a/src/lib/openclaw/client.ts
+++ b/src/lib/openclaw/client.ts
@@ -328,8 +328,8 @@ export class OpenClawClient extends EventEmitter {
                 id: requestId,
                 method: 'connect',
                 params: {
-                  minProtocol: 3,
-                  maxProtocol: 3,
+                  minProtocol: 4,
+                  maxProtocol: 4,
                   client: {
                     id: clientId,
                     version: '1.0.1',


### PR DESCRIPTION
## Summary
- The gateway client in `src/lib/openclaw/client.ts` hardcoded `minProtocol: 3, maxProtocol: 3` in the `connect` handshake.
- The gateway (tested against `2026.7.2-beta.5`) requires `MIN_CLIENT_PROTOCOL_VERSION = 4` for operator/UI clients (per its own `docs/gateway/protocol.md`), so every connection attempt was rejected with `protocol mismatch` (close code 1002).
- Effect: the app always showed as offline and never saw any agents, even with a correctly configured `OPENCLAW_GATEWAY_URL` and valid token.
- Confirmed the v4 connect schema for operator/UI clients (device auth, role, scopes, `client.mode: "ui"`) is otherwise unchanged from v3, so this is a one-line version bump, not a payload change.

## Test plan
- [x] Ran the app against a local OpenClaw gateway (`2026.7.2-beta.5`)
- [x] Confirmed WebSocket handshake completes and logs `Authenticated successfully`
- [x] Confirmed `/api/health` reports `"gateway":{"status":"ok","connected":true}` and lists active agents