### PR TITLE
Add current MiniMax fallback models

### DIFF
--- a/src/app/api/openclaw/models/route.test.ts
+++ b/src/app/api/openclaw/models/route.test.ts
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+test('fallback model discovery includes current MiniMax models', async () => {
+  const originalDiscoveryMode = process.env.MODEL_DISCOVERY;
+  process.env.MODEL_DISCOVERY = 'fallback';
+
+  try {
+    const { GET } = await import('./route');
+    const response = await GET();
+    const payload = await response.json();
+
+    assert.ok(payload.availableModels.includes('minimax/MiniMax-M3'));
+    assert.ok(payload.availableModels.includes('minimax/MiniMax-M2.7'));
+  } finally {
+    if (originalDiscoveryMode === undefined) delete process.env.MODEL_DISCOVERY;
+    else process.env.MODEL_DISCOVERY = originalDiscoveryMode;
+  }
+});

--- a/src/app/api/openclaw/models/route.ts
+++ b/src/app/api/openclaw/models/route.ts
@@ -50,6 +50,8 @@ const FALLBACK_MODELS = [
   'anthropic/claude-haiku-4-5',
   'openai/gpt-4o',
   'openai/o1',
+  'minimax/MiniMax-M3',
+  'minimax/MiniMax-M2.7',
 ];
 
 /**


### PR DESCRIPTION
Reason: The fallback model picker omits the current MiniMax models.

## Summary

- add MiniMax-M3 and MiniMax-M2.7 to fallback model discovery
- cover both model IDs with a focused route test

## Checks
- `npm exec -- tsx --test src/app/api/openclaw/models/route.test.ts`